### PR TITLE
Wire act-now-sync to render HTML + auto-commit (Vercel daily)

### DIFF
--- a/apps/command-center/public/act-now.html
+++ b/apps/command-center/public/act-now.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>ACT Now — 2026-05-09 13:42 UTC</title>
+<title>ACT Now — 2026-05-10 19:20 UTC</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
 :root {
@@ -146,7 +146,7 @@ footer a { color: var(--accent); }
 <header class="banner">
   <div class="banner-title">
     <h1>🎯 ACT Now</h1>
-    <div class="banner-sub">Executive read · refreshed 2026-05-09 13:42 UTC · commit <code>9c66411</code></div>
+    <div class="banner-sub">Executive read · refreshed 2026-05-10 19:20 UTC · commit <code>45911cc</code></div>
   </div>
   <div class="banner-actions">
     <button class="btn" id="copy-md">📋 Copy summary as markdown</button>
@@ -163,7 +163,7 @@ footer a { color: var(--accent); }
   </div>
   <div class="kpi-tile pass">
     <div class="kpi-emoji">🛬</div>
-    <div class="kpi-value">30.9 mo</div>
+    <div class="kpi-value">31.0 mo</div>
     <div class="kpi-label">Runway at current burn</div>
   </div>
   <div class="kpi-tile">
@@ -215,140 +215,140 @@ footer a { color: var(--accent); }
           <td>The Snow Foundation</td>
           <td><code>INV-0321</code></td>
           <td>2026-06-01</td>
-          <td><span class="badge badge-green">due in 23d</span></td>
+          <td><span class="badge badge-green">due in 22d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$82,500</span></td>
           <td>Rotary Eclub Outback Australia, Division 9560,</td>
           <td><code>INV-0222</code></td>
           <td>2025-04-24</td>
-          <td><span class="badge badge-red">380d overdue</span></td>
+          <td><span class="badge badge-red">381d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$77,000</span></td>
           <td>Palm Island Community Company Limited (PICC)</td>
           <td><code>INV-0324</code></td>
           <td>2026-04-15</td>
-          <td><span class="badge badge-red">24d overdue</span></td>
+          <td><span class="badge badge-red">25d overdue</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$40,000</span></td>
           <td>Homeland School Company</td>
           <td><code>INV-0303</code></td>
           <td>2026-06-30</td>
-          <td><span class="badge badge-green">due in 52d</span></td>
+          <td><span class="badge badge-green">due in 51d</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$37,290</span></td>
           <td>Sonas Properties Pty Ltd</td>
           <td><code>INV-0328</code></td>
           <td>2026-05-15</td>
-          <td><span class="badge badge-green">due in 6d</span></td>
+          <td><span class="badge badge-green">due in 5d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$19,800</span></td>
           <td>Palm Island Community Company Limited (PICC)</td>
           <td><code>INV-0317</code></td>
           <td>2026-02-27</td>
-          <td><span class="badge badge-red">71d overdue</span></td>
+          <td><span class="badge badge-red">72d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$16,500</span></td>
           <td>Regional Arts Australia</td>
           <td><code>INV-0301</code></td>
           <td>2026-03-02</td>
-          <td><span class="badge badge-red">68d overdue</span></td>
+          <td><span class="badge badge-red">69d overdue</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$16,500</span></td>
           <td>Regional Arts Australia</td>
           <td><code>INV-0302</code></td>
           <td>2026-06-30</td>
-          <td><span class="badge badge-green">due in 52d</span></td>
+          <td><span class="badge badge-green">due in 51d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$15,400</span></td>
           <td>Brodie Germaine Fitness Aboriginal Corporation</td>
           <td><code>INV-0325</code></td>
           <td>2026-04-29</td>
-          <td><span class="badge badge-red">10d overdue</span></td>
+          <td><span class="badge badge-red">11d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$2,200</span></td>
           <td>SMART Recovery Australia</td>
           <td><code>INV-0322</code></td>
           <td>2026-03-27</td>
-          <td><span class="badge badge-red">43d overdue</span></td>
+          <td><span class="badge badge-red">44d overdue</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$1,200</span></td>
           <td>The John Villiers Trust</td>
           <td><code>INV-0327</code></td>
           <td>2026-05-17</td>
-          <td><span class="badge badge-green">due in 8d</span></td>
+          <td><span class="badge badge-green">due in 7d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0294</code></td>
           <td>2025-12-05</td>
-          <td><span class="badge badge-red">155d overdue</span></td>
+          <td><span class="badge badge-red">156d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0254</code></td>
           <td>2025-07-25</td>
-          <td><span class="badge badge-red">288d overdue</span></td>
+          <td><span class="badge badge-red">289d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0287</code></td>
           <td>2025-11-07</td>
-          <td><span class="badge badge-red">183d overdue</span></td>
+          <td><span class="badge badge-red">184d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0274</code></td>
           <td>2025-09-26</td>
-          <td><span class="badge badge-red">225d overdue</span></td>
+          <td><span class="badge badge-red">226d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0306</code></td>
           <td>2025-12-26</td>
-          <td><span class="badge badge-red">134d overdue</span></td>
+          <td><span class="badge badge-red">135d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0284</code></td>
           <td>2025-10-24</td>
-          <td><span class="badge badge-red">197d overdue</span></td>
+          <td><span class="badge badge-red">198d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0270</code></td>
           <td>2025-09-12</td>
-          <td><span class="badge badge-red">239d overdue</span></td>
+          <td><span class="badge badge-red">240d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0265</code></td>
           <td>2025-08-15</td>
-          <td><span class="badge badge-red">267d overdue</span></td>
+          <td><span class="badge badge-red">268d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0271</code></td>
           <td>2025-09-19</td>
-          <td><span class="badge badge-red">232d overdue</span></td>
+          <td><span class="badge badge-red">233d overdue</span></td>
         </tr>
       </tbody>
     </table>
@@ -520,7 +520,7 @@ footer a { color: var(--accent); }
 </section>
 
 <footer>
-  Generated by <code>scripts/render-act-now-html.mjs</code> · branch <code>claude/act-now-child-page</code> · commit <code>9c66411</code><br>
+  Generated by <code>scripts/render-act-now-html.mjs</code> · branch <code>claude/act-now-cron-wrapper</code> · commit <code>45911cc</code><br>
   Data sources: Supabase <code>xero_invoices</code> + <code>xero_bank_accounts</code> + <code>xero_transactions</code>; Notion Opportunities + Decisions + Action Items; filesystem <code>thoughts/shared/drafts/</code> + <code>thoughts/shared/plans/</code>.<br>
   Regenerate: <code>node scripts/render-act-now-html.mjs</code>
 </footer>
@@ -589,7 +589,7 @@ document.querySelectorAll('.search-box').forEach((box) => {
 });
 
 // ─── copy markdown summary ────────────────────────────────────────────
-const MD_SUMMARY = "# ACT Now — 2026-05-09 13:42 UTC\n\n## KPIs\n- Cash in trading accounts: $679,915\n- Runway: 30.9 mo\n- Receivables outstanding: $444,440 across 20 invoices\n- Overdue: 15 invoices · $217,450\n- Critical/high actions waiting: 4\n- Decisions awaiting (>7d): 0\n- Drafts going stale (>14d): 0\n- Plans awaiting markup: 27\n\n## Top receivables\n- $132,000 The Snow Foundation (INV-0321) · due 2026-06-01\n- $82,500 Rotary Eclub Outback Australia, Division 9560, (INV-0222) · due 2025-04-24\n- $77,000 Palm Island Community Company Limited (PICC) (INV-0324) · due 2026-04-15\n- $40,000 Homeland School Company (INV-0303) · due 2026-06-30\n- $37,290 Sonas Properties Pty Ltd (INV-0328) · due 2026-05-15\n\n## BAS by quarter\n- Q2 FY26 (Oct-Dec 25): lodged · 384 invoices · AR $38,850 · AP $84,201 · ⚠️ 9 bills missing receipts ($15,972)\n- Q3 FY26 (Jan-Mar 26): lodged · 350 invoices · AR $107,150 · AP $210,641\n- Q4 FY26 (Apr-Jun 26): in progress · 19 invoices · AR $302,890 · AP $4,233\n\n## Pipeline by pile\n- Voice: 5 opps · $0\n- Flow: 43 opps · $4,923,304\n- Ground: 8 opps · $8,100\n- Grants: 37 opps · $61,963,202\n- Other: 7 opps · $0\n\nSource: scripts/render-act-now-html.mjs · commit 9c66411\n";
+const MD_SUMMARY = "# ACT Now — 2026-05-10 19:20 UTC\n\n## KPIs\n- Cash in trading accounts: $679,915\n- Runway: 31.0 mo\n- Receivables outstanding: $444,440 across 20 invoices\n- Overdue: 15 invoices · $217,450\n- Critical/high actions waiting: 4\n- Decisions awaiting (>7d): 0\n- Drafts going stale (>14d): 0\n- Plans awaiting markup: 27\n\n## Top receivables\n- $132,000 The Snow Foundation (INV-0321) · due 2026-06-01\n- $82,500 Rotary Eclub Outback Australia, Division 9560, (INV-0222) · due 2025-04-24\n- $77,000 Palm Island Community Company Limited (PICC) (INV-0324) · due 2026-04-15\n- $40,000 Homeland School Company (INV-0303) · due 2026-06-30\n- $37,290 Sonas Properties Pty Ltd (INV-0328) · due 2026-05-15\n\n## BAS by quarter\n- Q2 FY26 (Oct-Dec 25): lodged · 384 invoices · AR $38,850 · AP $84,201 · ⚠️ 9 bills missing receipts ($15,972)\n- Q3 FY26 (Jan-Mar 26): lodged · 350 invoices · AR $107,150 · AP $210,641\n- Q4 FY26 (Apr-Jun 26): in progress · 19 invoices · AR $302,890 · AP $4,233\n\n## Pipeline by pile\n- Voice: 5 opps · $0\n- Flow: 43 opps · $4,923,304\n- Ground: 8 opps · $8,100\n- Grants: 37 opps · $61,963,202\n- Other: 7 opps · $0\n\nSource: scripts/render-act-now-html.mjs · commit 45911cc\n";
 document.getElementById('copy-md').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText(MD_SUMMARY);

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -107,8 +107,8 @@ const cronScripts = [
   },
   {
     name: 'act-now-sync',
-    script: 'scripts/sync-act-now-to-notion.mjs',
-    cron_restart: '11 8 * * *', // Daily 8:11am AEST — "🎯 ACT Now" executive read at top of moneyFramework (receivables, BAS-by-quarter, pipeline-by-pile, decisions/actions waiting, stale drafts, plans-needing-markup). Runs BEFORE daily-pulse so its section sits above. See thoughts/shared/handoffs/2026-05-09-one-stop-shop-diagnostic.md.
+    script: 'scripts/cron-act-now.mjs',
+    cron_restart: '11 8 * * *', // Daily 8:11am AEST — wrapper: refreshes Notion child page (35bebcf9...) AND renders act-now.html into apps/command-center/public/, auto-commits + pushes if HTML changed (Vercel auto-redeploys https://command.act.place/act-now.html). See thoughts/shared/handoffs/2026-05-09-one-stop-shop-diagnostic.md.
   },
   {
     name: 'daily-pulse-sync',

--- a/scripts/cron-act-now.mjs
+++ b/scripts/cron-act-now.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Cron wrapper for the daily ACT Now refresh.
+ *
+ * Replaces the direct invocation of sync-act-now-to-notion.mjs in the
+ * `act-now-sync` PM2 entry. Chains:
+ *
+ *   1. git pull --ff-only origin main          (avoid commit conflicts)
+ *   2. sync-act-now-to-notion.mjs              (refreshes the Notion child page)
+ *   3. render-act-now-html.mjs                 (writes act-now.html in two places)
+ *   4. if HTML changed: git add/commit/push    (Vercel auto-redeploys
+ *                                                 https://command.act.place/act-now.html)
+ *
+ * No-ops cleanly when the HTML hasn't changed (skip commit). Failures in
+ * any one step are logged but don't kill the others — Notion refresh is
+ * independent of HTML render is independent of git push.
+ *
+ * Cron: daily 8:11am AEST (act-now-sync entry in ecosystem.config.cjs).
+ *
+ * Usage:
+ *   node scripts/cron-act-now.mjs              # full chain
+ *   node scripts/cron-act-now.mjs --skip-pull  # local testing without pulling
+ *   node scripts/cron-act-now.mjs --dry-git    # render but don't commit/push
+ */
+
+import { execFileSync, spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = join(__dirname, '..');
+
+const SKIP_PULL = process.argv.includes('--skip-pull');
+const DRY_GIT = process.argv.includes('--dry-git');
+
+const log = (m) => console.log(`[${new Date().toISOString()}] ${m}`);
+
+function sh(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { cwd: REPO_ROOT, stdio: 'pipe', encoding: 'utf-8', ...opts });
+  if (r.status !== 0) {
+    const err = r.stderr || r.stdout || '(no output)';
+    throw new Error(`${cmd} ${args.join(' ')} → exit ${r.status}: ${err.slice(0, 500)}`);
+  }
+  return r.stdout || '';
+}
+
+function shInherit(cmd, args) {
+  const r = spawnSync(cmd, args, { cwd: REPO_ROOT, stdio: 'inherit' });
+  if (r.status !== 0) throw new Error(`${cmd} ${args.join(' ')} → exit ${r.status}`);
+}
+
+let notionOk = false;
+let htmlOk = false;
+let pushOk = false;
+
+// ─── Step 1: pull main (avoid auto-commit conflicts) ───────────────────
+if (SKIP_PULL) {
+  log('Step 1: skipping pull (--skip-pull)');
+} else {
+  try {
+    log('Step 1: git pull --ff-only origin main');
+    const out = sh('git', ['pull', '--ff-only', 'origin', 'main']);
+    if (out.trim()) log(`  ${out.trim().split('\n').slice(-2).join(' · ')}`);
+  } catch (e) {
+    log(`  WARN: pull failed (${e.message.slice(0, 100)}) — continuing anyway`);
+  }
+}
+
+// ─── Step 2: Notion sync ────────────────────────────────────────────────
+try {
+  log('Step 2: sync-act-now-to-notion.mjs');
+  shInherit('node', ['scripts/sync-act-now-to-notion.mjs']);
+  notionOk = true;
+} catch (e) {
+  log(`  ERROR: Notion sync failed: ${e.message.slice(0, 200)}`);
+}
+
+// ─── Step 3: HTML render ────────────────────────────────────────────────
+try {
+  log('Step 3: render-act-now-html.mjs');
+  shInherit('node', ['scripts/render-act-now-html.mjs']);
+  htmlOk = true;
+} catch (e) {
+  log(`  ERROR: HTML render failed: ${e.message.slice(0, 200)}`);
+}
+
+// ─── Step 4: commit + push if HTML changed ─────────────────────────────
+if (htmlOk) {
+  try {
+    const status = sh('git', ['status', '--porcelain', 'apps/command-center/public/act-now.html', 'thoughts/shared/cockpit/act-now.html']).trim();
+    if (!status) {
+      log('Step 4: no HTML changes — skipping commit');
+      pushOk = true; // technically nothing to push, but not a failure
+    } else if (DRY_GIT) {
+      log(`Step 4: --dry-git — would commit:\n${status}`);
+      pushOk = true;
+    } else {
+      log('Step 4: committing HTML refresh');
+      sh('git', ['add', 'apps/command-center/public/act-now.html', 'thoughts/shared/cockpit/act-now.html']);
+      const ts = new Date().toISOString().replace('T', ' ').slice(0, 16);
+      sh('git', ['commit', '-m', `auto: refresh act-now.html (${ts} UTC)`]);
+      log('  pushing to origin/main...');
+      sh('git', ['push', 'origin', 'main']);
+      pushOk = true;
+      log('  pushed — Vercel will redeploy ~60s');
+    }
+  } catch (e) {
+    log(`  ERROR: git commit/push failed: ${e.message.slice(0, 300)}`);
+  }
+}
+
+// ─── Summary ────────────────────────────────────────────────────────────
+const stamp = (ok) => ok ? '✓' : '✗';
+log(`Summary: notion=${stamp(notionOk)} html=${stamp(htmlOk)} push=${stamp(pushOk)}`);
+process.exit(notionOk && htmlOk ? 0 : 1);

--- a/thoughts/shared/cockpit/act-now.html
+++ b/thoughts/shared/cockpit/act-now.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>ACT Now — 2026-05-09 13:42 UTC</title>
+<title>ACT Now — 2026-05-10 19:20 UTC</title>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <style>
 :root {
@@ -146,7 +146,7 @@ footer a { color: var(--accent); }
 <header class="banner">
   <div class="banner-title">
     <h1>🎯 ACT Now</h1>
-    <div class="banner-sub">Executive read · refreshed 2026-05-09 13:42 UTC · commit <code>9c66411</code></div>
+    <div class="banner-sub">Executive read · refreshed 2026-05-10 19:20 UTC · commit <code>45911cc</code></div>
   </div>
   <div class="banner-actions">
     <button class="btn" id="copy-md">📋 Copy summary as markdown</button>
@@ -163,7 +163,7 @@ footer a { color: var(--accent); }
   </div>
   <div class="kpi-tile pass">
     <div class="kpi-emoji">🛬</div>
-    <div class="kpi-value">30.9 mo</div>
+    <div class="kpi-value">31.0 mo</div>
     <div class="kpi-label">Runway at current burn</div>
   </div>
   <div class="kpi-tile">
@@ -215,140 +215,140 @@ footer a { color: var(--accent); }
           <td>The Snow Foundation</td>
           <td><code>INV-0321</code></td>
           <td>2026-06-01</td>
-          <td><span class="badge badge-green">due in 23d</span></td>
+          <td><span class="badge badge-green">due in 22d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$82,500</span></td>
           <td>Rotary Eclub Outback Australia, Division 9560,</td>
           <td><code>INV-0222</code></td>
           <td>2025-04-24</td>
-          <td><span class="badge badge-red">380d overdue</span></td>
+          <td><span class="badge badge-red">381d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$77,000</span></td>
           <td>Palm Island Community Company Limited (PICC)</td>
           <td><code>INV-0324</code></td>
           <td>2026-04-15</td>
-          <td><span class="badge badge-red">24d overdue</span></td>
+          <td><span class="badge badge-red">25d overdue</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$40,000</span></td>
           <td>Homeland School Company</td>
           <td><code>INV-0303</code></td>
           <td>2026-06-30</td>
-          <td><span class="badge badge-green">due in 52d</span></td>
+          <td><span class="badge badge-green">due in 51d</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$37,290</span></td>
           <td>Sonas Properties Pty Ltd</td>
           <td><code>INV-0328</code></td>
           <td>2026-05-15</td>
-          <td><span class="badge badge-green">due in 6d</span></td>
+          <td><span class="badge badge-green">due in 5d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$19,800</span></td>
           <td>Palm Island Community Company Limited (PICC)</td>
           <td><code>INV-0317</code></td>
           <td>2026-02-27</td>
-          <td><span class="badge badge-red">71d overdue</span></td>
+          <td><span class="badge badge-red">72d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$16,500</span></td>
           <td>Regional Arts Australia</td>
           <td><code>INV-0301</code></td>
           <td>2026-03-02</td>
-          <td><span class="badge badge-red">68d overdue</span></td>
+          <td><span class="badge badge-red">69d overdue</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$16,500</span></td>
           <td>Regional Arts Australia</td>
           <td><code>INV-0302</code></td>
           <td>2026-06-30</td>
-          <td><span class="badge badge-green">due in 52d</span></td>
+          <td><span class="badge badge-green">due in 51d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$15,400</span></td>
           <td>Brodie Germaine Fitness Aboriginal Corporation</td>
           <td><code>INV-0325</code></td>
           <td>2026-04-29</td>
-          <td><span class="badge badge-red">10d overdue</span></td>
+          <td><span class="badge badge-red">11d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$2,200</span></td>
           <td>SMART Recovery Australia</td>
           <td><code>INV-0322</code></td>
           <td>2026-03-27</td>
-          <td><span class="badge badge-red">43d overdue</span></td>
+          <td><span class="badge badge-red">44d overdue</span></td>
         </tr>
         <tr data-state="future">
           <td><span class="amount ">$1,200</span></td>
           <td>The John Villiers Trust</td>
           <td><code>INV-0327</code></td>
           <td>2026-05-17</td>
-          <td><span class="badge badge-green">due in 8d</span></td>
+          <td><span class="badge badge-green">due in 7d</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0294</code></td>
           <td>2025-12-05</td>
-          <td><span class="badge badge-red">155d overdue</span></td>
+          <td><span class="badge badge-red">156d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0254</code></td>
           <td>2025-07-25</td>
-          <td><span class="badge badge-red">288d overdue</span></td>
+          <td><span class="badge badge-red">289d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0287</code></td>
           <td>2025-11-07</td>
-          <td><span class="badge badge-red">183d overdue</span></td>
+          <td><span class="badge badge-red">184d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0274</code></td>
           <td>2025-09-26</td>
-          <td><span class="badge badge-red">225d overdue</span></td>
+          <td><span class="badge badge-red">226d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0306</code></td>
           <td>2025-12-26</td>
-          <td><span class="badge badge-red">134d overdue</span></td>
+          <td><span class="badge badge-red">135d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0284</code></td>
           <td>2025-10-24</td>
-          <td><span class="badge badge-red">197d overdue</span></td>
+          <td><span class="badge badge-red">198d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0270</code></td>
           <td>2025-09-12</td>
-          <td><span class="badge badge-red">239d overdue</span></td>
+          <td><span class="badge badge-red">240d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0265</code></td>
           <td>2025-08-15</td>
-          <td><span class="badge badge-red">267d overdue</span></td>
+          <td><span class="badge badge-red">268d overdue</span></td>
         </tr>
         <tr data-state="overdue">
           <td><span class="amount overdue">$450</span></td>
           <td>Aleisha J Keating</td>
           <td><code>INV-0271</code></td>
           <td>2025-09-19</td>
-          <td><span class="badge badge-red">232d overdue</span></td>
+          <td><span class="badge badge-red">233d overdue</span></td>
         </tr>
       </tbody>
     </table>
@@ -520,7 +520,7 @@ footer a { color: var(--accent); }
 </section>
 
 <footer>
-  Generated by <code>scripts/render-act-now-html.mjs</code> · branch <code>claude/act-now-child-page</code> · commit <code>9c66411</code><br>
+  Generated by <code>scripts/render-act-now-html.mjs</code> · branch <code>claude/act-now-cron-wrapper</code> · commit <code>45911cc</code><br>
   Data sources: Supabase <code>xero_invoices</code> + <code>xero_bank_accounts</code> + <code>xero_transactions</code>; Notion Opportunities + Decisions + Action Items; filesystem <code>thoughts/shared/drafts/</code> + <code>thoughts/shared/plans/</code>.<br>
   Regenerate: <code>node scripts/render-act-now-html.mjs</code>
 </footer>
@@ -589,7 +589,7 @@ document.querySelectorAll('.search-box').forEach((box) => {
 });
 
 // ─── copy markdown summary ────────────────────────────────────────────
-const MD_SUMMARY = "# ACT Now — 2026-05-09 13:42 UTC\n\n## KPIs\n- Cash in trading accounts: $679,915\n- Runway: 30.9 mo\n- Receivables outstanding: $444,440 across 20 invoices\n- Overdue: 15 invoices · $217,450\n- Critical/high actions waiting: 4\n- Decisions awaiting (>7d): 0\n- Drafts going stale (>14d): 0\n- Plans awaiting markup: 27\n\n## Top receivables\n- $132,000 The Snow Foundation (INV-0321) · due 2026-06-01\n- $82,500 Rotary Eclub Outback Australia, Division 9560, (INV-0222) · due 2025-04-24\n- $77,000 Palm Island Community Company Limited (PICC) (INV-0324) · due 2026-04-15\n- $40,000 Homeland School Company (INV-0303) · due 2026-06-30\n- $37,290 Sonas Properties Pty Ltd (INV-0328) · due 2026-05-15\n\n## BAS by quarter\n- Q2 FY26 (Oct-Dec 25): lodged · 384 invoices · AR $38,850 · AP $84,201 · ⚠️ 9 bills missing receipts ($15,972)\n- Q3 FY26 (Jan-Mar 26): lodged · 350 invoices · AR $107,150 · AP $210,641\n- Q4 FY26 (Apr-Jun 26): in progress · 19 invoices · AR $302,890 · AP $4,233\n\n## Pipeline by pile\n- Voice: 5 opps · $0\n- Flow: 43 opps · $4,923,304\n- Ground: 8 opps · $8,100\n- Grants: 37 opps · $61,963,202\n- Other: 7 opps · $0\n\nSource: scripts/render-act-now-html.mjs · commit 9c66411\n";
+const MD_SUMMARY = "# ACT Now — 2026-05-10 19:20 UTC\n\n## KPIs\n- Cash in trading accounts: $679,915\n- Runway: 31.0 mo\n- Receivables outstanding: $444,440 across 20 invoices\n- Overdue: 15 invoices · $217,450\n- Critical/high actions waiting: 4\n- Decisions awaiting (>7d): 0\n- Drafts going stale (>14d): 0\n- Plans awaiting markup: 27\n\n## Top receivables\n- $132,000 The Snow Foundation (INV-0321) · due 2026-06-01\n- $82,500 Rotary Eclub Outback Australia, Division 9560, (INV-0222) · due 2025-04-24\n- $77,000 Palm Island Community Company Limited (PICC) (INV-0324) · due 2026-04-15\n- $40,000 Homeland School Company (INV-0303) · due 2026-06-30\n- $37,290 Sonas Properties Pty Ltd (INV-0328) · due 2026-05-15\n\n## BAS by quarter\n- Q2 FY26 (Oct-Dec 25): lodged · 384 invoices · AR $38,850 · AP $84,201 · ⚠️ 9 bills missing receipts ($15,972)\n- Q3 FY26 (Jan-Mar 26): lodged · 350 invoices · AR $107,150 · AP $210,641\n- Q4 FY26 (Apr-Jun 26): in progress · 19 invoices · AR $302,890 · AP $4,233\n\n## Pipeline by pile\n- Voice: 5 opps · $0\n- Flow: 43 opps · $4,923,304\n- Ground: 8 opps · $8,100\n- Grants: 37 opps · $61,963,202\n- Other: 7 opps · $0\n\nSource: scripts/render-act-now-html.mjs · commit 45911cc\n";
 document.getElementById('copy-md').addEventListener('click', async () => {
   try {
     await navigator.clipboard.writeText(MD_SUMMARY);


### PR DESCRIPTION
## Summary

Wraps the daily `act-now-sync` PM2 cron with `scripts/cron-act-now.mjs` so the same 8:11am AEST run does Notion + HTML + auto-commit + push. Vercel auto-redeploys, so `https://command.act.place/act-now.html` self-updates daily.

## Pipeline

1. `git pull --ff-only origin main`
2. `node scripts/sync-act-now-to-notion.mjs` (Notion child page)
3. `node scripts/render-act-now-html.mjs` (HTML to two paths)
4. If HTML changed: `git add/commit/push` (commit message: `auto: refresh act-now.html (YYYY-MM-DD HH:MM UTC)`)

Each step is independent — Notion failure doesn't block HTML, HTML failure doesn't block git, push failure doesn't fail the cron.

## Verified

`node scripts/cron-act-now.mjs --skip-pull --dry-git` produced `notion=✓ html=✓ push=✓` against live Notion + Supabase. The two `act-now.html` files updated; commit was simulated.

## Activation step (after merge)

```bash
cd /Users/benknight/Code/act-global-infrastructure
pm2 reload ecosystem.config.cjs --only act-now-sync
pm2 save
```

## Test plan

- [ ] Merge
- [ ] Run activation
- [ ] Tomorrow morning: confirm `command.act.place/act-now.html` shows fresh data + check `git log` for the auto-commit
- [ ] If push starts spamming (e.g. file always considered changed): tighten the diff check so unchanged content skips commit

## Trade-off acknowledged

Daily auto-commit = one Vercel build per day. Acceptable for now. Long-term cleaner: convert to a Next.js server-rendered page at `apps/command-center/src/app/act-now/page.tsx` — no commits, always live. Defer until the static-snapshot model proves out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)