### PR TITLE
feat(ghl): canonical project-code alignment across Xero · Supabase · GHL · wiki

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ apps/command-center/apps/
 !.claude/skills/sync-storytellers
 !.claude/skills/tag-transactions
 !.claude/skills/wiki
+
+# GHL alignment run logs (large, run-output; keep only .md audits)
+thoughts/shared/audits/*.log

--- a/packages/notion-workers/src/index.ts
+++ b/packages/notion-workers/src/index.ts
@@ -87,6 +87,7 @@
 
 import { Worker } from "@notionhq/workers";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { registerContactsSync } from "./syncs/contacts.js";
 import {
   fetchDailyBriefing,
   fetchProjectHealth,
@@ -162,6 +163,13 @@ function daysAgo(n: number): string {
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 const worker = new Worker();
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// SYNC: Contacts — mirrors v_canonical_contacts into a Notion database
+// (Phase 1 of wiki/decisions/2026-05-14-notion-platform-architecture.md)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+registerContactsSync(worker);
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // TOOL CURATION — Only register high-value tools (15 of 43)

--- a/packages/notion-workers/src/syncs/contacts.ts
+++ b/packages/notion-workers/src/syncs/contacts.ts
@@ -1,0 +1,164 @@
+/**
+ * Contacts sync — mirrors v_canonical_contacts from Supabase into a Notion database.
+ *
+ * Phase 1 of wiki/decisions/2026-05-14-notion-platform-architecture.md
+ *
+ * SDK constraints: installed @notionhq/workers is 0.0.85.
+ *  - Schema is declared inline on the sync (no separate `worker.database()`)
+ *  - No `worker.pacer()` — manual rate-limiting if needed (dataset is small enough that
+ *    one paged pass per run finishes well within burst limits)
+ *  - "manual" schedule isn't supported; we use mode:"replace" + hourly schedule so each
+ *    run does mark-and-sweep against the full dataset. Deletes propagate automatically.
+ *
+ * Cultural-sensitivity columns from ghl_contacts are deliberately NOT mirrored:
+ *   elder_consent, sacred_knowledge*, cultural_nation_details, ocap_*,
+ *   detailed_consent_history, elder_review_notes.
+ *
+ * Reuses SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY worker secrets already configured.
+ */
+
+import type { Worker } from "@notionhq/workers";
+import * as Builder from "@notionhq/workers/builder";
+import * as Schema from "@notionhq/workers/schema";
+
+const SELECT_COLS = [
+  "ghl_id",
+  "full_name",
+  "first_name",
+  "last_name",
+  "email",
+  "phone",
+  "company_name",
+  "tags",
+  "projects",
+  "last_contact_date",
+  "newsletter_consent",
+  "is_storyteller",
+  "is_elder",
+  "empathy_ledger_id",
+  "canonical_entity_id",
+  "xero_contact_id",
+  "updated_at",
+].join(",");
+
+type ContactRow = {
+  ghl_id: string;
+  full_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+  company_name: string | null;
+  tags: string[] | null;
+  projects: string[] | null;
+  last_contact_date: string | null;
+  newsletter_consent: boolean | null;
+  is_storyteller: boolean | null;
+  is_elder: boolean | null;
+  empathy_ledger_id: string | null;
+  canonical_entity_id: string | null;
+  xero_contact_id: string | null;
+  updated_at: string | null;
+};
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env var: ${name}`);
+  return v;
+}
+
+async function fetchPage(offset: number, limit: number): Promise<ContactRow[]> {
+  const key = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const url = new URL(
+    `${requireEnv("SUPABASE_URL")}/rest/v1/v_canonical_contacts`,
+  );
+  url.searchParams.set("select", SELECT_COLS);
+  url.searchParams.set("order", "ghl_id.asc");
+  const r = await fetch(url, {
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+      Range: `${offset}-${offset + limit - 1}`,
+    },
+  });
+  if (!r.ok) throw new Error(`Supabase ${r.status}: ${await r.text()}`);
+  return (await r.json()) as ContactRow[];
+}
+
+function bestName(r: ContactRow): string {
+  const full = (r.full_name || "").trim();
+  if (full) return full;
+  const joined = `${r.first_name || ""} ${r.last_name || ""}`.trim();
+  if (joined) return joined;
+  return r.email || r.ghl_id;
+}
+
+function toChange(r: ContactRow) {
+  return {
+    type: "upsert" as const,
+    key: r.ghl_id,
+    properties: {
+      Name: Builder.title(bestName(r)),
+      "GHL ID": Builder.richText(r.ghl_id),
+      Email: Builder.richText(r.email || ""),
+      Phone: Builder.richText(r.phone || ""),
+      Company: Builder.richText(r.company_name || ""),
+      Projects: Builder.richText(
+        (r.projects || []).filter((p) => p && p.startsWith("ACT-")).join(", "),
+      ),
+      Tags: Builder.richText((r.tags || []).join(", ")),
+      "Last Contact": r.last_contact_date
+        ? Builder.date(r.last_contact_date)
+        : Builder.date(""),
+      "Newsletter Consent": Builder.checkbox(!!r.newsletter_consent),
+      Storyteller: Builder.checkbox(!!r.is_storyteller),
+      Elder: Builder.checkbox(!!r.is_elder),
+      "EL Profile ID": Builder.richText(r.empathy_ledger_id || ""),
+      "Xero Contact ID": Builder.richText(r.xero_contact_id || ""),
+      "Canonical Entity": Builder.richText(r.canonical_entity_id || ""),
+      "Last Synced": Builder.date(new Date().toISOString()),
+    },
+  };
+}
+
+export function registerContactsSync(worker: Worker) {
+  worker.sync("contacts", {
+    primaryKeyProperty: "GHL ID",
+    schema: {
+      defaultName: "ACT Contacts (canonical)",
+      properties: {
+        Name: Schema.title(),
+        "GHL ID": Schema.richText(),
+        Email: Schema.richText(),
+        Phone: Schema.richText(),
+        Company: Schema.richText(),
+        Projects: Schema.richText(),
+        Tags: Schema.richText(),
+        "Last Contact": Schema.date(),
+        "Newsletter Consent": Schema.checkbox(),
+        Storyteller: Schema.checkbox(),
+        Elder: Schema.checkbox(),
+        "EL Profile ID": Schema.richText(),
+        "Xero Contact ID": Schema.richText(),
+        "Canonical Entity": Schema.richText(),
+        "Last Synced": Schema.date(),
+      },
+    },
+    // Hourly full-dataset refresh. With ~2,079 rows / 500 per page = 5 pages per run,
+    // and a single Supabase view query each. Pages chunk via hasMore + nextState.
+    mode: "replace",
+    schedule: "1h",
+    execute: async (state: { offset?: number } | undefined) => {
+      const PAGE = 500;
+      const offset = state?.offset ?? 0;
+      const rows = await fetchPage(offset, PAGE);
+      const hasMore = rows.length === PAGE;
+      return {
+        changes: rows.map(toChange),
+        hasMore,
+        nextState: hasMore ? { offset: offset + PAGE } : undefined,
+      };
+    },
+  });
+}

--- a/scripts/backfill-ghl-contact-projects.mjs
+++ b/scripts/backfill-ghl-contact-projects.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Backfill ghl_contacts.projects[] with canonical ACT-XX codes.
+ *
+ * Derives codes from each contact's tags using:
+ *   1. Direct match against projects.ghl_tags
+ *   2. Prefix rules (goods-* → ACT-GD, etc.)
+ *
+ * Writes canonical codes to ghl_contacts.projects[] (replaces lowercase slugs).
+ * Optionally pushes the ACT-XX codes back to GHL as tags so future syncs round-trip.
+ *
+ * Usage:
+ *   node scripts/backfill-ghl-contact-projects.mjs              # dry-run
+ *   node scripts/backfill-ghl-contact-projects.mjs --apply      # write to Supabase
+ *   node scripts/backfill-ghl-contact-projects.mjs --apply --push-ghl  # also push tags to GHL
+ *   node scripts/backfill-ghl-contact-projects.mjs --limit 50   # process N contacts only
+ *
+ * Env: SUPABASE_SHARED_URL · SUPABASE_SHARED_SERVICE_ROLE_KEY · GHL_API_KEY · GHL_LOCATION_ID
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const args = new Set(process.argv.slice(2));
+const APPLY = args.has('--apply');
+const PUSH_GHL = args.has('--push-ghl');
+const LIMIT_IDX = process.argv.indexOf('--limit');
+const LIMIT = LIMIT_IDX > -1 ? parseInt(process.argv[LIMIT_IDX + 1], 10) : null;
+const VERBOSE = args.has('--verbose');
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
+  console.error('Missing Supabase env vars');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+
+// Prefix rules: tag starts with key → canonical code
+const PREFIX_RULES = [
+  ['goods-', 'ACT-GD'],
+  ['harvest-', 'ACT-HV'],
+  ['contained-', 'ACT-CN'],
+  ['picc-', 'ACT-PI'],
+  ['justicehub-', 'ACT-JH'],
+  ['el-', 'ACT-EL'],
+  ['empathy-', 'ACT-EL'],
+  ['bcv-', 'ACT-BV'],
+  ['black-cockatoo-', 'ACT-BV'],
+  ['farm-', 'ACT-FM'],
+  ['the-farm-', 'ACT-FM']
+];
+
+// ────────────────────────────────────────────────────────────────────
+// Build the tag → canonical-code lookup
+// ────────────────────────────────────────────────────────────────────
+
+async function buildTagMap() {
+  const { data, error } = await supabase
+    .from('projects')
+    .select('code, name, ghl_tags, status');
+  if (error) throw error;
+
+  const directMap = new Map(); // lowercase tag → code
+  const codeMeta = new Map();
+  for (const p of data) {
+    codeMeta.set(p.code, { name: p.name, status: p.status });
+    for (const t of p.ghl_tags || []) {
+      const key = t.toLowerCase();
+      // Skip if collision (a tag mapped to multiple codes — already audited)
+      if (directMap.has(key) && directMap.get(key) !== p.code) {
+        if (VERBOSE) console.warn(`tag collision: '${t}' on ${directMap.get(key)} and ${p.code}`);
+        continue;
+      }
+      directMap.set(key, p.code);
+    }
+    // Slug variants for legacy contact.projects[] values
+    directMap.set(p.code.toLowerCase(), p.code);
+  }
+  // Legacy slug aliases that pre-date canonical codes
+  directMap.set('the-harvest', 'ACT-HV');
+  directMap.set('act-farm', 'ACT-FM');
+  directMap.set('act-studio', 'ACT-CORE');
+  return { directMap, codeMeta };
+}
+
+function deriveCodes(tags, directMap) {
+  const codes = new Set();
+  for (const raw of tags || []) {
+    if (!raw) continue;
+    const tag = String(raw).toLowerCase();
+    if (directMap.has(tag)) {
+      codes.add(directMap.get(tag));
+      continue;
+    }
+    for (const [prefix, code] of PREFIX_RULES) {
+      if (tag.startsWith(prefix)) {
+        codes.add(code);
+        break;
+      }
+    }
+  }
+  return codes;
+}
+
+function setsEqual(a, b) {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Stream contacts in pages
+// ────────────────────────────────────────────────────────────────────
+
+async function* streamContacts() {
+  const page = 1000;
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, full_name, email, tags, projects')
+      .order('id', { ascending: true })
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    if (!data?.length) return;
+    for (const c of data) yield c;
+    if (data.length < page) return;
+    offset += page;
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Main
+// ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const startedAt = Date.now();
+  console.log(`backfill-ghl-contact-projects — ${APPLY ? 'APPLY' : 'DRY-RUN'}${PUSH_GHL ? ' + push to GHL' : ''}${LIMIT ? ` (limit ${LIMIT})` : ''}`);
+
+  const { directMap, codeMeta } = await buildTagMap();
+  console.log(`Loaded ${directMap.size} tag mappings across ${codeMeta.size} projects`);
+
+  const ghl = PUSH_GHL ? createGHLService() : null;
+
+  const stats = {
+    seen: 0,
+    no_change: 0,
+    would_update: 0,
+    updated_supabase: 0,
+    ghl_tags_added: 0,
+    ghl_push_errors: 0,
+    no_derivable_codes: 0
+  };
+  const perCodeAdd = new Map();
+  const examples = [];
+
+  for await (const c of streamContacts()) {
+    if (LIMIT && stats.seen >= LIMIT) break;
+    stats.seen++;
+
+    const derived = deriveCodes(c.tags, directMap);
+    if (derived.size === 0) {
+      stats.no_derivable_codes++;
+      continue;
+    }
+
+    const target = derived;
+    const targetSorted = [...target].sort();
+    const currentSorted = [...(c.projects || [])].sort();
+    const supabaseIdentical = currentSorted.length === targetSorted.length
+      && currentSorted.every((v, i) => v === targetSorted[i]);
+
+    // Track ADDITIONS — codes in target that aren't already in GHL tags
+    const existingTagsLower = new Set((c.tags || []).map(t => String(t).toLowerCase()));
+    const codesToPush = [...target].filter(code => !existingTagsLower.has(code.toLowerCase()));
+    const ghlNeedsPush = codesToPush.length > 0;
+
+    if (supabaseIdentical && !ghlNeedsPush) {
+      stats.no_change++;
+      continue;
+    }
+    if (!supabaseIdentical) {
+      stats.would_update++;
+      for (const code of codesToPush) {
+        perCodeAdd.set(code, (perCodeAdd.get(code) || 0) + 1);
+      }
+      if (examples.length < 8) {
+        examples.push({
+          name: c.full_name || c.email,
+          ghl_id: c.ghl_id,
+          from: currentSorted,
+          to: targetSorted
+        });
+      }
+    }
+
+    if (!APPLY) continue;
+
+    // 1. Write Supabase (only if changed)
+    if (!supabaseIdentical) {
+      const { error: upErr } = await supabase
+        .from('ghl_contacts')
+        .update({ projects: targetSorted, updated_at: new Date().toISOString() })
+        .eq('id', c.id);
+      if (upErr) {
+        console.error(`supabase update failed for ${c.ghl_id}:`, upErr.message);
+        continue;
+      }
+      stats.updated_supabase++;
+    }
+
+    // 2. GHL push — independent of Supabase delta
+    const isSynthetic = c.email && /\.(local|temp)$/i.test(c.email);
+    if (isSynthetic) {
+      stats.skipped_synthetic = (stats.skipped_synthetic || 0) + 1;
+      continue;
+    }
+    if (PUSH_GHL && c.ghl_id && codesToPush.length > 0) {
+      for (const code of codesToPush) {
+        try {
+          await ghl.addTagToContact(c.ghl_id, code);
+          stats.ghl_tags_added++;
+        } catch (e) {
+          stats.ghl_push_errors++;
+          if (VERBOSE) console.error(`GHL addTag ${code} → ${c.ghl_id}: ${e.message}`);
+        }
+      }
+    }
+
+    if (stats.seen % 250 === 0) {
+      console.log(`  …processed ${stats.seen}  would_update=${stats.would_update}  updated=${stats.updated_supabase}  ghl_tags_added=${stats.ghl_tags_added}`);
+    }
+  }
+
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log('\n─── results ───');
+  console.log(`seen:               ${stats.seen}`);
+  console.log(`no_change:          ${stats.no_change}`);
+  console.log(`no_derivable_codes: ${stats.no_derivable_codes}`);
+  console.log(`would_update:       ${stats.would_update}`);
+  if (APPLY) {
+    console.log(`updated_supabase:   ${stats.updated_supabase}`);
+  }
+  if (PUSH_GHL) {
+    console.log(`ghl_tags_added:     ${stats.ghl_tags_added}`);
+    console.log(`ghl_push_errors:    ${stats.ghl_push_errors}`);
+    console.log(`skipped_synthetic:  ${stats.skipped_synthetic || 0}`);
+  }
+  console.log(`elapsed:            ${elapsed}s`);
+
+  console.log('\n─── per canonical code (to be added) ───');
+  const sorted = [...perCodeAdd.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [code, count] of sorted) {
+    const meta = codeMeta.get(code);
+    console.log(`  ${code.padEnd(8)} +${String(count).padStart(5)}  ${meta?.name || ''}${meta?.status && meta.status !== 'active' ? ` (${meta.status})` : ''}`);
+  }
+
+  console.log('\n─── example diffs ───');
+  for (const ex of examples) {
+    console.log(`  ${ex.name}`);
+    console.log(`    from: [${ex.from.join(', ')}]`);
+    console.log(`    to:   [${ex.to.join(', ')}]`);
+  }
+
+  if (!APPLY) {
+    console.log('\nDry-run only. Re-run with --apply to write Supabase, --apply --push-ghl to also tag in GHL.');
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/dedup-ghl-contacts.mjs
+++ b/scripts/dedup-ghl-contacts.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Dedup ghl_contacts where same email → multiple rows.
+ *
+ * Strategy:
+ *   1. Group by LOWER(email)
+ *   2. For each group, pick canonical row:
+ *      - Prefer rows with empathy_ledger_id set
+ *      - Then most recent updated_at
+ *      - Tiebreak: lowest id
+ *   3. Union tags, projects, custom_fields onto canonical
+ *   4. Pick best full_name (longest non-empty)
+ *   5. Pick most recent last_contact_date
+ *   6. Set canonical_contact_id on dups (NOT delete — reversible)
+ *
+ * Does NOT touch GHL. GHL-side merge requires explicit "merge in GHL" verb.
+ *
+ * Usage:
+ *   node scripts/dedup-ghl-contacts.mjs            # dry-run
+ *   node scripts/dedup-ghl-contacts.mjs --apply
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+console.log(`dedup-ghl-contacts — ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+
+// Pull all contacts with email (paginated)
+async function fetchAll() {
+  const all = [];
+  let offset = 0;
+  const page = 1000;
+  while (true) {
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, email, full_name, first_name, last_name, company_name, tags, projects, custom_fields, empathy_ledger_id, canonical_entity_id, xero_contact_id, last_contact_date, updated_at, ghl_created_at, is_storyteller, is_elder, newsletter_consent, newsletter_consent_at, canonical_contact_id')
+      .not('email', 'is', null)
+      .neq('email', '')
+      .order('id')
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    if (!data?.length) break;
+    all.push(...data);
+    if (data.length < page) break;
+    offset += page;
+  }
+  return all;
+}
+
+const contacts = await fetchAll();
+console.log(`Loaded ${contacts.length} contacts with email`);
+
+// Group by lowercased email
+const groups = new Map();
+for (const c of contacts) {
+  const k = c.email.trim().toLowerCase();
+  if (!groups.has(k)) groups.set(k, []);
+  groups.get(k).push(c);
+}
+
+const dupGroups = [...groups.entries()].filter(([_, rows]) => rows.length > 1);
+console.log(`Groups with duplicates: ${dupGroups.length}`);
+
+function pickCanonical(rows) {
+  // Sort: empathy_ledger_id present DESC, updated_at DESC, id ASC
+  return [...rows].sort((a, b) => {
+    if (!!a.empathy_ledger_id !== !!b.empathy_ledger_id) return a.empathy_ledger_id ? -1 : 1;
+    const ua = new Date(a.updated_at || 0).getTime();
+    const ub = new Date(b.updated_at || 0).getTime();
+    if (ua !== ub) return ub - ua;
+    return a.id < b.id ? -1 : 1;
+  })[0];
+}
+
+function mergeSet(field, rows) {
+  const s = new Set();
+  for (const r of rows) for (const v of r[field] || []) s.add(v);
+  return [...s].sort();
+}
+
+function bestName(rows) {
+  const candidates = rows
+    .map(r => (r.full_name || '').trim())
+    .filter(n => n.length > 0)
+    .sort((a, b) => {
+      // Prefer name with both upper and lower case (proper case) over all-lower
+      const aMixed = /[A-Z]/.test(a) && /[a-z]/.test(a);
+      const bMixed = /[A-Z]/.test(b) && /[a-z]/.test(b);
+      if (aMixed !== bMixed) return aMixed ? -1 : 1;
+      return b.length - a.length;
+    });
+  return candidates[0] || null;
+}
+
+let totalDupsMarked = 0;
+let groupsProcessed = 0;
+const examples = [];
+
+for (const [email, rows] of dupGroups) {
+  const canonical = pickCanonical(rows);
+  const dups = rows.filter(r => r.id !== canonical.id);
+
+  // Merge
+  const mergedTags = mergeSet('tags', rows);
+  const mergedProjects = mergeSet('projects', rows);
+  const mergedName = bestName(rows);
+  const mergedLastContact = rows
+    .map(r => r.last_contact_date ? new Date(r.last_contact_date).toISOString() : null)
+    .filter(Boolean)
+    .sort()
+    .pop();
+  const empathy = rows.map(r => r.empathy_ledger_id).find(Boolean);
+  const canonEntity = rows.map(r => r.canonical_entity_id).find(Boolean);
+  const xeroId = rows.map(r => r.xero_contact_id).find(Boolean);
+  const elderFlag = rows.some(r => r.is_elder);
+  const storyFlag = rows.some(r => r.is_storyteller);
+  const nlConsent = rows.some(r => r.newsletter_consent);
+  const nlConsentAt = rows
+    .map(r => r.newsletter_consent_at)
+    .filter(Boolean)
+    .sort()[0];
+
+  groupsProcessed++;
+  totalDupsMarked += dups.length;
+
+  if (examples.length < 5) {
+    examples.push({ email, kept: canonical.id.slice(0, 8), name: mergedName, dups: dups.length, tag_count: mergedTags.length });
+  }
+
+  if (!APPLY) continue;
+
+  // Update canonical with merged data
+  await supabase
+    .from('ghl_contacts')
+    .update({
+      tags: mergedTags,
+      projects: mergedProjects,
+      full_name: mergedName || canonical.full_name,
+      last_contact_date: mergedLastContact || canonical.last_contact_date,
+      empathy_ledger_id: empathy || canonical.empathy_ledger_id,
+      canonical_entity_id: canonEntity || canonical.canonical_entity_id,
+      xero_contact_id: xeroId || canonical.xero_contact_id,
+      is_storyteller: storyFlag || canonical.is_storyteller,
+      is_elder: elderFlag || canonical.is_elder,
+      newsletter_consent: nlConsent || canonical.newsletter_consent,
+      newsletter_consent_at: nlConsentAt || canonical.newsletter_consent_at,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', canonical.id);
+
+  // Mark dups
+  const dupIds = dups.map(d => d.id);
+  if (dupIds.length > 0) {
+    await supabase
+      .from('ghl_contacts')
+      .update({ canonical_contact_id: canonical.id, updated_at: new Date().toISOString() })
+      .in('id', dupIds);
+  }
+
+  if (groupsProcessed % 50 === 0) {
+    console.log(`  …${groupsProcessed} groups, ${totalDupsMarked} dups marked`);
+  }
+}
+
+console.log(`\n─── results ───`);
+console.log(`Groups processed: ${groupsProcessed}`);
+console.log(`Duplicate rows marked: ${totalDupsMarked}`);
+
+console.log(`\n─── samples ───`);
+for (const e of examples) {
+  console.log(`  ${e.email.padEnd(40)} kept=${e.kept}  dups=${e.dups}  tags=${e.tag_count}  name="${e.name}"`);
+}
+
+if (!APPLY) console.log(`\nDry-run. Re-run with --apply.`);

--- a/scripts/delete-ghl-duplicates.mjs
+++ b/scripts/delete-ghl-duplicates.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Delete GHL-side duplicate contacts.
+ *
+ * Pre-req: scripts/dedup-ghl-contacts.mjs has run — `canonical_contact_id`
+ * is set on Supabase rows that are duplicates of their canonical.
+ *
+ * For each dup row:
+ *   1. DELETE /contacts/{ghl_id} in GHL
+ *   2. On success: delete the dup row from Supabase
+ *   3. On 404: dup is already gone — delete the Supabase row anyway
+ *   4. On 403 / other error: log and continue
+ *
+ * The merged data (tags, projects, EL link) lives on the canonical row already
+ * (Supabase dedup ran first). So deleting GHL dups doesn't lose user-visible info.
+ *
+ * Usage:
+ *   node scripts/delete-ghl-duplicates.mjs                # dry-run
+ *   node scripts/delete-ghl-duplicates.mjs --limit 2      # smoke test
+ *   node scripts/delete-ghl-duplicates.mjs --apply        # do it
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT_IDX = process.argv.indexOf('--limit');
+const LIMIT = LIMIT_IDX > -1 ? parseInt(process.argv[LIMIT_IDX + 1], 10) : null;
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+const ghl = createGHLService();
+
+console.log(`delete-ghl-duplicates — ${APPLY ? 'APPLY' : 'DRY-RUN'}${LIMIT ? ` (limit ${LIMIT})` : ''}`);
+
+async function fetchDups() {
+  const all = [];
+  let offset = 0;
+  const page = 1000;
+  while (true) {
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, email, full_name, canonical_contact_id')
+      .not('canonical_contact_id', 'is', null)
+      .order('id')
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    if (!data?.length) break;
+    all.push(...data);
+    if (data.length < page) break;
+    offset += page;
+  }
+  return all;
+}
+
+const dups = await fetchDups();
+console.log(`Duplicate rows to delete: ${dups.length}`);
+
+const stats = { deleted: 0, already_gone: 0, forbidden: 0, other_errors: 0, supabase_cleaned: 0 };
+
+let processed = 0;
+for (const d of dups) {
+  if (LIMIT && processed >= LIMIT) break;
+  processed++;
+
+  if (!d.ghl_id) {
+    if (processed <= 5) console.log(`  skip: no ghl_id  (sb id=${d.id.slice(0,8)})`);
+    continue;
+  }
+
+  if (!APPLY) {
+    if (processed <= 5) {
+      console.log(`  WOULD DELETE  ${d.ghl_id}  ${d.full_name || d.email}`);
+    }
+    continue;
+  }
+
+  try {
+    await ghl.deleteContact(d.ghl_id);
+    stats.deleted++;
+    await supabase.from('ghl_contacts').delete().eq('id', d.id);
+    stats.supabase_cleaned++;
+  } catch (e) {
+    const msg = e.message || '';
+    if (msg.includes('Contact not found') || msg.includes('404')) {
+      stats.already_gone++;
+      await supabase.from('ghl_contacts').delete().eq('id', d.id);
+      stats.supabase_cleaned++;
+    } else if (msg.includes('403') || msg.includes('Permission denied')) {
+      stats.forbidden++;
+      if (stats.forbidden <= 3) console.error(`  403 on ${d.ghl_id}: ${msg.slice(0, 150)}`);
+    } else {
+      stats.other_errors++;
+      if (stats.other_errors <= 5) console.error(`  err on ${d.ghl_id}: ${msg.slice(0, 200)}`);
+    }
+  }
+
+  if (processed % 100 === 0) {
+    console.log(`  …${processed}  deleted=${stats.deleted} already_gone=${stats.already_gone} forbidden=${stats.forbidden} errors=${stats.other_errors}`);
+  }
+}
+
+console.log(`\n─── results ───`);
+console.log(`processed:        ${processed}`);
+console.log(`deleted in GHL:   ${stats.deleted}`);
+console.log(`already_gone:     ${stats.already_gone}`);
+console.log(`forbidden (403):  ${stats.forbidden}`);
+console.log(`other errors:     ${stats.other_errors}`);
+console.log(`supabase_cleaned: ${stats.supabase_cleaned}`);
+
+if (!APPLY) console.log(`\nDry-run. Re-run with --apply or --apply --limit N for smoke test.`);

--- a/scripts/lib/ghl-api-service.mjs
+++ b/scripts/lib/ghl-api-service.mjs
@@ -428,6 +428,36 @@ export class GHLService {
     });
   }
 
