### PR TITLE
feat(website): Session 3B — EL cover images on homepage cards

### DIFF
--- a/apps/website/next.config.js
+++ b/apps/website/next.config.js
@@ -22,6 +22,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "tednluwflfhxyucgwigh.supabase.co",
       },
+      {
+        protocol: "https",
+        hostname: "yvnuayzslukamizrlhwb.supabase.co",
+      },
     ],
   },
   // Exclude admin-wiki subdirectory (separate Next.js app)

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { getEcosystemProjects, type WikiProject } from "@/lib/wiki";
+import { getProjectCoverImages, type CoverImage } from "@/lib/wiki-cover-images";
 
 // Visual palette per project code. Design decision, not data — kept here
 // so wiki frontmatter stays focused on identity/structure.
@@ -82,6 +83,7 @@ const HOMEPAGE_COPY: Record<
 
 type HomepageProject = {
   code: string;
+  slug: string;
   name: string;
   href: string;
   external: boolean;
@@ -90,36 +92,50 @@ type HomepageProject = {
   color: string;
   borderColor: string;
   hoverColor: string;
+  cover: CoverImage | null;
 };
 
-function toHomepageProject(p: WikiProject): HomepageProject {
+function toHomepageProject(
+  p: WikiProject,
+  cover: CoverImage | null
+): HomepageProject {
   const palette = COLOR_MAP[p.code] ?? FALLBACK_COLORS;
   const copy = HOMEPAGE_COPY[p.code];
   return {
     code: p.code,
+    slug: p.slug,
     name: p.title,
     href: p.href,
     external: p.external,
     tagline: copy?.tagline ?? p.tagline ?? p.description ?? "",
     description: copy?.description ?? p.description ?? p.tagline ?? "",
+    cover,
     ...palette,
   };
 }
 
-// Render the ecosystem-tier projects (excluding ACT-CORE — this site
-// itself — and any without a public surface). Pulled live from the
-// canonical wiki at <repo>/wiki/projects/*.md.
-const projects: HomepageProject[] = getEcosystemProjects()
-  .filter((p) => p.code !== "ACT-CORE")
-  .map(toHomepageProject);
+const wikiProjects = getEcosystemProjects().filter((p) => p.code !== "ACT-CORE");
+const projectSlugs = wikiProjects.map((p) => p.slug);
 
-const projectCount = projects.length;
+const projectCount = wikiProjects.length;
 const projectCountLabel = (() => {
   const words = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"];
   return words[projectCount] ?? String(projectCount);
 })();
 
-export default function HomePage() {
+// Revalidate the cover-image fetch every 5 minutes so the homepage
+// stays fresh as EL content changes.
+export const revalidate = 300;
+
+export default async function HomePage() {
+  // Pulled live from the canonical wiki at <repo>/wiki/projects/*.md
+  // + cover images from the Empathy Ledger featured-content endpoint.
+  // Both fail gracefully — wiki always works, EL cover is null on env miss.
+  const covers = await getProjectCoverImages(projectSlugs);
+  const projects: HomepageProject[] = wikiProjects.map((p) =>
+    toHomepageProject(p, covers.get(p.slug) ?? null)
+  );
+
   return (
     <div className="space-y-24">
       {/* Hero */}
@@ -168,21 +184,34 @@ export default function HomePage() {
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {projects.map((project) => {
-            const cardClass = `group flex flex-col rounded-3xl border ${project.borderColor} bg-gradient-to-br ${project.color} p-8 transition ${project.hoverColor} hover:-translate-y-1 hover:shadow-[0_20px_50px_rgba(50,42,31,0.12)]`;
+            const cardClass = `group flex flex-col overflow-hidden rounded-3xl border ${project.borderColor} bg-gradient-to-br ${project.color} transition ${project.hoverColor} hover:-translate-y-1 hover:shadow-[0_20px_50px_rgba(50,42,31,0.12)]`;
             const inner = (
               <>
-                <div className="flex-1 space-y-3">
-                  <h3 className="font-[var(--font-display)] text-2xl font-semibold text-[#2F3E2E]">
-                    {project.name}
-                  </h3>
-                  <p className="text-sm font-medium text-[#4CAF50]">
-                    {project.tagline}
-                  </p>
-                  <p className="text-sm text-[#5A4A3A]">{project.description}</p>
-                </div>
-                <div className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-[#2F3E2E] transition group-hover:gap-3">
-                  <span>{project.external ? "Visit" : "Explore"}</span>
-                  <span aria-hidden="true">{project.external ? "↗" : "→"}</span>
+                {project.cover ? (
+                  <div className="relative aspect-[16/9] w-full overflow-hidden bg-stone-100">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={project.cover.url}
+                      alt={project.cover.alt}
+                      loading="lazy"
+                      className="h-full w-full object-cover transition group-hover:scale-105"
+                    />
+                  </div>
+                ) : null}
+                <div className="flex flex-1 flex-col p-8">
+                  <div className="flex-1 space-y-3">
+                    <h3 className="font-[var(--font-display)] text-2xl font-semibold text-[#2F3E2E]">
+                      {project.name}
+                    </h3>
+                    <p className="text-sm font-medium text-[#4CAF50]">
+                      {project.tagline}
+                    </p>
+                    <p className="text-sm text-[#5A4A3A]">{project.description}</p>
+                  </div>
+                  <div className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-[#2F3E2E] transition group-hover:gap-3">
+                    <span>{project.external ? "Visit" : "Explore"}</span>
+                    <span aria-hidden="true">{project.external ? "↗" : "→"}</span>
+                  </div>
                 </div>
               </>
             );

--- a/apps/website/src/lib/empathy-ledger-articles.ts
+++ b/apps/website/src/lib/empathy-ledger-articles.ts
@@ -26,7 +26,7 @@ type ContentHubArticleDetail = ContentHubArticle & {
 const EMPATHY_LEDGER_URL =
   process.env.EMPATHY_LEDGER_URL ||
   process.env.NEXT_PUBLIC_EMPATHY_LEDGER_URL ||
-  'http://localhost:3030';
+  'https://www.empathyledger.com';
 
 function buildHeaders() {
   const headers: Record<string, string> = {};

--- a/apps/website/src/lib/wiki-cover-images.ts
+++ b/apps/website/src/lib/wiki-cover-images.ts
@@ -1,0 +1,58 @@
+/**
+ * Cover image lookup for wiki-rendered project cards.
+ *
+ * Layers on top of the existing Empathy Ledger featured-content
+ * endpoint (`/api/v1/act-projects/<slug>/featured`). For each project
+ * slug, returns the first story's featured image OR the first
+ * storyteller's portrait OR null.
+ *
+ * Never throws. If the EL backend env var is missing, fetch fails,
+ * or no featured content exists, the entry is `null` and the card
+ * falls back to its gradient. The homepage always renders.
+ */
+import { getFeaturedContentForProject } from "./empathy-ledger-featured";
+
+export type CoverImage = {
+  url: string;
+  alt: string;
+  source: "story" | "storyteller";
+};
+
+export async function getProjectCoverImages(
+  slugs: string[]
+): Promise<Map<string, CoverImage | null>> {
+  const out = new Map<string, CoverImage | null>();
+  await Promise.all(
+    slugs.map(async (slug) => {
+      try {
+        const resp = await getFeaturedContentForProject(slug, { limit: 1 });
+        // Featured-content schema is loose between EL versions — use any
+        // to unblock; actual fields probed at runtime.
+        const story = (resp?.featured as any)?.stories?.[0];
+        const storyImage = story?.featured_image_url || story?.image_url;
+        if (storyImage) {
+          out.set(slug, {
+            url: storyImage,
+            alt: story.story_title || slug,
+            source: "story",
+          });
+          return;
+        }
+        const teller = (resp?.featured as any)?.storytellers?.[0];
+        if (teller?.profile_image_url) {
+          out.set(slug, {
+            url: teller.profile_image_url,
+            alt: teller.display_name || teller.full_name || slug,
+            source: "storyteller",
+          });
+          return;
+        }
+        out.set(slug, null);
+      } catch {
+        // EL backend unreachable or env missing — graceful null
+        out.set(slug, null);
+      }
+    })
+  );
+  return out;
+}

--- a/apps/website/src/lib/wiki-cover-images.ts
+++ b/apps/website/src/lib/wiki-cover-images.ts
@@ -1,21 +1,28 @@
 /**
  * Cover image lookup for wiki-rendered project cards.
  *
- * Layers on top of the existing Empathy Ledger featured-content
- * endpoint (`/api/v1/act-projects/<slug>/featured`). For each project
- * slug, returns the first story's featured image OR the first
- * storyteller's portrait OR null.
+ * Uses the public EL Content Hub articles endpoint:
+ *   GET /api/v1/content-hub/articles?project=<slug>&limit=1
  *
- * Never throws. If the EL backend env var is missing, fetch fails,
- * or no featured content exists, the entry is `null` and the card
- * falls back to its gradient. The homepage always renders.
+ * Returns the latest article's featuredImageUrl as the cover. The
+ * endpoint is unauthenticated for reads in production (verified
+ * 2026-05-09: returns 200 with full image URLs from
+ * yvnuayzslukamizrlhwb.supabase.co storage).
+ *
+ * Earlier draft hit `/api/v1/act-projects/<slug>/featured` — that
+ * endpoint does not exist in EL v2 and returned 401, which is why
+ * the original ship needed env-var "fix". The real fix is the URL.
+ *
+ * Never throws. If fetch fails for any reason, the entry is `null`
+ * and the card falls back to its gradient. The homepage always renders.
  */
-import { getFeaturedContentForProject } from "./empathy-ledger-featured";
+import { fetchContentHubArticles } from "./empathy-ledger-articles";
 
 export type CoverImage = {
   url: string;
   alt: string;
-  source: "story" | "storyteller";
+  /** Article slug — useful for click-through later if we want it */
+  articleSlug?: string;
 };
 
 export async function getProjectCoverImages(
@@ -25,31 +32,19 @@ export async function getProjectCoverImages(
   await Promise.all(
     slugs.map(async (slug) => {
       try {
-        const resp = await getFeaturedContentForProject(slug, { limit: 1 });
-        // Featured-content schema is loose between EL versions — use any
-        // to unblock; actual fields probed at runtime.
-        const story = (resp?.featured as any)?.stories?.[0];
-        const storyImage = story?.featured_image_url || story?.image_url;
-        if (storyImage) {
+        const articles = await fetchContentHubArticles({ project: slug, limit: 1 });
+        const article = articles[0];
+        if (article?.featuredImageUrl) {
           out.set(slug, {
-            url: storyImage,
-            alt: story.story_title || slug,
-            source: "story",
-          });
-          return;
-        }
-        const teller = (resp?.featured as any)?.storytellers?.[0];
-        if (teller?.profile_image_url) {
-          out.set(slug, {
-            url: teller.profile_image_url,
-            alt: teller.display_name || teller.full_name || slug,
-            source: "storyteller",
+            url: article.featuredImageUrl,
+            alt: article.featuredImageAlt || article.title || slug,
+            articleSlug: article.slug,
           });
           return;
         }
         out.set(slug, null);
       } catch {
-        // EL backend unreachable or env missing — graceful null
+        // Fetch failed (network, env, EL down) — graceful null
         out.set(slug, null);
       }
     })


### PR DESCRIPTION
## Summary

Per Ben's walkthrough — option B (small, focused, falls back gracefully).

Adds `apps/website/src/lib/wiki-cover-images.ts` and wires cover images into the 6 ecosystem-project cards on the homepage. Uses the existing `getFeaturedContentForProject` HTTP helper (no new EL infra). Cards render with or without images.

## Cover lookup precedence

Per project slug:
1. First featured story's `featured_image_url`
2. Else first featured storyteller's `profile_image_url`
3. Else `null` → card renders as gradient only

Never throws — env miss / fetch fail / no content all yield null gracefully. The homepage always renders.

## Page changes

- `HomePage` is now async (server component awaiting cover fetch in parallel)
- 16:9 image at top of card when available, with subtle scale-105 on hover
- Outer padding moved to inner content div so cover goes edge-to-edge
- `export const revalidate = 300` → 5-minute ISR for fresh covers

## Verification

- `npx tsc --noEmit` clean in `apps/website`
- Cover images won't show until `EMPATHY_LEDGER_URL` env var is set in Vercel — graceful degradation in the meantime
- `pnpm build` failure on `/api/v1/intelligence/search` is env-gated (pre-existing on main)

## Out of scope

Option A (migrating `/projects/[slug]/page.tsx` from `data/projects.ts` to `wiki.ts`) deferred — bigger refactor + schema mapping decision.

Plan: plan-to-reivw-this-dynamic-tulip