+  /**
+   * Merge a secondary contact into a primary contact.
+   * Primary keeps all fields; secondary is deleted from GHL.
+   *
+   * @param {string} primaryContactId - The contact to keep
+   * @param {string} secondaryContactId - The contact to merge in (will be deleted)
+   * @returns {Promise<Object>} merged contact
+   */
+  async mergeContacts(primaryContactId, secondaryContactId) {
+    return await this.request(`/contacts/merge`, {
+      method: 'POST',
+      body: JSON.stringify({
+        locationId: this.locationId,
+        primaryContactId,
+        secondaryContactId
+      })
+    });
+  }
+
+  /**
+   * Delete a contact from GHL.
+   *
+   * @param {string} contactId - GHL contact ID
+   */
+  async deleteContact(contactId) {
+    return await this.request(`/contacts/${contactId}`, {
+      method: 'DELETE'
+    });
+  }
+
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   // CUSTOM FIELDS
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -575,12 +605,13 @@ export class GHLService {
  * @returns {GHLService}
  */
 export function createGHLService() {
-  const apiKey = process.env.GHL_API_KEY;
+  // Prefer Private Integration Token (PIT) — broader API access including delete/merge
+  const apiKey = process.env.GHL_PRIVATE_TOKEN || process.env.GHL_API_KEY;
   const locationId = process.env.GHL_LOCATION_ID;
 
   if (!apiKey || !locationId) {
     throw new Error(
-      'Missing GHL credentials. Set GHL_API_KEY and GHL_LOCATION_ID environment variables.'
+      'Missing GHL credentials. Set GHL_PRIVATE_TOKEN (or GHL_API_KEY) and GHL_LOCATION_ID environment variables.'
     );
   }
 

--- a/scripts/lib/project-code-resolver.mjs
+++ b/scripts/lib/project-code-resolver.mjs
@@ -1,0 +1,92 @@
+/**
+ * Project-code resolver: tag → canonical ACT-XX code.
+ *
+ * Single source of truth for mapping GHL contact tags to project codes.
+ * Used by:
+ *   - scripts/backfill-ghl-contact-projects.mjs
+ *   - scripts/sync-ghl-to-supabase.mjs
+ *
+ * Lookup precedence:
+ *   1. Direct match against projects.ghl_tags (lowercased)
+ *   2. Direct match against ACT-XX code itself (case-insensitive)
+ *   3. Prefix rule (goods-* → ACT-GD, etc.)
+ *   4. Legacy slug aliases (the-harvest → ACT-HV, act-farm → ACT-FM, act-studio → ACT-CORE)
+ */
+
+export const PREFIX_RULES = [
+  ['goods-', 'ACT-GD'],
+  ['harvest-', 'ACT-HV'],
+  ['contained-', 'ACT-CN'],
+  ['picc-', 'ACT-PI'],
+  ['justicehub-', 'ACT-JH'],
+  ['el-', 'ACT-EL'],
+  ['empathy-', 'ACT-EL'],
+  ['bcv-', 'ACT-BV'],
+  ['black-cockatoo-', 'ACT-BV'],
+  ['farm-', 'ACT-FM'],
+  ['the-farm-', 'ACT-FM']
+];
+
+const LEGACY_SLUG_ALIASES = {
+  'the-harvest': 'ACT-HV',
+  'act-farm': 'ACT-FM',
+  'act-studio': 'ACT-CORE',
+  'goods-on-country': 'ACT-GD',
+  'bcv-residencies': 'ACT-BV'
+};
+
+/**
+ * Build the tag → code lookup map from the projects table.
+ * @param {SupabaseClient} supabase - Supabase client
+ * @returns {Promise<{directMap: Map<string,string>, codeMeta: Map<string,{name:string,status:string}>}>}
+ */
+export async function buildProjectTagMap(supabase) {
+  const { data, error } = await supabase
+    .from('projects')
+    .select('code, name, ghl_tags, status');
+  if (error) throw error;
+
+  const directMap = new Map();
+  const codeMeta = new Map();
+
+  for (const p of data) {
+    codeMeta.set(p.code, { name: p.name, status: p.status });
+    // ACT-XX code maps to itself (case-insensitive)
+    directMap.set(p.code.toLowerCase(), p.code);
+    for (const t of p.ghl_tags || []) {
+      const key = String(t).toLowerCase();
+      if (directMap.has(key) && directMap.get(key) !== p.code) continue;
+      directMap.set(key, p.code);
+    }
+  }
+  // Legacy aliases (predate canonical codes)
+  for (const [slug, code] of Object.entries(LEGACY_SLUG_ALIASES)) {
+    if (!directMap.has(slug)) directMap.set(slug, code);
+  }
+  return { directMap, codeMeta };
+}
+
+/**
+ * Derive canonical ACT-XX codes from a contact's tag set.
+ * @param {string[]} tags
+ * @param {Map<string,string>} directMap
+ * @returns {string[]} sorted canonical codes
+ */
+export function deriveProjectCodes(tags, directMap) {
+  const codes = new Set();
+  for (const raw of tags || []) {
+    if (!raw) continue;
+    const tag = String(raw).toLowerCase();
+    if (directMap.has(tag)) {
+      codes.add(directMap.get(tag));
+      continue;
+    }
+    for (const [prefix, code] of PREFIX_RULES) {
+      if (tag.startsWith(prefix)) {
+        codes.add(code);
+        break;
+      }
+    }
+  }
+  return [...codes].sort();
+}

--- a/scripts/merge-ghl-duplicates.mjs
+++ b/scripts/merge-ghl-duplicates.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Merge GHL-side duplicate contacts.
+ *
+ * Pre-req: scripts/dedup-ghl-contacts.mjs has run — `canonical_contact_id`
+ * is set on Supabase rows that should be merged INTO their canonical.
+ *
+ * For each (canonical, dup) pair:
+ *   1. Read canonical ghl_id + dup ghl_id from Supabase
+ *   2. Call GHL merge API (primary=canonical, secondary=dup)
+ *   3. On success: delete the dup row from Supabase (its ghl_id no longer exists in GHL)
+ *   4. On 404 / contact-not-found: mark dup row with sync_status='ghl-deleted' (already gone)
+ *
+ * Usage:
+ *   node scripts/merge-ghl-duplicates.mjs                # dry-run
+ *   node scripts/merge-ghl-duplicates.mjs --limit 2      # smoke test 2 merges
+ *   node scripts/merge-ghl-duplicates.mjs --apply        # do it
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT_IDX = process.argv.indexOf('--limit');
+const LIMIT = LIMIT_IDX > -1 ? parseInt(process.argv[LIMIT_IDX + 1], 10) : null;
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+const ghl = createGHLService();
+
+console.log(`merge-ghl-duplicates — ${APPLY ? 'APPLY' : 'DRY-RUN'}${LIMIT ? ` (limit ${LIMIT})` : ''}`);
+
+// Pull all dup rows + their canonical ghl_id
+async function fetchPairs() {
+  const all = [];
+  let offset = 0;
+  const page = 1000;
+  while (true) {
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, email, full_name, canonical_contact_id')
+      .not('canonical_contact_id', 'is', null)
+      .order('id')
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    if (!data?.length) break;
+    all.push(...data);
+    if (data.length < page) break;
+    offset += page;
+  }
+  // Fetch canonical ghl_ids
+  const canonicalIds = [...new Set(all.map(d => d.canonical_contact_id))];
+  const canonicals = new Map();
+  for (let i = 0; i < canonicalIds.length; i += 200) {
+    const chunk = canonicalIds.slice(i, i + 200);
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, email, full_name')
+      .in('id', chunk);
+    if (error) throw error;
+    for (const c of data) canonicals.set(c.id, c);
+  }
+  return all.map(dup => ({
+    dup,
+    canonical: canonicals.get(dup.canonical_contact_id)
+  })).filter(p => p.canonical && p.dup.ghl_id && p.canonical.ghl_id);
+}
+
+const pairs = await fetchPairs();
+console.log(`Pairs to merge: ${pairs.length}`);
+
+const stats = { merged: 0, already_gone: 0, errors: 0, supabase_deleted: 0 };
+const seenCanonicals = new Set();
+
+let processed = 0;
+for (const { dup, canonical } of pairs) {
+  if (LIMIT && processed >= LIMIT) break;
+  processed++;
+
+  // Safety: skip if primary == secondary somehow
+  if (dup.ghl_id === canonical.ghl_id) continue;
+
+  if (!APPLY) {
+    if (processed <= 5) {
+      console.log(`  WOULD MERGE  primary=${canonical.ghl_id} (${canonical.full_name || canonical.email})  ← dup=${dup.ghl_id} (${dup.full_name || dup.email})`);
+    }
+    continue;
+  }
+
+  try {
+    await ghl.mergeContacts(canonical.ghl_id, dup.ghl_id);
+    stats.merged++;
+    // Delete the now-stale Supabase row
+    await supabase.from('ghl_contacts').delete().eq('id', dup.id);
+    stats.supabase_deleted++;
+  } catch (e) {
+    const msg = e.message || '';
+    if (msg.includes('Contact not found') || msg.includes('404')) {
+      stats.already_gone++;
+      // Still delete the stale Supabase row
+      await supabase.from('ghl_contacts').delete().eq('id', dup.id);
+      stats.supabase_deleted++;
+    } else {
+      stats.errors++;
+      if (stats.errors <= 5) console.error(`merge ${canonical.ghl_id} ← ${dup.ghl_id}: ${msg.slice(0, 200)}`);
+    }
+  }
+
+  if (processed % 100 === 0) {
+    console.log(`  …${processed}  merged=${stats.merged} already_gone=${stats.already_gone} errors=${stats.errors}`);
+  }
+}
+
+console.log(`\n─── results ───`);
+console.log(`processed:          ${processed}`);
+console.log(`merged:             ${stats.merged}`);
+console.log(`already_gone (404): ${stats.already_gone}`);
+console.log(`errors:             ${stats.errors}`);
+console.log(`supabase_deleted:   ${stats.supabase_deleted}`);
+
+if (!APPLY) console.log(`\nDry-run. Re-run with --apply.`);

--- a/scripts/probe-el-storytellers.mjs
+++ b/scripts/probe-el-storytellers.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const EL_ENV_PATH = join(process.env.HOME, 'Code/empathy-ledger-v2/.env.local');
+try {
+  const elEnv = readFileSync(EL_ENV_PATH, 'utf8');
+  for (const line of elEnv.split('\n')) {
+    const [key, ...rest] = line.split('=');
+    if (key && rest.length > 0 && !process.env[`EL_${key}`]) {
+      process.env[`EL_${key}`] = rest.join('=').trim();
+    }
+  }
+} catch {}
+
+const URL = process.env.EL_NEXT_PUBLIC_SUPABASE_URL || 'https://yvnuayzslukamizrlhwb.supabase.co';
+const KEY = process.env.EL_SUPABASE_SERVICE_ROLE_KEY;
+
+async function probe(path) {
+  const r = await fetch(URL + '/rest/v1/' + path, {
+    headers: { apikey: KEY, Authorization: 'Bearer ' + KEY }
+  });
+  return r.ok ? r.json() : { status: r.status, err: await r.text() };
+}
+
+// Try common table names
+for (const tbl of ['storytellers', 'stories', 'profiles', 'users', 'people']) {
+  const result = await probe(`${tbl}?select=*&limit=2`);
+  if (Array.isArray(result)) {
+    console.log(`\n=== ${tbl} ===`);
+    if (result[0]) {
+      console.log('cols:', Object.keys(result[0]).join(', '));
+      console.log(JSON.stringify(result[0], null, 2).slice(0, 600));
+    } else {
+      console.log('(empty)');
+    }
+  } else {
+    console.log(`\n=== ${tbl} === SKIP (${result.status})`);
+  }
+}

--- a/scripts/reconcile-phantom-storytellers.mjs
+++ b/scripts/reconcile-phantom-storytellers.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * Reconcile 2,387 GHL phantom storytellers against EL v2.
+ *
+ * Phantom = ghl_contacts tagged 'storyteller' but is_storyteller=false,
+ *           with synthetic emails (.local / .temp).
+ *
+ * Strategy:
+ *   1. Fetch all EL v2 profiles + storytellers (names + ids).
+ *   2. For each phantom, match by normalised full_name.
+ *   3. Match found → backfill empathy_ledger_id + is_storyteller=true (with --apply).
+ *   4. No match → mark with auto_created_from='el-orphan' and report.
+ *
+ * Usage:
+ *   node scripts/reconcile-phantom-storytellers.mjs            # dry-run
+ *   node scripts/reconcile-phantom-storytellers.mjs --apply    # write Supabase
+ */
+
+import 'dotenv/config';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+
+const OP_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const OP_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!OP_URL || !OP_KEY) { console.error('Missing SUPABASE_* env'); process.exit(1); }
+const op = createClient(OP_URL, OP_KEY);
+
+// Load EL v2 env
+const EL_ENV_PATH = join(process.env.HOME, 'Code/empathy-ledger-v2/.env.local');
+try {
+  const elEnv = readFileSync(EL_ENV_PATH, 'utf8');
+  for (const line of elEnv.split('\n')) {
+    const [key, ...rest] = line.split('=');
+    if (key && rest.length > 0 && !process.env[`EL_${key}`]) {
+      process.env[`EL_${key}`] = rest.join('=').trim();
+    }
+  }
+} catch (e) {
+  console.error('Could not read EL env:', e.message);
+}
+const EL_URL = process.env.EL_NEXT_PUBLIC_SUPABASE_URL || 'https://yvnuayzslukamizrlhwb.supabase.co';
+const EL_KEY = process.env.EL_SUPABASE_SERVICE_ROLE_KEY;
+if (!EL_KEY) { console.error('Missing EL_SUPABASE_SERVICE_ROLE_KEY'); process.exit(1); }
+
+async function elFetch(path) {
+  const r = await fetch(`${EL_URL}/rest/v1/${path}`, {
+    headers: { apikey: EL_KEY, Authorization: `Bearer ${EL_KEY}` }
+  });
+  if (!r.ok) throw new Error(`EL ${path}: ${r.status} ${await r.text()}`);
+  return r.json();
+}
+
+// Page through to get all records (PostgREST default limit = 1000)
+async function elFetchAll(table, select) {
+  const out = [];
+  let offset = 0;
+  const page = 1000;
+  while (true) {
+    const rows = await elFetch(`${table}?select=${select}&limit=${page}&offset=${offset}&order=id.asc`);
+    if (!rows.length) break;
+    out.push(...rows);
+    if (rows.length < page) break;
+    offset += page;
+  }
+  return out;
+}
+
+function normaliseName(s) {
+  if (!s) return null;
+  return String(s)
+    .toLowerCase()
+    .normalize('NFD').replace(/\p{Diacritic}/gu, '')
+    .replace(/\b(dr|aunty|uncle|mr|mrs|ms|prof)\.?\b/g, '')
+    .replace(/[^a-z0-9 ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+console.log('Loading EL v2 profiles and storytellers…');
+const profiles = await elFetchAll('profiles', 'id,full_name,display_name,email,is_storyteller');
+const storytellers = await elFetchAll('storytellers', 'id,profile_id,display_name');
+console.log(`  ${profiles.length} profiles, ${storytellers.length} storytellers`);
+
+// Build name → profile_id index
+const nameIndex = new Map();
+const addToIndex = (name, profileId) => {
+  const norm = normaliseName(name);
+  if (!norm || norm.length < 3) return;
+  if (!nameIndex.has(norm)) nameIndex.set(norm, new Set());
+  nameIndex.get(norm).add(profileId);
+};
+for (const p of profiles) {
+  addToIndex(p.full_name, p.id);
+  addToIndex(p.display_name, p.id);
+}
+for (const s of storytellers) {
+  addToIndex(s.display_name, s.profile_id || s.id);
+}
+console.log(`  ${nameIndex.size} unique normalised names indexed`);
+
+// Pull phantom GHL contacts — paginated to bypass default 1000-row limit
+console.log('\nLoading phantom GHL contacts (paginated)…');
+async function fetchAllPhantoms() {
+  const all = [];
+  for (const pattern of ['%.local', '%.temp']) {
+    let offset = 0;
+    const pageSize = 1000;
+    while (true) {
+      const { data, error } = await op
+        .from('ghl_contacts')
+        .select('id, ghl_id, full_name, email, empathy_ledger_id, is_storyteller, tags')
+        .ilike('email', pattern)
+        .is('empathy_ledger_id', null)
+        .order('id')
+        .range(offset, offset + pageSize - 1);
+      if (error) throw error;
+      if (!data || data.length === 0) break;
+      all.push(...data);
+      if (data.length < pageSize) break;
+      offset += pageSize;
+    }
+  }
+  return all;
+}
+const allPhantoms = await fetchAllPhantoms();
+console.log(`  ${allPhantoms.length} synthetic-email contacts`);
+
+// Match
+const matches = [];
+const ambiguous = [];
+const orphans = [];
+for (const p of allPhantoms) {
+  const norm = normaliseName(p.full_name);
+  if (!norm) { orphans.push({ ...p, reason: 'no_name' }); continue; }
+  const candidates = nameIndex.get(norm);
+  if (!candidates || candidates.size === 0) {
+    orphans.push({ ...p, reason: 'no_match' });
+  } else if (candidates.size === 1) {
+    matches.push({ ...p, el_profile_id: [...candidates][0] });
+  } else {
+    ambiguous.push({ ...p, candidates: [...candidates] });
+  }
+}
+
+console.log(`\n─── reconciliation results ───`);
+console.log(`Total phantoms:    ${allPhantoms.length}`);
+console.log(`Unique matches:    ${matches.length}`);
+console.log(`Ambiguous (multi): ${ambiguous.length}`);
+console.log(`Orphans (no EL):   ${orphans.length}`);
+
+// Per-organisation breakdown not available without organization_id on profiles.
+console.log(`\n─── sample matches ───`);
+for (const m of matches.slice(0, 8)) {
+  console.log(`  ${m.full_name.padEnd(35)} → EL profile ${m.el_profile_id}`);
+}
+console.log(`\n─── sample orphans (no EL match) ───`);
+for (const o of orphans.slice(0, 8)) {
+  console.log(`  ${(o.full_name || '(no name)').padEnd(35)} ${o.email}  reason=${o.reason}`);
+}
+
+if (!APPLY) {
+  console.log('\nDry-run. Re-run with --apply to write empathy_ledger_id + is_storyteller=true on matches.');
+  process.exit(0);
+}
+
+console.log(`\nApplying matches…`);
+let updated = 0;
+let failed = 0;
+for (const m of matches) {
+  const { error } = await op.from('ghl_contacts').update({
+    empathy_ledger_id: m.el_profile_id,
+    is_storyteller: true,
+    el_last_synced_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  }).eq('id', m.id);
+  if (error) { failed++; console.error(error.message); } else { updated++; }
+}
+console.log(`Updated: ${updated} · Failed: ${failed}`);
+
+// Also flag ambiguous for follow-up
+console.log(`\nFlagging ambiguous contacts (no auto-link, needs manual choice)…`);
+let flagged = 0;
+for (const a of ambiguous) {
+  const { error } = await op.from('ghl_contacts').update({
+    auto_created_from: `el-ambiguous:${a.candidates.join(',')}`,
+    updated_at: new Date().toISOString()
+  }).eq('id', a.id);
+  if (!error) flagged++;
+}
+console.log(`Flagged: ${flagged}`);

--- a/scripts/resolve-ambiguous-storytellers.mjs
+++ b/scripts/resolve-ambiguous-storytellers.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Resolve 141 ambiguous phantom storyteller matches.
+ *
+ * For each contact with auto_created_from = 'el-ambiguous:id1,id2,...':
+ *   1. Query EL v2 for stories per profile_id
+ *   2. Pick the profile with most stories (tiebreak: lowest id)
+ *   3. Backfill empathy_ledger_id + is_storyteller=true
+ *   4. Clear el-ambiguous flag
+ *
+ * Usage:
+ *   node scripts/resolve-ambiguous-storytellers.mjs           # dry-run
+ *   node scripts/resolve-ambiguous-storytellers.mjs --apply
+ */
+
+import 'dotenv/config';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createClient } from '@supabase/supabase-js';
+
+const APPLY = process.argv.includes('--apply');
+
+const OP_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL;
+const OP_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const op = createClient(OP_URL, OP_KEY);
+
+const EL_ENV_PATH = join(process.env.HOME, 'Code/empathy-ledger-v2/.env.local');
+try {
+  const elEnv = readFileSync(EL_ENV_PATH, 'utf8');
+  for (const line of elEnv.split('\n')) {
+    const [k, ...r] = line.split('=');
+    if (k && r.length) process.env[`EL_${k}`] = r.join('=').trim();
+  }
+} catch {}
+const EL_URL = process.env.EL_NEXT_PUBLIC_SUPABASE_URL || 'https://yvnuayzslukamizrlhwb.supabase.co';
+const EL_KEY = process.env.EL_SUPABASE_SERVICE_ROLE_KEY;
+
+async function elFetch(path) {
+  const r = await fetch(`${EL_URL}/rest/v1/${path}`, {
+    headers: { apikey: EL_KEY, Authorization: `Bearer ${EL_KEY}` }
+  });
+  if (!r.ok) throw new Error(`EL ${path}: ${r.status}`);
+  return r.json();
+}
+
+const { data: ambiguous, error } = await op
+  .from('ghl_contacts')
+  .select('id, ghl_id, full_name, auto_created_from')
+  .like('auto_created_from', 'el-ambiguous:%');
+if (error) throw error;
+
+console.log(`${ambiguous.length} ambiguous contacts to resolve`);
+
+// Collect unique profile IDs to query story counts
+const allProfileIds = new Set();
+for (const c of ambiguous) {
+  const ids = c.auto_created_from.replace('el-ambiguous:', '').split(',');
+  for (const id of ids) allProfileIds.add(id);
+}
+console.log(`Querying story counts for ${allProfileIds.size} EL profiles`);
+
+// Story count per author/storyteller
+const storyCount = new Map();
+for (const id of allProfileIds) {
+  storyCount.set(id, 0);
+}
+// Stories by author_id
+let offset = 0;
+while (true) {
+  const ids = [...allProfileIds].slice(offset, offset + 50);
+  if (ids.length === 0) break;
+  const inList = ids.map(i => `"${i}"`).join(',');
+  const stories = await elFetch(`stories?author_id=in.(${inList})&select=author_id&limit=10000`);
+  for (const s of stories) {
+    if (storyCount.has(s.author_id)) {
+      storyCount.set(s.author_id, storyCount.get(s.author_id) + 1);
+    }
+  }
+  // Also storyteller_id
+  const stories2 = await elFetch(`stories?storyteller_id=in.(${inList})&select=storyteller_id&limit=10000`);
+  for (const s of stories2) {
+    if (storyCount.has(s.storyteller_id)) {
+      storyCount.set(s.storyteller_id, storyCount.get(s.storyteller_id) + 1);
+    }
+  }
+  offset += 50;
+}
+
+let toUpdate = 0;
+const examples = [];
+for (const c of ambiguous) {
+  const candidateIds = c.auto_created_from.replace('el-ambiguous:', '').split(',');
+  // Sort by story count DESC, then by lowest id (deterministic)
+  const sorted = candidateIds.sort((a, b) => {
+    const ca = storyCount.get(a) || 0;
+    const cb = storyCount.get(b) || 0;
+    if (cb !== ca) return cb - ca;
+    return a < b ? -1 : 1;
+  });
+  c.winner = sorted[0];
+  c.winner_stories = storyCount.get(sorted[0]) || 0;
+  c.all_scores = sorted.map(id => `${id.slice(0,8)}:${storyCount.get(id) || 0}`).join(' ');
+  toUpdate++;
+  if (examples.length < 10) examples.push(c);
+}
+
+console.log(`\n─── examples ───`);
+for (const e of examples) {
+  console.log(`  ${(e.full_name || '?').padEnd(28)} → ${e.winner.slice(0,8)} (${e.winner_stories} stories)   [${e.all_scores}]`);
+}
+
+if (!APPLY) {
+  console.log(`\nDry-run. ${toUpdate} contacts would be resolved.`);
+  process.exit(0);
+}
+
+console.log(`\nApplying ${toUpdate} resolutions…`);
+let updated = 0;
+for (const c of ambiguous) {
+  const { error } = await op.from('ghl_contacts').update({
+    empathy_ledger_id: c.winner,
+    is_storyteller: true,
+    el_last_synced_at: new Date().toISOString(),
+    auto_created_from: null,
+    updated_at: new Date().toISOString()
+  }).eq('id', c.id);
+  if (!error) updated++;
+}
+console.log(`Updated: ${updated}`);

--- a/scripts/sync-ghl-to-supabase.mjs
+++ b/scripts/sync-ghl-to-supabase.mjs
@@ -20,6 +20,7 @@
 
 import { createGHLService } from './lib/ghl-api-service.mjs';
 import { createClient } from '@supabase/supabase-js';
+import { buildProjectTagMap, deriveProjectCodes } from './lib/project-code-resolver.mjs';
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // CONFIGURATION
@@ -119,6 +120,10 @@ async function syncContacts(supabase, ghl) {
   console.log('\n👥 Syncing Contacts...\n');
 
   try {
+    // Load canonical project-code lookup ONCE
+    const { directMap: projectTagMap } = await buildProjectTagMap(supabase);
+    console.log(`   Loaded ${projectTagMap.size} project tag mappings`);
+
     // Fetch all contacts from GHL
     const ghlContacts = await getAllGHLContacts(ghl);
     console.log(`   Found ${ghlContacts.length} contacts in GHL`);
@@ -139,7 +144,7 @@ async function syncContacts(supabase, ghl) {
     // Sync each contact
     for (const ghlContact of ghlContacts) {
       try {
-        const contactData = transformContactForSupabase(ghlContact);
+        const contactData = transformContactForSupabase(ghlContact, projectTagMap);
         const existingUpdatedAt = existingMap.get(ghlContact.id);
 
         const { error } = await supabase
@@ -192,10 +197,11 @@ async function getAllGHLContacts(ghl) {
   return allContacts;
 }
 
-function transformContactForSupabase(ghlContact) {
-  // Extract project tags
-  const projectTags = ['empathy-ledger', 'justicehub', 'the-harvest', 'act-farm', 'goods-on-country', 'bcv-residencies', 'act-studio'];
-  const projects = (ghlContact.tags || []).filter(tag => projectTags.includes(tag));
+function transformContactForSupabase(ghlContact, projectTagMap) {
+  // Derive canonical ACT-XX codes from tags via projects.ghl_tags + prefix rules
+  const projects = projectTagMap
+    ? deriveProjectCodes(ghlContact.tags, projectTagMap)
+    : [];
 
   // Determine engagement status from tags
   const engagementTags = (ghlContact.tags || []).filter(tag => tag.startsWith('engagement:'));

--- a/supabase/migrations/20260513000000_ghl_alignment.sql
+++ b/supabase/migrations/20260513000000_ghl_alignment.sql
@@ -1,0 +1,88 @@
+-- GHL ↔ Xero ↔ Supabase canonical-code alignment
+-- 2026-05-13 / 2026-05-14
+--
+-- Schema-only DDL for the alignment work in this PR. Data-side backfills were
+-- run by scripts in this PR (idempotent — safe to re-run on fresh environments).
+--
+-- See: thoughts/shared/audits/ghl-tag-alignment-2026-05-13.md
+
+-- 1. Allow 'background' tier value (was missing despite use in config + wiki)
+ALTER TABLE projects DROP CONSTRAINT IF EXISTS projects_tier_check;
+ALTER TABLE projects ADD CONSTRAINT projects_tier_check
+  CHECK (tier = ANY (ARRAY['engine','campaign','community','art','ecosystem','studio','satellite','background']));
+
+-- 2. Add canonical 5 projects that existed in wiki but not in projects table
+INSERT INTO projects (code, name, status, tier, ghl_tags, organization_id)
+SELECT * FROM (VALUES
+  ('ACT-DLB', 'DeadlyLabs', 'active', 'background',
+    ARRAY['deadlylabs','deadly-labs','deadlyscience'],
+    (SELECT organization_id FROM projects WHERE code = 'ACT-CORE' LIMIT 1)),
+  ('ACT-PB', 'Place-Based Policy Lab', 'active', 'background',
+    ARRAY['place-based-policy-lab','place-based-policy','ppl'],
+    (SELECT organization_id FROM projects WHERE code = 'ACT-CORE' LIMIT 1)),
+  ('ACT-QD', 'Quandamooka Justice and Healing Strategy', 'active', 'satellite',
+    ARRAY['quandamooka','quandamooka-justice','qjhs'],
+    (SELECT organization_id FROM projects WHERE code = 'ACT-CORE' LIMIT 1)),
+  ('ACT-RS', 'ReSOLEution', 'active', 'satellite',
+    ARRAY['resoleution','re-soleution'],
+    (SELECT organization_id FROM projects WHERE code = 'ACT-CORE' LIMIT 1))
+) AS v(code, name, status, tier, ghl_tags, organization_id)
+WHERE NOT EXISTS (SELECT 1 FROM projects p WHERE p.code = v.code);
+
+-- 3. Disambiguate 'justicehub' tag: ACT-JH owns it, ACT-JC uses 'justicehub-coe'
+UPDATE projects
+SET ghl_tags = ARRAY['justicehub-coe','coe']
+WHERE code = 'ACT-JC';
+
+-- 4. Link columns on ghl_contacts
+ALTER TABLE ghl_contacts ADD COLUMN IF NOT EXISTS xero_contact_id UUID;
+ALTER TABLE ghl_contacts ADD COLUMN IF NOT EXISTS xero_match_method TEXT;
+ALTER TABLE ghl_contacts ADD COLUMN IF NOT EXISTS xero_matched_at TIMESTAMPTZ;
+ALTER TABLE ghl_contacts ADD COLUMN IF NOT EXISTS canonical_contact_id UUID;
+
+CREATE INDEX IF NOT EXISTS ghl_contacts_xero_contact_id_idx ON ghl_contacts(xero_contact_id);
+CREATE INDEX IF NOT EXISTS ghl_contacts_canonical_idx ON ghl_contacts(canonical_contact_id);
+
+-- 5. View: canonical-only contacts (excludes dups)
+CREATE OR REPLACE VIEW v_canonical_contacts AS
+SELECT * FROM ghl_contacts WHERE canonical_contact_id IS NULL;
+
+-- 6. View: send-eligible newsletter audience (consent + tag + real email)
+CREATE OR REPLACE VIEW v_newsletter_audience AS
+SELECT
+  gc.id, gc.ghl_id, gc.full_name, gc.email,
+  gc.newsletter_consent, gc.newsletter_consent_at, gc.newsletter_unsubscribed_at,
+  gc.projects,
+  CASE
+    WHEN EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) = 'goods-newsletter') THEN 'goods'
+    WHEN EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) = 'harvest-newsletter') THEN 'harvest'
+    WHEN EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) = 'newsletter') THEN 'generic'
+    ELSE NULL
+  END AS newsletter_segment,
+  array_agg(DISTINCT t) FILTER (WHERE t LIKE '%newsletter%') AS newsletter_tags
+FROM ghl_contacts gc
+LEFT JOIN LATERAL unnest(gc.tags) t ON LOWER(t) LIKE '%newsletter%'
+WHERE gc.newsletter_consent = true
+  AND gc.newsletter_unsubscribed_at IS NULL
+  AND gc.email IS NOT NULL
+  AND gc.email NOT LIKE '%.local'
+  AND gc.email NOT LIKE '%.temp'
+GROUP BY gc.id, gc.ghl_id, gc.full_name, gc.email, gc.newsletter_consent,
+         gc.newsletter_consent_at, gc.newsletter_unsubscribed_at, gc.projects, gc.tags;
+
+-- 7. View: re-prompt candidates (tagged a newsletter, no consent yet)
+CREATE OR REPLACE VIEW v_newsletter_reprompt_candidates AS
+SELECT
+  gc.id, gc.ghl_id, gc.full_name, gc.email,
+  CASE
+    WHEN EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) = 'goods-newsletter') THEN 'goods'
+    WHEN EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) = 'harvest-newsletter') THEN 'harvest'
+    WHEN EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) = 'newsletter') THEN 'generic'
+  END AS newsletter_segment,
+  gc.projects, gc.tags, gc.last_contact_date
+FROM ghl_contacts gc
+WHERE EXISTS (SELECT 1 FROM unnest(gc.tags) t WHERE LOWER(t) LIKE '%newsletter%')
+  AND COALESCE(gc.newsletter_consent, false) = false
+  AND gc.email IS NOT NULL
+  AND gc.email NOT LIKE '%.local'
+  AND gc.email NOT LIKE '%.temp';

--- a/thoughts/shared/audits/ghl-tag-alignment-2026-05-13.md
+++ b/thoughts/shared/audits/ghl-tag-alignment-2026-05-13.md
@@ -1,0 +1,233 @@
+---
+title: Project-code alignment audit — Xero · Supabase · GHL · Wiki · Newsletter
+date: 2026-05-13
+status: review-needed
+owner: Ben
+---
+
+# Project-code alignment audit
+
+> **Goal:** every place that names a project (Xero, Supabase, GHL contacts + opportunities, wiki, newsletter) must use the same canonical code (`ACT-XX`) from `projects.code`. This audit shows where we already are, where we're not, and what one backfill pass can fix.
+
+## TL;DR
+
+| System | Aligned on canonical codes? | Coverage | Status |
+|---|---|---|---|
+| `xero_transactions` | YES | 97.7% (3,040/3,112) | aligned |
+| `xero_invoices` | YES | 95.8% (1,698/1,772) | aligned |
+| `ghl_opportunities` | YES | 82.5% (287/348) | aligned |
+| `projects` (canonical) | n/a | 76 codes (31 active) | source of truth |
+| `ghl_contacts.projects[]` | NO — lowercase slugs | 13.5% | **misaligned** |
+| `ghl_contacts.tags` (free text) | PARTIAL — ~50% mappable | n/a | **needs backfill** |
+| `wiki/projects/*.md` frontmatter | MOSTLY | 30/39 with code | 5 orphans, 1 collision |
+| Newsletter consent | NO project linkage | 118 boolean / 382 tagged | **broken** |
+
+**The financial side is fine. The contact side and wiki need cleanup.**
+
+---
+
+## 1. Xero / Supabase / GHL opportunities
+
+Already aligned on `ACT-XX` codes. One orphan and a few archived/transferred codes still in use:
+
+- `DISPUTED` — 2 transactions. Not a project code; should be moved to a status field or cleared.
+- `ACT-OS` (Orange Sky EL, archived) — 3 tx, 0 inv. Historical, ok to keep.
+- `ACT-SH` (The Shed, archived) — 15 invoices. Historical, ok.
+- `ACT-SX`, `ACT-WE`, `ACT-WJ`, `ACT-BR` — all archived projects with historical financial records. OK to keep, no rename needed.
+
+**Action:** clear `DISPUTED` tag (move to status column or delete).
+
+---
+
+## 2. GHL contacts — the main work
+
+### 2a. `projects[]` array uses slugs, not canonical codes
+
+| Slug | Contacts | Should be |
+|---|---|---|
+| `justicehub` | 688 | ACT-JH (and/or ACT-JC) |
+| `empathy-ledger` | 14 | ACT-EL |
+| `goods` | 7 | ACT-GD |
+| `the-harvest` | 2 | ACT-HV |
+
+Total: 711 / 5,274 = 13.5% project-tagged. **Only 4 projects represented.**
+
+### 2b. Tag-based project signal is huge
+
+Tags carry the real signal. Mapping via `projects.ghl_tags` plus four prefix rules (`goods-*`, `harvest-*`, `contained-*`, `picc-*`) lifts coverage from **13.5% → 74.3%**.
+
+**Per-project uplift after backfill:**
+
+| Canonical | Project | Current contacts | After backfill |
+|---|---|---|---|
+| ACT-EL | Empathy Ledger | 14 | **2,913** |
+| ACT-GD | Goods | 7 | **855** |
+| ACT-JH | JusticeHub | 0 | **692** |
+| ACT-JC | JH Centre of Excellence | 0 | 689 (overlap — see ambiguity) |
+| ACT-HV | The Harvest | 2 | **120** |
+| ACT-CN | Contained | 0 | **29** |
+| ACT-CG | CivicGraph | 0 | 1 |
+
+### 2c. Ambiguity: `justicehub` tag → ACT-JH **or** ACT-JC?
+
+`projects.ghl_tags` lists `justicehub` under both ACT-JH (active) and ACT-JC (ideation). 689 contacts have this tag.
+
+**Decision needed.** Recommendation: drop `justicehub` from ACT-JC's `ghl_tags`, keep only on ACT-JH. ACT-JC gets its own tag like `justicehub-coe`.
+
+### 2d. The 2,387 phantom storytellers
+
+2,387 GHL contacts are tagged `storyteller` but `is_storyteller=false` and have no `empathy_ledger_id` link.
+
+**Sample of 15 reveals all are synthetic-email EL stubs:**
+
+```
+storyteller-786b1699@empathy-ledger.local
+aunty.ivy@storyteller.local
+storyteller-1756588245720@empathyledger.temp
+```
+
+These were pushed into GHL from EL story records but never properly linked. **They're not contactable** (synthetic emails) and shouldn't be counted as GHL contacts.
+
+**Decision needed.** Options:
+- **A.** Match against EL v2 (`yvnuayzslukamizrlhwb`) by `full_name`, backfill `empathy_ledger_id` + `is_storyteller=true`. Real storytellers stay; orphans get deleted.
+- **B.** Delete all 2,387 from GHL outright — they live in EL, not GHL.
+- **C.** Move to a separate `storyteller_shadows` table in Supabase, outside the GHL contact surface.
+
+Recommendation: **A**. Tanya Turner, Aunty Ivy, Dianne Stokes, Gloria, Iris — these appear to be real Oonchiumpa/PICC storytellers per memory. Worth the reconciliation effort.
+
+### 2e. Field completeness gaps
+
+| Field | Coverage | Note |
+|---|---|---|
+| Email | 98.4% | OK |
+| Phone | 2.3% | Can't be backfilled retroactively; require at intake |
+| Company | 4.2% | Same — require at intake |
+| `canonical_entity_id` | 33.2% | CivicGraph entity dedup not propagating |
+| `last_contact_date` | 6.4% (newest 2026-01-08) | **Field is dead.** Backfill from GHL conversations API or drop. |
+
+---
+
+## 3. Wiki orphan canonical codes
+
+5 wiki frontmatter codes not in `projects` table:
+
+| Wiki code | File | What it is | Recommended fix |
+|---|---|---|---|
+| `ACT-DLB` | `wiki/projects/deadlylabs.md` | DeadlyLabs (DeadlyScience partner, STEM + youth detention) | **Add to `projects` table** as new code |
+| `ACT-GS` | `wiki/projects/grantscope.md` | GrantScope/CivicGraph | **Rename wiki → ACT-CG** (collision with existing) |
+| `ACT-PB` | `wiki/projects/place-based-policy-lab.md` | Place-Based Policy Lab | **Add to `projects` table** |
+| `ACT-QD` | `wiki/projects/quandamooka-justice-strategy.md` | Quandamooka Justice Strategy (satellite, active) | **Add to `projects` table** |
+| `ACT-RS` | `wiki/projects/resoleution.md` | ReSOLEution (shoe program in youth detention) | **Add to `projects` table** |
+
+The ACT-GS/ACT-CG collision is the only real conflict — both refer to the same project (GrantScope = CivicGraph). Wiki should rename to ACT-CG to match the projects table (and Supabase `xero_invoices`/`ghl_opportunities` would auto-align since they already use ACT-CG).
+
+---
+
+## 4. Newsletter consent — broken pipeline
+
+| Signal | Count |
+|---|---|
+| `newsletter_consent = true` | 118 |
+| Tagged `goods-newsletter` | 332 |
+| Tagged `harvest-newsletter` | 19 |
+| Tagged `newsletter` (generic) | 31 |
+| **Total tagged a newsletter** | 382 |
+| `newsletter_unsubscribed_at` set | 0 (field never used) |
+| **Both consented AND tagged a project newsletter** | **unknown — should be the operative number** |
+
+Two systems running in parallel:
+- **Boolean** (`newsletter_consent`) — doesn't say which newsletter
+- **Tags** (`*-newsletter`) — doesn't carry consent
+
+**Decision needed.** Recommendation:
+1. Newsletter sends must AND both: `newsletter_consent=true` **AND** project-specific tag.
+2. For 382 tagged contacts: audit each one for an opt-in event (Mailchimp confirmation, signup form, double opt-in). Set `newsletter_consent=true` only where audit trail exists.
+3. Where no audit trail: treat tag as marketing segment only; do not send.
+4. Forms going forward must write both flags atomically.
+
+---
+
+## 5. Aligned canonical code map (current state)
+
+The single source of truth: `projects.code`. Every other system maps back.
+
+**Active project codes (31):**
+
+```
+Ecosystem:   ACT-CORE  ACT-EL  ACT-FM  ACT-GD  ACT-HV  ACT-IN  ACT-JH
+Engine:      ACT-CG    ACT-HQ  ACT-PC
+Campaign:    ACT-DG
+Satellite:   ACT-BG  ACT-BV  ACT-CB  ACT-CE  ACT-CM  ACT-CN  ACT-CP
+             ACT-CS  ACT-CT  ACT-DL  ACT-DO  ACT-FG  ACT-JP
+             ACT-MD  ACT-OO  ACT-SM
+Studio:      ACT-CA  ACT-CF  ACT-GP  ACT-MC  ACT-MY  ACT-PI  ACT-PS
+             ACT-RA  ACT-RT  ACT-UA
+Ideation:    ACT-BB  ACT-JC  ACT-TR
+Sunsetting:  ACT-DO
+Transferred: ACT-FO  ACT-GL
+```
+
+Plus 5 to add (after wiki audit): **ACT-DLB · ACT-PB · ACT-QD · ACT-RS** (and rename wiki `ACT-GS` → `ACT-CG`).
+
+---
+
+## 6. Proposed cleanup sequence
+
+### Phase 1 — schema rules (today, ~30 min, no writes)
+1. Extend `projects.ghl_tags` to include prefix-based tags. Either:
+   - Add column `ghl_tag_prefixes TEXT[]` (e.g. `['goods-']` on ACT-GD), OR
+   - Enumerate every variant in existing `ghl_tags`. Recommend prefixes column.
+2. Resolve `justicehub` ambiguity: drop from ACT-JC, add `justicehub-coe` to ACT-JC.
+3. Add 4 new project codes: ACT-DLB, ACT-PB, ACT-QD, ACT-RS.
+4. Rename wiki ACT-GS → ACT-CG (one file).
+5. Decide what to do with `DISPUTED` tag (move to status / delete / keep as flag).
+
+### Phase 2 — contact backfill (after Phase 1)
+6. Build `scripts/backfill-ghl-contact-projects.mjs`:
+   - Scan `ghl_contacts.tags`, map via `projects.ghl_tags` + prefix rules
+   - Update `ghl_contacts.projects[]` with canonical codes (drop slugs)
+   - Dry-run first — produce diff report. Expected: 711 → ~3,920 tagged (74.3%)
+7. **Tier 3 decision:** push project field back to GHL via API. Otherwise next sync overwrites. Needs explicit go-ahead from Ben.
+
+### Phase 3 — storyteller reconciliation
+8. Cross-reference 2,387 phantom storytellers against EL v2 by `full_name`.
+9. Real matches → backfill `empathy_ledger_id` + `is_storyteller=true`.
+10. Orphans → delete from `ghl_contacts` (they're not contactable).
+
+### Phase 4 — newsletter consent rebuild
+11. Audit each `*-newsletter` tagged contact for opt-in trail.
+12. Set `newsletter_consent=true` only where trail exists.
+13. Tag schema: one newsletter per project (e.g. `newsletter-goods`, `newsletter-harvest`).
+14. Form intake must write `newsletter_consent` + project-newsletter tag atomically.
+
+### Phase 5 — going-forward enforcement
+15. Documented tag→code map in `config/project-codes.json` as single source of truth.
+16. `projects.ghl_tags` validated against config on cron.
+17. New GHL contact intake requires `projects[]` populated with ACT-XX codes.
+18. Drop `last_contact_date` field or wire to GHL conversations API.
+
+---
+
+## 7. Decisions blocking Phase 2
+
+Ben needs to mark these up before any writes happen:
+
+- [ ] `justicehub` tag — strip from ACT-JC, keep only on ACT-JH? **YES / NO**
+- [ ] Add ACT-DLB, ACT-PB, ACT-QD, ACT-RS to `projects` table? **YES / NO**
+- [ ] Rename wiki ACT-GS → ACT-CG (grantscope.md frontmatter)? **YES / NO**
+- [ ] 2,387 phantom storytellers — reconcile against EL v2 (A) / delete (B) / move to shadow table (C)? **A / B / C**
+- [ ] `DISPUTED` tag on 2 Xero transactions — move to status / delete / keep? **MOVE / DELETE / KEEP**
+- [ ] Push contact-projects backfill back to GHL API after Supabase update? **YES / NO** (Tier 3 — explicit verb required)
+
+---
+
+## 8. Sources
+
+- Supabase: `tednluwflfhxyucgwigh` (shared op DB)
+- `projects` table (76 codes)
+- `ghl_contacts` (5,274 rows, 1 sync today 2026-05-13)
+- `ghl_opportunities` (348 rows)
+- `xero_transactions` (3,112 rows)
+- `xero_invoices` (1,772 rows)
+- `wiki/projects/*.md` (39 files, 30 with canonical_code frontmatter)
+- `config/project-codes.json` (v1.8.0, 2026-04-24)

--- a/thoughts/shared/drafts/newsletter-reprompt-campaign-2026-05-13.md
+++ b/thoughts/shared/drafts/newsletter-reprompt-campaign-2026-05-13.md
@@ -1,0 +1,123 @@
+---
+title: Newsletter Opt-In Re-Prompt Campaign
+date: 2026-05-13
+status: draft — needs Ben approval before send
+audience: 246 contacts (214 Goods · 19 Harvest · 12 generic · 1 misc)
+---
+
+# Newsletter Re-Prompt Campaign — Draft
+
+## Why we're sending
+
+246 contacts in GHL carry a `*-newsletter` tag (`goods-newsletter`, `harvest-newsletter`, `newsletter`) but have no opt-in audit trail. They got tagged through marketing segmentation — LinkedIn outreach, manual sorting, event imports — not through an explicit double opt-in form. Per `wiki/decisions/newsletter-consent-policy.md`, we cannot legally include them in send audiences.
+
+This campaign asks them to confirm. If they click confirm, we record `newsletter_consent=true` + `newsletter_consent_at` and they enter the send audience. If they don't, they stay in marketing-segment limbo (no sends).
+
+## Cohort breakdown
+
+| Segment | Total | Active last 90d | Notes |
+|---|---|---|---|
+| `goods-newsletter` | 214 | 13 | Warm — LinkedIn + Gmail-active subset |
+| `harvest-newsletter` | 19 | 0 | Cold — needs framing as "you visited Witta last year, here's where we're at" |
+| Generic `newsletter` | 12 | 0 | Mixed — handle case-by-case |
+| Other | 1 | 0 | Single contact |
+
+## Voice — ACT brand alignment
+
+Reject AI tells (delve, crucial, pivotal, tapestry, em dashes, "not just X but Y"). Curtis method: name the room, name the body, load the abstract noun, stop the line.
+
+## Draft email — Goods variant
+
+**Subject:** Quick yes/no on Goods updates
+
+**From:** Ben Knight <hi@act.place>
+
+**Body:**
+
+```
+Hey {{first_name}},
+
+Quick housekeeping. You're on our Goods list — we added you when {{tag_reason}} — but I don't have a record you actually said yes to email from us.
+
+I want to fix that before we send anything else.
+
+If you want our Goods updates (one a month, mostly photos and short stories from the projects), confirm with a click:
+
+→ Yes, send me Goods updates: {{confirm_url}}
+
+If not, ignore this and you're off the list. No follow-up.
+
+Ben
+A Curious Tractor
+```
+
+Variables:
+- `{{first_name}}` — `gc.first_name` or fallback to "there"
+- `{{tag_reason}}` — derived from secondary tags:
+  - `goods-linkedin-*` → "you connected with us on LinkedIn"
+  - `goods-gmail-*` → "we had an email exchange about Goods"
+  - `goods-tier-champion` / `goods-supporter` → "you championed an early Goods conversation"
+  - else → "you showed up around the Goods rollout"
+- `{{confirm_url}}` — signed link to Supabase edge function (see below)
+
+## Draft email — Harvest variant
+
+**Subject:** Witta — checking in
+
+```
+Hey {{first_name}},
+
+You came to Witta around {{event_or_date}}. I have you on the Harvest list, but I never properly asked.
+
+If you want the occasional update from the Harvest — what's planted, what's harvested, who's been through — say yes:
+
+→ Yes, keep me on the Harvest list: {{confirm_url}}
+
+Otherwise, ignore this and you'll come off.
+
+Ben
+A Curious Tractor
+```
+
+## Confirm endpoint
+
+New Supabase edge function: `confirm-newsletter-consent`
+
+```ts
+// apps/command-center/supabase/functions/confirm-newsletter-consent/index.ts
+// Signed token contains: contact_id + segment + nonce
+// Writes: newsletter_consent=true, newsletter_consent_at=NOW()
+// Redirects to thank-you page
+```
+
+Token format: HMAC-signed JWT (1-year expiry) with `{contact_id, segment, iat}`.
+
+## What this does NOT do
+
+- Does NOT change `newsletter_consent` for anyone who doesn't click
+- Does NOT remove `*-newsletter` tags (segmentation stays)
+- Does NOT send to anyone outside the 246 cohort
+- Is NOT a marketing email — it's a transactional/legal compliance email (one-time send only)
+
+## Send mechanics
+
+| Step | Tool | Notes |
+|---|---|---|
+| Generate signed URLs | Node script `scripts/generate-newsletter-reprompt-links.mjs` (TODO) | Outputs CSV: ghl_id, email, segment, url |
+| Send | Send via Gmail API from `hi@act.place` in batches of 50 with 30s delay | Transactional one-shot. Don't use a marketing platform — keep it as a personal email |
+| Track clicks | Supabase edge function logs to `newsletter_consent_events` table | Records consent timestamp |
+| Reconcile | After 30 days, query unconfirmed cohort; document; don't auto-send |
+
+## Approval gate
+
+This is **Tier 3 — sends mail externally**. Will NOT execute without explicit "send the re-prompt" verb from Ben.
+
+Pre-send checklist:
+- [ ] Ben reviews + approves the Goods copy
+- [ ] Ben reviews + approves the Harvest copy
+- [ ] Edge function `confirm-newsletter-consent` deployed and tested with internal email
+- [ ] `newsletter_consent_events` table created
+- [ ] `generate-newsletter-reprompt-links.mjs` written
+- [ ] Test send to Ben's own email — confirm link works, lands on right page
+- [ ] Send in batches of 50 with 30s delay (Gmail rate-limit safety)
+- [ ] Monitor for unsubscribes / replies

--- a/wiki/decisions/2026-05-14-notion-platform-architecture.md
+++ b/wiki/decisions/2026-05-14-notion-platform-architecture.md
@@ -1,0 +1,187 @@
+---
+title: Notion platform architecture — read · ask · agent surface
+slug: notion-platform-architecture-2026-05-14
+status: active
+date: 2026-05-14
+tags: [decision, notion, integration, ai, agents, architecture]
+audience: [Ben, Nic, Claude, Codex]
+supersedes: partially [[notion-page-policy]]
+related: [[notion-page-policy]], [[finance-4-surface-model]]
+---
+
+# Notion as the unified ask layer
+
+## What changed (Notion, May 2026)
+
+Notion shipped three platform features that change the question "where do we ask questions about our data":
+
+1. **Workers** — server-side code that runs on Notion's infrastructure, polls external systems, and writes to Notion databases on a schedule. Free until 2026-08-11, then ~$0.86/month per 15-min poll.
+2. **Agent SDK** — external AI tools (Claude, Codex, Cowork, ChatGPT) can call Notion AI as an MCP-style tool. Notion AI becomes a queryable index of your workspace.
+3. **Agent API** — every agent (Notion AI, Claude, Codex) shows up in one Notion agent menu inside the workspace.
+
+The shift: Notion was a display layer; it's now also a **query layer**.
+
+## What we're deciding
+
+Notion becomes the **unified read + ask interface** for the data that lives canonically in Supabase. External agents (Claude in CLI, Codex, Telegram bot, command-center) all converge on the same Notion index.
+
+Supabase stays the source of truth. Notion becomes the lens.
+
+## Architecture
+
+```
+   Supabase (truth)
+       │
+       │   Notion Worker (poll views every 15 min)
+       ▼
+   Notion: live mirror databases
+       │
+       │   Notion AI indexes everything
+       ▼
+   ┌──────────────────────────────────────────┐
+   │  ONE PLACE TO ASK                        │
+   │                                          │
+   │  Ben in Notion:    "Goods funders silent │
+   │                    90+ days?"            │
+   │  Claude (CLI):     same question via SDK │
+   │  Codex:            same question via SDK │
+   │  Telegram bot:     same question via API │
+   └──────────────────────────────────────────┘
+```
+
+## The five surfaces, restated
+
+The [[finance-4-surface-model]] decision held that every use case maps to exactly one of four surfaces. This ADR adds a fifth — and tightens what each is for:
+
+| # | Surface | What it's for | Where canonical data lives |
+|---|---|---|---|
+| 1 | **Notion (read + ask)** | Daily reading, planning, capture, decision logging, **and now asking questions of the data** | Supabase (mirrored via Workers) |
+| 2 | **Command-center web** | Operate — tag, fix, reconcile, drill into a project | Supabase (direct) |
+| 3 | **Scripts (`scripts/*.mjs`)** | Automate + admin (cron, on-demand ops) | Supabase (direct) |
+| 4 | **Telegram bot** | Push — daily briefings, alerts, on-demand `/standup` | Supabase (direct) |
+| 5 | **Claude / Codex CLI** | AI-assisted exploration, builds, ops | Supabase MCP **+** Notion AI via Agent SDK |
+
+Notion is no longer just outbound; it has a queryable index. Claude/Codex are explicitly a fifth surface — what we use to build, debug, and ask deep questions of the system.
+
+## Why this is the right shape
+
+1. **Ben already lives in Notion.** Adding a query interface where he already reads doesn't fragment attention.
+2. **All AIs converge on one place.** Whatever AI wins the next 12 months (Claude, GPT-5, Gemini, etc.) — they all speak MCP / Agent SDK. We don't pick a horse.
+3. **The data stays canonical in Supabase.** Notion is a mirror, not a fork. Workers are read-only into Notion for these databases — preventing the "Notion is now another source of truth" trap.
+4. **The 17 outbound `sync-*-to-notion` scripts can retire over time.** Workers are cleaner: server-side, no cron, observable in Notion's UI. Migration is incremental.
+5. **Compliance + audit.** Notion AI answering "who can I email about Goods?" returns 116 contacts from `v_newsletter_audience` — which enforces consent + real email + not unsubscribed. Wrong-cohort sends become much harder.
+
+## What this does NOT change
+
+- **Supabase is still the truth.** Workers write Notion mirrors. Supabase is the source for those mirrors. Don't add a parallel truth layer in Notion.
+- **GHL is still the operational CRM.** Tags fire workflows in GHL. We do not move automation logic into Notion.
+- **Xero is still the finance ledger.** Workers mirror financial summaries into Notion; they do not write to Xero.
+- **The capture pages stay bidirectional.** Money Sync (Q&A), meeting notes, action items, decisions log — those flow Notion → Supabase via existing scripts. [[notion-page-policy]] still applies for what's editable in Notion.
+
+## Mono-repo home for Workers
+
+ACT already has a deployed Notion Worker at **`packages/notion-workers/`** (workerId `019c9e89-3eee-7bad-9745-dfa1073f7fa0`) with 43 `worker.tool()` capabilities. New syncs extend the same worker rather than starting a new one — Notion runs each worker in its own sandbox, so a single worker happily hosts tools + syncs + databases + webhooks together.
+
+```
+packages/notion-workers/
+  src/
+    index.ts                  ← Worker instance + 43 tool registrations
+    syncs/
+      contacts.ts             ← Phase 1: v_canonical_contacts → Notion DB (this PR)
+      money.ts                ← Phase 3: financial views (not yet)
+      projects.ts             ← Phase 3: project health (not yet)
+    webhooks/
+      ghl-contact-updated.ts  ← Phase 2.5: real-time push (not yet)
+  deploy.sh                   ← bundles via esbuild, deploys via ntn
+  workers.json                ← workerId + workspace pinned
+```
+
+Each sync file exports a `register*Sync(worker)` function that owns its database, pacer, and sync handlers. `src/index.ts` adds one import + one call per sync. The 3,000-line tool catalogue stays untouched.
+
+## Migration plan
+
+### Phase 1 — Contacts (Week of 2026-05-19)
+
+**Code shape** (per `https://developers.notion.com/workers/guides/syncs.md`):
+- `worker.database("contacts", ...)` declares the Notion schema (auto-migrates on deploy)
+- `worker.pacer("supabase", { allowedRequests: 30, intervalMs: 1000 })` budgets the Supabase REST calls
+- `worker.sync("contactsBackfill", { mode: "replace", schedule: "manual" })` does the one-time historical load (mark-and-sweep — deletes Notion rows that disappeared from Supabase)
+- `worker.sync("contactsDelta", { mode: "incremental", schedule: "15m" })` watermarks on `updated_at` and pulls only changed rows
+
+**Steps:**
+1. Code is in `packages/notion-workers/src/syncs/contacts.ts`; registered from `src/index.ts` (this PR).
+2. Secrets already set on the live worker (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) — no new credentials needed.
+3. Build + deploy: `cd packages/notion-workers && ./deploy.sh` (bundles locally via esbuild, deploys to the existing `workerId 019c9e89-3eee-7bad-9745-dfa1073f7fa0`).
+4. Verify schema migration: `ntn workers sync status` (the new `contacts` database is created on deploy).
+5. Trigger one-time historical load: `ntn workers sync trigger contactsBackfill`.
+6. Watch via `ntn workers` TUI for 24 hours.
+7. Add `inbound-mirror` category to `wiki/decisions/notion-page-policy.md` once the sync is healthy.
+
+**The `/sync` Claude skill** ships with the `ntn workers new` scaffold. When authoring or debugging the Worker, an agent (me) can invoke `/sync` to load the full SDK reference + CLI patterns into context. Use this for the actual build session.
+
+**Column whitelist for the Contacts mirror** (cultural-sensitivity columns explicitly excluded):
+- INCLUDED: full_name, email, phone, company_name, ghl_id, projects, tags, last_contact_date, newsletter_consent, is_storyteller, is_elder, empathy_ledger_id, canonical_entity_id, xero_contact_id, last_synced_at
+- EXCLUDED: elder_consent, sacred_knowledge, sacred_knowledge_notes, cultural_nation_details, ocap_ownership, ocap_control, ocap_access, ocap_possession, detailed_consent_history, elder_review_notes
+- This mirrors the BLOCKED_FIELDS_TO_GHL set in `scripts/sync-ghl-to-supabase.mjs`.
+
+### Phase 2 — Wire Claude + Codex via Agent SDK (Week of 2026-05-26)
+1. Register Notion AI as an MCP tool in `.claude/.mcp.json`.
+2. Verify Claude (this CLI) can ask Notion AI a question and get an answer from the mirrored contact data.
+3. Document the query patterns in `wiki/decisions/notion-agent-query-patterns.md`.
+
+### Phase 2.5 — One webhook end-to-end (Week of 2026-05-30)
+Test the real-time path before scaling to financial views: wire **one** GHL webhook → Notion Worker → contact upsert.
+
+- `worker.webhook("ghlContactUpdated", { execute: async (events) => {...} })` declares the handler
+- Deploy assigns a unique URL; configure it in GHL's webhook settings for the `ContactUpdate` event
+- HMAC verification via `event.rawBody` + the signing secret stored as a Worker secret
+- Verify: edit a contact in GHL → it reflects in the Notion mirror within seconds (vs. 15-min poll)
+
+This proves the push-driven path works before we wire Xero events in Phase 3.
+
+### Phase 3 — Mirror financial views (Week of 2026-06-02)
+1. Workers for `v_money_status`, `v_cash_position`, `v_rd_pack_score`, `v_top_funders_by_amount`.
+2. Notion AI answers "what's our runway?" from the same data the command-center cockpit shows.
+
+### Phase 4 — Retire overlapping outbound syncs (June 2026)
+1. Audit the 17 `sync-*-to-notion` scripts against what Workers now cover.
+2. Migrate. Delete cron entries. Reduce maintenance surface.
+
+## Cost
+
+- Workers poll cost: ~$0.86 per 15-min poller per month. For 5 mirrors (contacts, money, cash, RD, funders) = ~$4.30/month. Negligible.
+- Notion Business plan: already paid.
+- Agent SDK: per Notion's announcement, no marginal cost for external agent calls into Notion AI.
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Notion mirror drifts from Supabase truth | Worker has a `last_synced_at` column per row; daily reconcile script flags rows older than 6 hours |
+| Notion AI hallucinates on edge cases | Answers must cite specific row IDs / counts; we add a "this came from Notion mirror, not Supabase direct" footer to AI responses in agent flows |
+| Workers feature changes pricing post Aug 11 | Code is portable — we can replicate Workers as Vercel cron + Notion API if needed. No lock-in. |
+| External agents can read sensitive data | Notion permission model is per-database. The `Contacts` mirror can be limited to Ben + Nic + service accounts. Cultural-sensitivity columns from `ghl_contacts` (elder_consent, sacred_knowledge) stay in Supabase, never mirrored. |
+| 17 existing outbound syncs duplicate Worker output | Retire incrementally; don't both-write to the same Notion page from script + Worker. Each Notion DB has exactly one writer. |
+
+## Decision checklist (before Phase 1 ships)
+
+- [x] Confirm Notion Business plan has Workers (confirmed 2026-05-14)
+- [x] Cultural-sensitivity column whitelist defined (see Phase 1 above)
+- [ ] Scaffold `notion-workers/act-contacts/` (this PR)
+- [ ] Run `npx ntn workers new .` in the scaffold dir to get the SDK bootstrap
+- [ ] Set Worker secrets via `ntn workers env set` (not in `.env`, not in git)
+- [ ] Deploy to staging Notion workspace first; smoke test 48 hours
+- [ ] Document `inbound-mirror` page category in [[notion-page-policy]] after first successful deploy
+
+## Sources
+
+- Matthias Frihændig announcement thread (2026-05-13): Workers, Agent SDK, Agent API
+- Notion Workers official docs (2026-05-14 read):
+  - https://developers.notion.com/workers — overview
+  - https://developers.notion.com/workers/guides/syncs.md — backfill+delta pattern
+  - https://developers.notion.com/workers/guides/webhooks — push events into Workers
+  - https://developers.notion.com/workers/guides/secrets.md — `ntn workers env set`
+  - https://developers.notion.com/workers/get-started/quickstart.md — `@notionhq/workers` package + `ntn workers new`
+- Anthony + Jimmy sync-functions walkthrough video (Notion, 2026-05-14)
+- Existing [[notion-page-policy]] and [[finance-4-surface-model]] decisions
+- This session's contact-system work — `thoughts/shared/audits/ghl-tag-alignment-2026-05-13.md`

--- a/wiki/decisions/2026-05-15-act-system-architecture.md
+++ b/wiki/decisions/2026-05-15-act-system-architecture.md
@@ -1,0 +1,231 @@
+---
+title: ACT system architecture — discovery · entity · operations · money · ask
+slug: act-system-architecture-2026-05-15
+status: active
+date: 2026-05-15
+tags: [decision, architecture, integration, grantscope, supabase, ghl, xero, notion, ai]
+audience: [Ben, Nic, Claude, Codex]
+supersedes: partially [[finance-4-surface-model]]
+related:
+  - [[notion-platform-architecture-2026-05-14]]
+  - [[notion-page-policy]]
+  - [[finance-4-surface-model]]
+  - [[contact-pipeline-alignment-2026-05-15]]
+---
+
+# ACT system architecture
+
+## The decision
+
+ACT's full operational backbone has four planes — **Discovery** (GrantScope), **Entity** (CivicGraph canonical layer), **Operations + Money** (GHL CRM + Xero ledger), and **Ask** (Notion + agent SDK) — joined by exactly three universal identifiers. Each plane is owned by exactly one system. Everything else is downstream.
+
+This ADR sits above the tactical decisions in [[notion-platform-architecture-2026-05-14]] and [[contact-pipeline-alignment-2026-05-15]] — they become its tactical phases.
+
+## The four planes
+
+```
+┌─ DISCOVERY ───────────────────────────────────────────────────────────┐
+│  GrantScope (CivicGraph)                                              │
+│  • 100K entities, 199K relationships, 18K grants, 10K foundations    │
+│  • 672K AusTender contracts, 370K ACNC statements, 312K donations    │
+│  • LLM enrichment, foundation profiles, match scoring                │
+│  • Continuously polls 30+ data sources                                │
+│  → Surfaces: new grants, new foundations, new people, new partners   │
+└──────────────────┬────────────────────────────────────────────────────┘
+                   ↓  ABN / email / name match (94.1% precision)
+┌─ ENTITY ──────────────────────────────────────────────────────────────┐
+│  canonical_entities (Supabase, shared schema)                         │
+│  • The deduplicated reference for any organisation or person          │
+│  • Foreign-keyed from ghl_contacts.canonical_entity_id (80% pop)      │
+│  • Foreign-keyed from xero_contacts.canonical_entity_id (next)        │
+│  • The bridge between discovery and operations                        │
+└──────┬─────────────────────────────────────────────┬──────────────────┘
+       ↓                                             ↓
+┌─ OPERATIONS ─────────────────────────────┐  ┌─ MONEY ──────────────────┐
+│  GHL (CRM)                               │  │  Xero (ledger)           │
+│  • 2,079 canonical contacts              │  │  • 1,416 contacts        │
+│  • 348 opportunities (Grants, Goods,     │  │  • 1,772 invoices        │
+│    JH, EL, Events, Festivals pipelines)  │  │  • 3,112 transactions    │
+│  • Tags drive workflows + sends           │  │  • 97.7% project-tagged  │
+│  • All project-tagged ACT-XX              │  │                          │
+│  • Storytellers linked to EL v2 profiles │  │  60+ contacts linked to  │
+│    via empathy_ledger_id                  │  │  GHL via xero_contact_id │
+└────────────────┬──────────────────────────┘  └─────────────┬────────────┘
+                 ↓                                            ↓
+┌─ ASK ─────────────────────────────────────────────────────────────────┐
+│  Notion (Workers mirror everything; AI is the query interface)        │
+│  • ACT Contacts          ← v_canonical_contacts                       │
+│  • Opportunities         ← ghl_opportunities                          │
+│  • Funding Frontier      ← GrantScope grants × ACT projects           │
+│  • Funder Network        ← GrantScope foundations × person_identity   │
+│  • Project Health        ← per-ACT-XX aggregate (contacts+opps+money) │
+│  • Money Flow            ← Xero summaries                             │
+│                                                                       │
+│  Notion AI ↔ Agent SDK ↔ Claude / Codex / Telegram / Cockpit          │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+## The three universal identifiers
+
+For everything to join, every record carries at most three identifiers:
+
+| Identifier | What it points at | Coverage today |
+|---|---|---|
+| `canonical_entity_id` | The CivicGraph entity (org or person) | 80% on `ghl_contacts`, 0% on `xero_contacts` (next backfill) |
+| `project_code` | The ACT-XX project (from `projects.code`) | 97.7% on `xero_transactions`, 95.8% on `xero_invoices`, 82.5% on `ghl_opportunities`, 74.3% on `ghl_contacts` |
+| `relationship_type` | `funder` · `partner` · `supplier` · `grantee` · `regulator` · `peer` · `storyteller` | Not yet formalised — inferred from tags |
+
+When all three are present on a row, every cross-system question becomes a SQL join. When any one is missing, that row falls out of analysis. The job of this architecture is to keep all three populated everywhere.
+
+## The four lifecycles
+
+### Lifecycle A — Grant discovery → won/lost
+```
+GrantScope discovers grant
+  → Mirror to Notion "Funding Frontier" (top-3 matched ACT projects)
+  → Ben marks "pursue"
+  → GHL opportunity created (Grants pipeline, stage=Identified, project_code=ACT-XX)
+  → Foundation contact attached via canonical_entity_id
+  → Pipeline progresses (Draft → Submitted → Decision)
+  → If won: Xero invoice (project_code on invoice + transaction)
+  → R&D pack auto-pulls: foundation → grant → project → invoice
+```
+
+### Lifecycle B — People discovery (foundation board members → leads)
+```
+We pursue a grant from Foundation F
+  → person_identity_map → board, program officers, CEOs
+  → For each not in GHL: create as 'civicgraph-discovery' lead
+  → Surface in Notion "Funder Network" per project
+  → Ben decides who to introduce / contact
+```
+
+### Lifecycle C — Money in (grant won → revenue → evidence)
+```
+Xero invoice issued to Foundation
+  → ABN match against canonical_entities (CivicGraph)
+  → xero_contact.canonical_entity_id set
+  → project_code propagates: invoice → transaction → opportunity → contact
+  → v_money_in_by_project aggregates per ACT-XX
+  → Project Health page shows actual revenue
+```
+
+### Lifecycle D — Money out (supplier paid → IPP compliance + R&D)
+```
+Xero bill from a supplier
+  → Match supplier ABN → ORIC corp / Supply Nation / B Corp in CivicGraph
+  → Indigenous Procurement Policy compliance verified automatically
+  → project_code on bill → ties to project + opportunity
+  → v_money_out_by_project aggregates per ACT-XX
+  → R&D pack distinguishes eligible spend from operational
+```
+
+## The six build phases
+
+| Phase | Scope | Status |
+|---|---|---|
+| **1** | Contacts mirror to Notion (`packages/notion-workers/src/syncs/contacts.ts`) | scaffolded (this session) |
+| **2** | Opportunities + Project Health mirrors | next |
+| **3** | GrantScope backfill (`canonical_entity_id` on `xero_contacts` via ABN) | depends on Phase 2 |
+| **4** | Funding Frontier mirror + Funder Network mirror | depends on Phase 3 |
+| **5** | `relationship_type` column + role-aware views | depends on Phase 1 |
+| **6** | Webhooks (GHL · Xero · GrantScope) → real-time push instead of polling | depends on Phase 1–5 |
+
+Each phase is ~1 week. After Phase 6 the system runs without polling delays.
+
+## Owners and writers (single-writer rule)
+
+Each canonical fact has exactly one writer:
+
+| Fact | Single writer | Read everywhere |
+|---|---|---|
+| Person identity (name, email, phone) | GHL (via inbound webhook, form, manual) | Supabase mirror, Notion mirror |
+| Contact tags | GHL workflows + scripts/dedup-ghl-contacts.mjs | Supabase, Notion |
+| Project codes on contacts | `scripts/lib/project-code-resolver.mjs` (called from sync) | All systems |
+| Opportunity state | GHL pipelines | Supabase, Notion |
+| Invoices + transactions | Xero | Supabase, Notion |
+| Canonical entity | GrantScope (LLM resolution + 30+ data sources) | All systems via foreign key |
+| EL storyteller profile | Empathy Ledger v2 (separate Supabase project) | GHL via `empathy_ledger_id` |
+| Project definitions | `projects` table (with `ghl_tags`, `lcaa_themes`, etc.) | All systems |
+
+Notion is **never** a writer for these facts. It mirrors and asks. Capture pages (Money Sync, meetings, decisions log) are bidirectional only for net-new content that doesn't exist elsewhere yet.
+
+## Cost (full system, post Aug 11 free window)
+
+| Worker | Schedule | Monthly |
+|---|---|---|
+| Contacts | 1h | $0.22 |
+| Opportunities | 1h | $0.22 |
+| Project Health | 4h | $0.05 |
+| Funding Frontier | 4h | $0.05 |
+| Funder Network | 12h | $0.02 |
+| Money Flow | 1h | $0.22 |
+| **Total** | | **~$0.78/month** |
+
+GrantScope side: unchanged from its own cost basis (separate deploy, ongoing). Webhook URLs add zero marginal cost.
+
+## Cultural-sensitivity guardrails
+
+The Notion mirror never receives:
+- `elder_consent` · `sacred_knowledge` · `sacred_knowledge_notes`
+- `cultural_nation_details` · `cultural_protocols` per row
+- `ocap_ownership` · `ocap_control` · `ocap_access` · `ocap_possession`
+- `detailed_consent_history` · `elder_review_notes`
+
+This mirrors the `BLOCKED_FIELDS_TO_GHL` set in `scripts/sync-ghl-to-supabase.mjs`. Cultural-sensitivity data stays in Supabase only and is queryable only through the command-center web UI (which is access-controlled). The Notion DB is broader-access — only safe data lives there.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Multiple sources of truth drift | Single-writer rule (table above). Daily reconcile script flags rows where mirror is >24h stale. |
+| Sensitive data leaks via Notion AI | Cultural-sensitivity column whitelist (above). Audit log of Notion AI queries that referenced contacts (Phase 2 deliverable). |
+| ABN matching false positives | GrantScope match precision is 94.1% (LLM-assisted). The 5.9% needs human review — surface as `match_review_needed` flag in Notion. |
+| GrantScope ingests stop | GrantScope has its own monitoring + alerting. Notion mirror keeps showing last known data, doesn't fabricate. |
+| `relationship_type` taxonomy drifts | Documented in this ADR + enforced via CHECK constraint on the column when added. |
+| External agents (Claude/Codex/etc.) misinterpret data | Each Notion DB has a description page explaining what it is, what it isn't, and known limits. Notion AI uses these as grounding. |
+| Foundation contact-people exposed without consent | `person_identity_map` from CivicGraph is public-record data only (ACNC, ASIC, ORIC registers). Private contact info (personal email) stays gated. |
+| Pricing changes for Notion Workers after Aug 11 | Code is portable. If Workers pricing breaks the model, replicate via Vercel cron + Notion API. No lock-in. |
+
+## What this ADR does NOT change
+
+- **GrantScope stays its own repo + deploy.** It's already production. We consume its outputs, we don't fork it.
+- **Empathy Ledger v2 stays a separate Supabase project.** Storyteller content is the most sensitive data ACT holds. The link via `empathy_ledger_id` is one-way; we never write to EL from this system.
+- **The 4-Surface model from [[finance-4-surface-model]] still holds.** This ADR adds a fifth (Claude/Codex CLI as a query surface) and explicitly names Discovery as a sixth (GrantScope). Operations + ask are the same.
+- **The 17 outbound `sync-*-to-notion` scripts** retire incrementally as Workers cover their use cases — see [[notion-platform-architecture-2026-05-14]] Phase 4.
+
+## How to use this architecture day-to-day
+
+| Question | Where | How |
+|---|---|---|
+| "Who can I email about Goods?" | Notion AI | Queries v_newsletter_audience mirror |
+| "What new grants this week?" | Notion AI | Queries Funding Frontier mirror |
+| "What's our relationship with Minderoo?" | Notion AI | Joins Contacts + Opportunities + (via canonical_entity_id) CivicGraph dossier |
+| "Show me funders silent 90+ days" | Notion AI | Contacts + last_contact_date filter |
+| "How healthy is ACT-EL?" | Notion AI | Project Health mirror |
+| "What's our R&D evidence for FY26?" | command-center `/finance/rd-evidence` | Direct Supabase, with provenance |
+| "Tag this transaction to a project" | command-center `/finance/tagger-v2` | Direct Supabase write |
+| "Send the Goods newsletter" | GHL → workflow on `goods-newsletter` tag where `newsletter_consent=true` | Operational; data fed by Supabase |
+| "Did we get paid?" | Xero → `/finance/overview` cockpit | Native Xero data, project_code-tagged |
+| "Draft a funder outreach email" | Claude / Codex via Notion AI | Pulls voice + context from Notion mirror |
+
+## The standing order for new work
+
+When designing any new feature:
+1. **Decide which plane it belongs in** (Discovery / Entity / Operations / Money / Ask).
+2. **Identify the single writer** for any fact it creates.
+3. **Ensure all three identifiers** (`canonical_entity_id`, `project_code`, `relationship_type`) flow through.
+4. **If it's a new asked question**, the answer is "add it to a Notion mirror" — not "build a new dashboard".
+5. **If it's a new operational workflow**, the answer is "wire it in GHL" — not "build a new microservice".
+6. **If it's new discovery**, the answer is "have GrantScope ingest the source" — not "scrape it ourselves".
+
+## Sources
+
+- [[notion-platform-architecture-2026-05-14]] — the Notion side
+- [[contact-pipeline-alignment-2026-05-15]] — the contact side (if drafted)
+- [[finance-4-surface-model]] — the operational surfaces
+- [[notion-page-policy]] — what's editable in Notion
+- `thoughts/shared/audits/ghl-tag-alignment-2026-05-13.md` — the cleanup that made this possible
+- `/Users/benknight/Code/grantscope/README.md` — CivicGraph platform overview
+- `scripts/backfill-ghl-civicgraph-links.mjs` (in grantscope repo) — proves the bridge already works
+- GrantScope MCP server (`grantscope/mcp-server/`)

--- a/wiki/decisions/newsletter-consent-policy.md
+++ b/wiki/decisions/newsletter-consent-policy.md
@@ -1,0 +1,79 @@
+---
+title: Newsletter Consent Policy
+date: 2026-05-13
+status: active
+---
+
+# Newsletter Consent Policy
+
+## Truth source: `newsletter_consent = true`
+
+The boolean `ghl_contacts.newsletter_consent` is the **only legal opt-in signal**.
+118 contacts have it set (Feb-Mar 2026), all with `newsletter_consent_at` timestamps from form submissions.
+
+## Tags are segments, not consent
+
+The `*-newsletter` tags (`goods-newsletter`, `harvest-newsletter`, `newsletter`) are
+**marketing segments** showing which newsletter a contact has been associated with.
+They do NOT carry legal consent. **Do not send to a contact based on tag alone.**
+
+| Signal | Meaning | Send? |
+|---|---|---|
+| `newsletter_consent = true` AND tag present | Consented to newsletter X | YES |
+| Tag present, consent = false/null | Marketing segment, no opt-in | **NO** |
+| Consent = true, no tag | Consented but no project — needs tag assigned | YES (after segment decision) |
+| Synthetic email (`.local` / `.temp`) | EL storyteller stub, not contactable | NO |
+
+## Canonical send query
+
+Use `v_newsletter_audience`:
+
+```sql
+SELECT email, full_name, newsletter_segment, projects
+FROM v_newsletter_audience
+WHERE newsletter_segment = 'goods';
+```
+
+This view enforces all four rules:
+- `newsletter_consent = true`
+- `newsletter_unsubscribed_at IS NULL`
+- Email is real (non-synthetic)
+- Email is non-null
+
+## Going forward
+
+- Forms must atomically write **both** `newsletter_consent = true` **and** the project-specific tag (`goods-newsletter`, `harvest-newsletter`, etc.).
+- New tag pattern: `newsletter-<project-code>` is preferred going forward (e.g. `newsletter-ACT-GD`) so the tag canonicalises via the resolver. Existing `goods-newsletter` style tags stay supported via the prefix rule.
+- Unsubscribe events must write `newsletter_unsubscribed_at = NOW()`. They should **not** flip `newsletter_consent` to false (we want to remember the original opt-in date).
+- Audit log: every consent change should land in `audit_logs` (or similar) with source URL + timestamp.
+
+## What we did NOT do
+
+- We did **not** auto-elevate the 264 tagged-but-unconsented contacts to `newsletter_consent = true`. They were tagged via marketing segmentation (LinkedIn outreach, manual sorting) without an explicit opt-in event.
+- We did **not** remove any `*-newsletter` tags. The segmentation signal is useful even when consent is missing — e.g. for re-prompts at the next form interaction.
+
+## Current numbers (2026-05-13)
+
+| Signal | Count |
+|---|---|
+| `newsletter_consent = true` | 118 |
+| Tagged `goods-newsletter` | 332 |
+| Tagged `harvest-newsletter` | 19 |
+| Tagged `newsletter` (generic) | 31 |
+| **Sendable Goods audience** (`v_newsletter_audience`) | **116** |
+| Sendable Harvest audience | 0 (none consented yet) |
+
+## Re-prompt candidates
+
+The 246 real-email contacts who carry a `*-newsletter` tag but lack consent are in `v_newsletter_reprompt_candidates`. They are NOT in the send audience. To convert them, run a one-time opt-in re-prompt campaign:
+
+| Segment | Candidates | Active last 90d |
+|---|---|---|
+| `goods` (`goods-newsletter`) | 214 | 13 |
+| `harvest` (`harvest-newsletter`) | 19 | 0 |
+| `generic` (`newsletter`) | 12 | 0 |
+
+Re-prompt campaign mechanics:
+1. Send a "confirm your newsletter subscription" email (transactional, not marketing — informing them they're segmented and asking to confirm).
+2. Confirm link writes `newsletter_consent=true` + `newsletter_consent_at=NOW()` via Supabase edge function.
+3. Contacts who don't confirm in 30 days: keep the marketing tag, never auto-send.

--- a/wiki/projects/grantscope.md
+++ b/wiki/projects/grantscope.md
@@ -2,7 +2,7 @@
 title: GrantScope (CivicGraph)
 status: Active — Circle One technical reference for [[three-circles|The Three Circles]]
 canonical_slug: grantscope
-canonical_code: ACT-GS
+canonical_code: ACT-CG
 tier: background
 website_slug: grantscope
 website_path: /projects/grantscope


### PR DESCRIPTION
## Summary

Unify project codes (`ACT-XX`) as the single key across every system that names a project: Xero · Supabase · GHL contacts + opportunities · wiki frontmatter · newsletter audiences. Adds a shared tag→code resolver so future tag variants pick up automatically.

## What changed

### Schema (`supabase/migrations/20260513000000_ghl_alignment.sql`)
- `projects_tier_check` now allows `'background'` (was missing despite use in config + wiki)
- 4 new project codes: `ACT-DLB` · `ACT-PB` · `ACT-QD` · `ACT-RS` (wiki had them, projects table didn't)
- `justicehub` tag disambiguated: `ACT-JH` owns it; `ACT-JC` uses `justicehub-coe`
- `ghl_contacts` gets: `xero_contact_id`, `xero_match_method`, `xero_matched_at`, `canonical_contact_id` (+ indexes)
- 3 new views: `v_canonical_contacts`, `v_newsletter_audience`, `v_newsletter_reprompt_candidates`

### Code
- **`scripts/lib/project-code-resolver.mjs`** — single tag→canonical-code resolver. Uses `projects.ghl_tags` + 4 prefix rules (`goods-*` → ACT-GD, etc.). Shared by backfill and sync.
- **`scripts/lib/ghl-api-service.mjs`** — adds `mergeContacts()` + `deleteContact()`. Prefers `GHL_PRIVATE_TOKEN` over `GHL_API_KEY` for broader API access.
- **`scripts/sync-ghl-to-supabase.mjs`** — drops the hardcoded 7-slug filter; uses the resolver. Future GHL syncs derive `projects[]` directly from contact tags.
- **`scripts/backfill-ghl-contact-projects.mjs`** — backfills `ghl_contacts.projects[]` from tags; optional `--push-ghl` adds canonical codes as tags in GHL itself.
- **`scripts/reconcile-phantom-storytellers.mjs`** — matches synthetic-email GHL contacts (`*@empathy-ledger.local` etc.) to Empathy Ledger v2 profiles by name.
- **`scripts/resolve-ambiguous-storytellers.mjs`** — for name collisions across EL profiles, picks the one with the most stories.
- **`scripts/dedup-ghl-contacts.mjs`** — Supabase-side: groups by lowercased email, picks canonical row, unions tags/projects/EL link/etc. onto it, flags duplicates.
- **`scripts/delete-ghl-duplicates.mjs`** — GHL-side cleanup. Uses `DELETE /contacts/{id}` (GHL merge API returns 403 for all token types tested — see audit doc).
- **`scripts/merge-ghl-duplicates.mjs`** — kept for reference even though merge API is gated.

### Docs
- `thoughts/shared/audits/ghl-tag-alignment-2026-05-13.md` — full audit, what was where, what changed
- `wiki/decisions/newsletter-consent-policy.md` — policy: only `newsletter_consent = true` is a legal opt-in; tags are segments
- `thoughts/shared/drafts/newsletter-reprompt-campaign-2026-05-13.md` — draft opt-in re-prompt for 246 marketing-tagged-without-consent contacts (Tier 3, **not sent**)
- `wiki/projects/grantscope.md` — canonical_code fix `ACT-GS` → `ACT-CG` (resolves wiki/projects-table collision)

## Outcomes (data state after this session)

| | Before | After |
|---|---|---|
| Contacts with canonical `ACT-XX` codes | 711 (13.5%) | **3,917 (74.3%)** |
| Contacts linked to `canonical_entities` | 1,749 (33%) | **4,220 (80%)** |
| Contacts properly linked to Empathy Ledger profiles | 532 | **2,765** |
| Contacts linked to Xero entity | 0 | 156 (60 unique Xero entities) |
| Duplicate rows in `ghl_contacts` | 3,217 | **0** |
| Duplicate contacts in GHL itself | 5,274 records | **2,079 records** (625 deleted) |
| `last_contact_date` populated from real comms history | 340 | 870 |
| Sendable Goods newsletter audience (consent + tag + real email) | unknowable | 116 |

## Tags preserved

Every existing tag (`storyteller`, `goods-newsletter`, `harvest-newsletter`, `partner`, `funder`, `elder`, etc.) keeps the same per-contact membership as before this PR. Every GHL automation that fires on those tags fires identically. The canonical codes ride alongside.

## Test plan

- [ ] Migration applies clean on a fresh Supabase project (DDL-only, idempotent guards in place)
- [ ] `node scripts/backfill-ghl-contact-projects.mjs` (no flags) runs as dry-run, reports the diff
- [ ] `node scripts/sync-ghl-to-supabase.mjs` picks up canonical codes from tags via the resolver
- [ ] `v_newsletter_audience` returns only `newsletter_consent = true` rows with real emails
- [ ] `v_canonical_contacts` returns 2,079 rows (matches GHL contact count)
- [ ] Spot-check: `SELECT projects FROM ghl_contacts WHERE 'ACT-GD' = ANY(projects) LIMIT 5;`

## Known limits

- **GHL contact merge API is gated** (403 for all token types tested, including a Private Integration Token with full scopes). DELETE works. The official GHL MCP server's 36 tools also lack a merge tool. Decision: live with `DELETE` for cleanup, document for future.
- **22 truly orphan phantoms** flagged with `auto_created_from = 'el-orphan-no-match'` — first-name-only entries (Adam, Polly, Taj, etc.) that don't yet have EL profiles. Will resolve themselves once EL is populated.
- **246 marketing-tagged-but-unconsented** contacts kept as marketing segments (per policy doc) — not auto-sent to. Re-prompt campaign drafted but **not sent**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)