### PR TITLE
feat(finance): AI-leverage Dext+Xero workflow — 6 gaps closed + UX audit

### DIFF
--- a/apps/command-center/src/app/api/finance/compliance-calendar/route.ts
+++ b/apps/command-center/src/app/api/finance/compliance-calendar/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+export const dynamic = 'force-dynamic'
+
+// Repo root is two levels up from apps/command-center.
+const REPO = path.resolve(process.cwd(), '..', '..')
+const SNAPSHOT_DIR = path.join(REPO, 'thoughts', 'shared', 'data', 'compliance-calendar')
+
+interface Obligation {
+  id: string
+  title: string
+  type: string
+  entity: string
+  due_date: string | null
+  earliest_filable?: string | null
+  status: string
+  lead_times_days?: number[]
+  notes?: string
+  owner: string
+  expected_refund_aud?: number
+  project_code?: string | null
+  source: 'wiki' | 'ghl_opportunities'
+  monetary_value?: number
+  days_until_due: number | null
+  severity: 'critical' | 'high' | 'medium' | null
+  at_risk: boolean
+  last_filed_at?: string | null
+}
+
+interface CalendarResponse {
+  generatedAt: string
+  source: 'snapshot' | 'live'
+  sources: {
+    wiki: { path: string; count: number }
+    grants: { table: string; count: number }
+  }
+  counters: { critical: number; high: number; medium: number; filed: number }
+  obligations: Obligation[]
+}
+
+export async function GET() {
+  const snap = readLatestSnapshot()
+  if (!snap) {
+    return NextResponse.json(
+      {
+        error: 'No compliance-calendar snapshot found',
+        hint: 'Run `node scripts/build-compliance-calendar.mjs` to seed thoughts/shared/data/compliance-calendar/.',
+      },
+      { status: 503 },
+    )
+  }
+  return NextResponse.json({ ...snap, source: 'snapshot' })
+}
+
+function readLatestSnapshot(): CalendarResponse | null {
+  if (!existsSync(SNAPSHOT_DIR)) return null
+  const files = readdirSync(SNAPSHOT_DIR).filter(f => f.endsWith('.json')).sort()
+  if (files.length === 0) return null
+  try {
+    return JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, files[files.length - 1]), 'utf8'))
+  } catch {
+    return null
+  }
+}
+

--- a/apps/command-center/src/app/api/finance/dext-push-audit/route.ts
+++ b/apps/command-center/src/app/api/finance/dext-push-audit/route.ts
@@ -1,0 +1,568 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+const FY_START = '2025-07-01'
+const FY_END = '2026-06-30'
+const DATE_WINDOW_DAYS = 5
+
+type StatusFilter =
+  | 'needs_action'
+  | 'duplicate_risk'
+  | 'match_candidate'
+  | 'ambiguous'
+  | 'project_review'
+  | 'done'
+  | 'all'
+
+interface DextInvoiceRow {
+  id: string
+  xero_id: string | null
+  invoice_number: string | null
+  type: string | null
+  status: string | null
+  contact_name: string | null
+  date: string | null
+  total: number | string | null
+  amount_due: number | string | null
+  amount_paid: number | string | null
+  has_attachments: boolean | null
+  reference: string | null
+  project_code: string | null
+  project_code_source: string | null
+  line_items: unknown
+}
+
+interface XeroPaymentRow {
+  id: string
+  xero_payment_id: string | null
+  invoice_xero_id: string | null
+  invoice_number: string | null
+  status: string | null
+  date: string | null
+  amount: number | string | null
+  reference: string | null
+  is_reconciled: boolean | null
+  bank_account_name: string | null
+  account_name: string | null
+}
+
+interface BankLineRow {
+  id: string
+  date: string | null
+  payee: string | null
+  particulars: string | null
+  reference: string | null
+  amount: number | string | null
+  direction: string | null
+  status: string | null
+  bank_account: string | null
+  project_code: string | null
+  project_source: string | null
+}
+
+interface ProjectOption {
+  code: string
+  name: string | null
+  tier: string | null
+  status: string | null
+}
+
+interface AuditCandidate {
+  id: string
+  date: string | null
+  payee: string
+  amount: number
+  status: string | null
+  bankAccount: string | null
+  dateDeltaDays: number | null
+  vendorScore: number
+  amountDelta: number
+  projectCode: string | null
+  projectSource: string | null
+}
+
+interface AuditItem {
+  id: string
+  xeroId: string | null
+  date: string | null
+  vendor: string
+  amount: number
+  amountDue: number
+  amountPaid: number
+  xeroStatus: string | null
+  reference: string | null
+  dextRef: string | null
+  hasAttachment: boolean
+  projectCode: string | null
+  projectSource: string | null
+  accountCode: string | null
+  taxType: string | null
+  description: string | null
+  paymentCount: number
+  paymentReconciled: boolean
+  payments: Array<{
+    id: string
+    xeroPaymentId: string | null
+    date: string | null
+    amount: number
+    status: string | null
+    isReconciled: boolean | null
+    accountName: string | null
+    reference: string | null
+  }>
+  candidates: AuditCandidate[]
+  decision: 'done' | 'find_match' | 'duplicate_risk' | 'ambiguous' | 'project_review' | 'bookkeeper' | 'unknown'
+  decisionLabel: string
+  nextStep: string
+  riskLevel: 'low' | 'medium' | 'high'
+  needsProjectReview: boolean
+  receiptEvidenceUrl: string
+}
+
+function asNumber(value: number | string | null | undefined): number {
+  if (value == null) return 0
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function cleanText(value: unknown): string {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+const GENERIC_WORDS = new Set([
+  'and',
+  'australia',
+  'australian',
+  'bank',
+  'brisbane',
+  'company',
+  'co',
+  'corp',
+  'corporation',
+  'group',
+  'ltd',
+  'limited',
+  'melbourne',
+  'payment',
+  'pty',
+  'sydney',
+  'the',
+])
+
+function tokens(value: unknown): string[] {
+  return cleanText(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_WORDS.has(token))
+}
+
+function vendorScore(invoiceVendor: string, bankText: string): number {
+  const invoice = cleanText(invoiceVendor)
+  const bank = cleanText(bankText)
+  if (!invoice || !bank) return 0
+  if (invoice === bank) return 1
+  if (invoice.includes(bank) || bank.includes(invoice)) return 0.95
+
+  const invoiceTokens = tokens(invoice)
+  const bankTokens = new Set(tokens(bank))
+  if (!invoiceTokens.length || !bankTokens.size) return 0
+  const matches = invoiceTokens.filter((token) => bankTokens.has(token)).length
+  return matches / invoiceTokens.length
+}
+
+function dateDeltaDays(a: string | null, b: string | null): number | null {
+  if (!a || !b) return null
+  const first = new Date(`${a}T00:00:00`).getTime()
+  const second = new Date(`${b}T00:00:00`).getTime()
+  if (!Number.isFinite(first) || !Number.isFinite(second)) return null
+  return Math.round((second - first) / 86400000)
+}
+
+function quarterForDate(date: string | null): string {
+  if (!date) return 'Q2'
+  const month = new Date(`${date}T00:00:00`).getMonth() + 1
+  if (month >= 7 && month <= 9) return 'Q1'
+  if (month >= 10 && month <= 12) return 'Q2'
+  if (month >= 1 && month <= 3) return 'Q3'
+  return 'Q4'
+}
+
+function receiptEvidenceUrl(date: string | null, vendor: string): string {
+  const params = new URLSearchParams()
+  params.set('quarter', quarterForDate(date))
+  params.set('status', 'all')
+  if (vendor.trim()) params.set('search', vendor.trim())
+  return `/finance/receipt-evidence?${params.toString()}`
+}
+
+function dextRef(reference: string | null): string | null {
+  const match = String(reference || '').match(/dext_import\s+([a-z0-9-]+)/i)
+  return match?.[1] || null
+}
+
+function firstLineValue(lineItems: unknown, key: string): string | null {
+  if (!Array.isArray(lineItems)) return null
+  for (const item of lineItems) {
+    if (!item || typeof item !== 'object') continue
+    const row = item as Record<string, unknown>
+    const value = row[key] || row[key.toLowerCase()]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+async function fetchPaged<T>(
+  label: string,
+  makeQuery: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>
+): Promise<T[]> {
+  const rows: T[] = []
+  const pageSize = 1000
+
+  for (let from = 0; from < 10000; from += pageSize) {
+    const { data, error } = await makeQuery(from, from + pageSize - 1)
+    if (error) throw new Error(`${label}: ${error.message}`)
+    const page = data || []
+    rows.push(...page)
+    if (page.length < pageSize) break
+  }
+
+  return rows
+}
+
+function findBankCandidates(invoice: DextInvoiceRow, bankLines: BankLineRow[]): AuditCandidate[] {
+  const invoiceAmount = Math.abs(asNumber(invoice.total))
+  const vendor = invoice.contact_name || ''
+
+  return bankLines
+    .map((line) => {
+      const amount = Math.abs(asNumber(line.amount))
+      const amountDelta = Math.abs(amount - invoiceAmount)
+      const deltaDays = dateDeltaDays(invoice.date, line.date)
+      const score = vendorScore(vendor, `${line.payee || ''} ${line.particulars || ''} ${line.reference || ''}`)
+      return { line, amount, amountDelta, deltaDays, score }
+    })
+    .filter(({ amountDelta, deltaDays, score }) => {
+      if (amountDelta > 0.01) return false
+      if (deltaDays === null || Math.abs(deltaDays) > DATE_WINDOW_DAYS) return false
+      return score >= 0.25
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score
+      return Math.abs(a.deltaDays || 0) - Math.abs(b.deltaDays || 0)
+    })
+    .slice(0, 5)
+    .map(({ line, amount, amountDelta, deltaDays, score }) => ({
+      id: line.id,
+      date: line.date,
+      payee: line.payee || line.particulars || line.reference || 'Bank line',
+      amount,
+      status: line.status,
+      bankAccount: line.bank_account,
+      dateDeltaDays: deltaDays,
+      vendorScore: Math.round(score * 100),
+      amountDelta,
+      projectCode: line.project_code,
+      projectSource: line.project_source,
+    }))
+}
+
+function classify(invoice: DextInvoiceRow, payments: XeroPaymentRow[], candidates: AuditCandidate[]) {
+  const amountDue = Math.abs(asNumber(invoice.amount_due))
+  const amountPaid = Math.abs(asNumber(invoice.amount_paid))
+  const paymentReconciled = payments.some((payment) => payment.is_reconciled === true)
+  const needsProjectReview = Boolean(
+    !invoice.project_code || invoice.project_code === 'ACT-IN' || invoice.project_code_source?.includes('vendor')
+  )
+  const unreconciledCandidates = candidates.filter((candidate) => candidate.status === 'unreconciled')
+  const xeroStatus = String(invoice.status || '').toUpperCase()
+  const paid = xeroStatus === 'PAID' || amountPaid > 0
+
+  if (xeroStatus === 'VOIDED' || xeroStatus === 'DELETED') {
+    return {
+      decision: 'done' as const,
+      decisionLabel: 'Voided/deleted shadow',
+      nextStep: 'No Xero action. Keep as audit history only.',
+      riskLevel: 'low' as const,
+      needsProjectReview: false,
+    }
+  }
+
+  if (paymentReconciled) {
+    return {
+      decision: 'done' as const,
+      decisionLabel: 'Already reconciled',
+      nextStep: 'No Xero action. Check project/R&D only if needed.',
+      riskLevel: 'low' as const,
+      needsProjectReview,
+    }
+  }
+
+  if (paid && unreconciledCandidates.length === 1) {
+    return {
+      decision: 'duplicate_risk' as const,
+      decisionLabel: 'Do not create duplicate',
+      nextStep: 'In Xero, use Find & Match against the existing Dext-created bill payment if the bank line is visible.',
+      riskLevel: 'high' as const,
+      needsProjectReview,
+    }
+  }
+
+  if (unreconciledCandidates.length > 1 || candidates.length > 1) {
+    return {
+      decision: 'ambiguous' as const,
+      decisionLabel: 'Ambiguous',
+      nextStep: 'Multiple matching bank-line candidates. Human check before any Xero click.',
+      riskLevel: 'medium' as const,
+      needsProjectReview,
+    }
+  }
+
+  if (candidates.length === 1) {
+    return {
+      decision: 'find_match' as const,
+      decisionLabel: 'Find & Match candidate',
+      nextStep: 'If this bank line is visible in Xero Reconcile, match it to the Dext-created bill/payment. Do not create a new transaction.',
+      riskLevel: 'medium' as const,
+      needsProjectReview,
+    }
+  }
+
+  if (needsProjectReview) {
+    return {
+      decision: 'project_review' as const,
+      decisionLabel: 'Project review',
+      nextStep: 'Fix project tag before using this for BAS/R&D reporting.',
+      riskLevel: 'medium' as const,
+      needsProjectReview,
+    }
+  }
+
+  return {
+    decision: 'bookkeeper' as const,
+    decisionLabel: 'No bank-line mirror match',
+    nextStep: 'Do not create another transaction. Check Account Transactions or send to bookkeeper for duplicate/Remove & Redo decision.',
+    riskLevel: 'medium' as const,
+    needsProjectReview,
+  }
+}
+
+function matchesStatus(item: AuditItem, status: StatusFilter): boolean {
+  if (status === 'all') return true
+  if (status === 'needs_action') return item.decision !== 'done' || item.needsProjectReview
+  if (status === 'done') return item.decision === 'done'
+  if (status === 'project_review') return item.needsProjectReview
+  if (status === 'duplicate_risk') return item.decision === 'duplicate_risk'
+  if (status === 'match_candidate') return item.decision === 'find_match'
+  if (status === 'ambiguous') return item.decision === 'ambiguous'
+  return true
+}
+
+function matchesText(item: AuditItem, q: string): boolean {
+  if (!q) return true
+  const haystack = [
+    item.vendor,
+    item.reference,
+    item.dextRef,
+    item.projectCode,
+    item.accountCode,
+    item.description,
+    ...item.candidates.map((candidate) => `${candidate.payee} ${candidate.date}`),
+  ].filter(Boolean).join(' ').toLowerCase()
+  return haystack.includes(q.toLowerCase())
+}
+
+function matchesProject(item: AuditItem, project: string): boolean {
+  if (!project || project === 'all') return true
+  if (project === '__blank__') return !item.projectCode
+  return item.projectCode === project
+}
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams
+  const status = (params.get('status') || 'needs_action') as StatusFilter
+  const project = params.get('project') || 'all'
+  const q = (params.get('q') || '').trim()
+  const limit = Math.min(Math.max(parseInt(params.get('limit') || '300', 10), 50), 800)
+
+  try {
+    const [invoices, bankLines, allPayments, projectsResult] = await Promise.all([
+      fetchPaged<DextInvoiceRow>('dext pushed invoices', (from, to) =>
+        supabase
+          .from('xero_invoices')
+          .select('id, xero_id, invoice_number, type, status, contact_name, date, total, amount_due, amount_paid, has_attachments, reference, project_code, project_code_source, line_items')
+          .eq('type', 'ACCPAY')
+          .ilike('reference', '%auto-pushed%dext_import%')
+          .gte('date', FY_START)
+          .lte('date', FY_END)
+          .order('date', { ascending: false })
+          .range(from, to)
+      ),
+      fetchPaged<BankLineRow>('bank statement lines', (from, to) =>
+        supabase
+          .from('bank_statement_lines')
+          .select('id, date, payee, particulars, reference, amount, direction, status, bank_account, project_code, project_source')
+          .eq('direction', 'debit')
+          .gte('date', FY_START)
+          .lte('date', FY_END)
+          .order('date', { ascending: false })
+          .range(from, to)
+      ),
+      fetchPaged<XeroPaymentRow>('xero payments', (from, to) =>
+        supabase
+          .from('xero_payments')
+          .select('id, xero_payment_id, invoice_xero_id, invoice_number, status, date, amount, reference, is_reconciled, bank_account_name, account_name')
+          .gte('date', FY_START)
+          .lte('date', FY_END)
+          .order('date', { ascending: false })
+          .range(from, to)
+      ),
+      supabase
+        .from('projects')
+        .select('code, name, tier, status')
+        .not('code', 'is', null)
+        .or('status.is.null,status.neq.archived')
+        .order('tier', { ascending: true, nullsFirst: false })
+        .order('name', { ascending: true })
+        .limit(500),
+    ])
+
+    if (projectsResult.error) throw new Error(`projects: ${projectsResult.error.message}`)
+
+    const invoiceIds = invoices.map((invoice) => invoice.xero_id).filter(Boolean) as string[]
+    const invoiceIdSet = new Set(invoiceIds)
+    const payments = allPayments.filter((payment) => payment.invoice_xero_id && invoiceIdSet.has(payment.invoice_xero_id))
+
+    const paymentsByInvoice = new Map<string, XeroPaymentRow[]>()
+    for (const payment of payments) {
+      if (!payment.invoice_xero_id) continue
+      const list = paymentsByInvoice.get(payment.invoice_xero_id) || []
+      list.push(payment)
+      paymentsByInvoice.set(payment.invoice_xero_id, list)
+    }
+
+    const items: AuditItem[] = invoices.map((invoice) => {
+      const invoicePayments = invoice.xero_id ? paymentsByInvoice.get(invoice.xero_id) || [] : []
+      const candidates = findBankCandidates(invoice, bankLines)
+      const classification = classify(invoice, invoicePayments, candidates)
+      const vendor = invoice.contact_name || 'Dext pushed bill'
+
+      return {
+        id: invoice.id,
+        xeroId: invoice.xero_id,
+        date: invoice.date,
+        vendor,
+        amount: Math.abs(asNumber(invoice.total)),
+        amountDue: Math.abs(asNumber(invoice.amount_due)),
+        amountPaid: Math.abs(asNumber(invoice.amount_paid)),
+        xeroStatus: invoice.status,
+        reference: invoice.reference,
+        dextRef: dextRef(invoice.reference),
+        hasAttachment: Boolean(invoice.has_attachments),
+        projectCode: invoice.project_code,
+        projectSource: invoice.project_code_source,
+        accountCode: firstLineValue(invoice.line_items, 'account_code'),
+        taxType: firstLineValue(invoice.line_items, 'tax_type'),
+        description: firstLineValue(invoice.line_items, 'description'),
+        paymentCount: invoicePayments.length,
+        paymentReconciled: invoicePayments.some((payment) => payment.is_reconciled === true),
+        payments: invoicePayments.map((payment) => ({
+          id: payment.id,
+          xeroPaymentId: payment.xero_payment_id,
+          date: payment.date,
+          amount: Math.abs(asNumber(payment.amount)),
+          status: payment.status,
+          isReconciled: payment.is_reconciled,
+          accountName: payment.bank_account_name || payment.account_name,
+          reference: payment.reference,
+        })),
+        candidates,
+        receiptEvidenceUrl: receiptEvidenceUrl(invoice.date, vendor),
+        ...classification,
+      }
+    })
+
+    const summary = {
+      total: items.length,
+      totalAmount: items.reduce((sum, item) => sum + item.amount, 0),
+      needsAction: items.filter((item) => matchesStatus(item, 'needs_action')).length,
+      duplicateRisk: items.filter((item) => item.decision === 'duplicate_risk').length,
+      matchCandidates: items.filter((item) => item.decision === 'find_match').length,
+      ambiguous: items.filter((item) => item.decision === 'ambiguous').length,
+      projectReview: items.filter((item) => item.needsProjectReview).length,
+      done: items.filter((item) => item.decision === 'done').length,
+      paymentReconciled: items.filter((item) => item.paymentReconciled).length,
+    }
+
+    const filtered = items
+      .filter((item) => matchesStatus(item, status))
+      .filter((item) => matchesProject(item, project))
+      .filter((item) => matchesText(item, q))
+      .sort((a, b) => {
+        const rank = { duplicate_risk: 0, ambiguous: 1, find_match: 2, project_review: 3, bookkeeper: 4, unknown: 5, done: 6 }
+        const rankDiff = rank[a.decision] - rank[b.decision]
+        if (rankDiff !== 0) return rankDiff
+        return b.amount - a.amount
+      })
+
+    return NextResponse.json({
+      fy: { start: FY_START, end: FY_END },
+      filters: { status, project, q, limit },
+      summary,
+      projects: ((projectsResult.data || []) as ProjectOption[]).map((p) => ({
+        code: p.code,
+        name: p.name,
+        tier: p.tier,
+        status: p.status,
+      })),
+      caveat: 'Bank-line candidates are from the ACT Supabase mirror, not the live Xero Reconcile screen. Verify visibility in Xero before clicking.',
+      totalMatching: filtered.length,
+      items: filtered.slice(0, limit),
+    })
+  } catch (error) {
+    console.error('[finance/dext-push-audit] GET failed:', error)
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const id = typeof body.id === 'string' ? body.id : null
+    const projectCode = typeof body.projectCode === 'string' && body.projectCode.trim()
+      ? body.projectCode.trim()
+      : null
+
+    if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 })
+
+    if (projectCode) {
+      const { data: project, error: projectError } = await supabase
+        .from('projects')
+        .select('code')
+        .eq('code', projectCode)
+        .maybeSingle()
+      if (projectError) return NextResponse.json({ error: projectError.message }, { status: 500 })
+      if (!project) return NextResponse.json({ error: `Unknown project code: ${projectCode}` }, { status: 400 })
+    }
+
+    const { error } = await supabase
+      .from('xero_invoices')
+      .update({
+        project_code: projectCode,
+        project_code_source: 'manual_dext_push_audit',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ ok: true, id, projectCode })
+  } catch (error) {
+    console.error('[finance/dext-push-audit] PATCH failed:', error)
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/api/finance/pilot-risks/route.ts
+++ b/apps/command-center/src/app/api/finance/pilot-risks/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+/**
+ * Pilot lifecycle risk items for the AT RISK TODAY pane on /finance/command.
+ *
+ * Pass 2B B6. Same staleness ladder as scripts/idea-board-reminders.mjs:
+ *   idea 90d · scope 30d · fundraise 14d
+ *
+ * Severity (Q11):
+ *   🟠 high   — scope 30d+ OR fundraise 14d+
+ *   🟡 medium — snooze-burned (3 snoozes total — forced decision)
+ *
+ * Note: 'idea' staleness at 90d intentionally does NOT raise to AT RISK because
+ * those are pre-scope hunches, not in-flight commitments. They surface in the
+ * nightly reminder cron only.
+ */
+
+const STAGE_STALE_DAYS: Record<string, number> = {
+  scope: 30,
+  fundraise: 14,
+}
+const SNOOZE_LIMIT = 3
+
+interface PilotRiskItem {
+  id: string
+  severity: 'high' | 'medium'
+  stage: 'scope' | 'fundraise'
+  text: string
+  owner: string
+  age_days: number
+  snooze_count: number
+  snooze_burned: boolean
+  value_estimate: number
+  href: string
+}
+
+export async function GET() {
+  try {
+    const now = new Date()
+
+    const { data: rows, error } = await supabase
+      .from('idea_board')
+      .select('id, text, lifecycle_stage, owner, stage_entered_at, created_at, value_estimate, idea_snoozes(id, snoozed_until)')
+      .in('lifecycle_stage', Object.keys(STAGE_STALE_DAYS))
+
+    if (error) return NextResponse.json({ error: error.message, items: [] }, { status: 500 })
+
+    const today = now.toISOString().slice(0, 10)
+    const items: PilotRiskItem[] = []
+
+    for (const r of rows ?? []) {
+      const stage = r.lifecycle_stage as 'scope' | 'fundraise'
+      const threshold = STAGE_STALE_DAYS[stage]
+      if (!threshold) continue
+
+      const stageStartedAt = r.stage_entered_at ?? r.created_at
+      const ageDays = Math.floor((now.getTime() - new Date(stageStartedAt as string).getTime()) / (1000 * 60 * 60 * 24))
+
+      const snoozes = (r.idea_snoozes ?? []) as Array<{ snoozed_until: string }>
+      const snoozeCount = snoozes.length
+      const snoozeBurned = snoozeCount >= SNOOZE_LIMIT
+      const activeSnooze = snoozes.some((s) => s.snoozed_until > today)
+
+      // Skip if actively snoozed (unless burned — burned always surfaces)
+      if (activeSnooze && !snoozeBurned) continue
+
+      const isStale = ageDays >= threshold
+
+      if (!isStale && !snoozeBurned) continue
+
+      items.push({
+        id: r.id as string,
+        severity: snoozeBurned ? 'medium' : 'high',
+        stage,
+        text: r.text as string,
+        owner: (r.owner as string) ?? 'ben',
+        age_days: ageDays,
+        snooze_count: snoozeCount,
+        snooze_burned: snoozeBurned,
+        value_estimate: Number(r.value_estimate ?? 0),
+        href: `/ideas?focus=${r.id}`,
+      })
+    }
+
+    items.sort((a, b) => {
+      // High before medium; within severity, oldest first
+      if (a.severity !== b.severity) return a.severity === 'high' ? -1 : 1
+      return b.age_days - a.age_days
+    })
+
+    return NextResponse.json({
+      generatedAt: new Date().toISOString(),
+      items,
+      counters: {
+        high: items.filter((i) => i.severity === 'high').length,
+        medium: items.filter((i) => i.severity === 'medium').length,
+        snooze_burned: items.filter((i) => i.snooze_burned).length,
+      },
+    })
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message, items: [] }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/api/finance/receipt-evidence/pdf-preview/route.ts
+++ b/apps/command-center/src/app/api/finance/receipt-evidence/pdf-preview/route.ts
@@ -1,0 +1,104 @@
+import { execFile } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+
+const execFileAsync = promisify(execFile)
+const MAX_PDF_BYTES = 25 * 1024 * 1024
+
+async function findPdfToPpm() {
+  const candidates = [
+    '/opt/homebrew/bin/pdftoppm',
+    '/usr/local/bin/pdftoppm',
+    'pdftoppm',
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      if (candidate.includes('/')) await access(candidate)
+      return candidate
+    } catch {
+      // Try the next known install path.
+    }
+  }
+
+  return null
+}
+
+function parsePreviewUrl(rawUrl: string | null) {
+  if (!rawUrl) throw new Error('url required')
+  const url = new URL(rawUrl)
+
+  // This endpoint fetches server-side; keep it scoped to Supabase storage URLs.
+  if (!url.hostname.endsWith('.supabase.co')) {
+    throw new Error('unsupported pdf host')
+  }
+
+  return url
+}
+
+export async function GET(request: NextRequest) {
+  const workDir = join(tmpdir(), `receipt-pdf-preview-${randomUUID()}`)
+
+  try {
+    const pdfUrl = parsePreviewUrl(request.nextUrl.searchParams.get('url'))
+    const page = Math.max(1, Number(request.nextUrl.searchParams.get('page') || '1') || 1)
+    const dpi = Math.min(240, Math.max(120, Number(request.nextUrl.searchParams.get('dpi') || '180') || 180))
+    const pdftoppm = await findPdfToPpm()
+
+    if (!pdftoppm) {
+      return NextResponse.json({ error: 'pdftoppm not installed' }, { status: 500 })
+    }
+
+    const pdfRes = await fetch(pdfUrl.toString(), { cache: 'no-store' })
+    if (!pdfRes.ok) {
+      return NextResponse.json({ error: `failed to fetch pdf: ${pdfRes.status}` }, { status: 502 })
+    }
+
+    const contentType = pdfRes.headers.get('content-type') || ''
+    if (contentType && !contentType.includes('pdf') && !contentType.includes('octet-stream')) {
+      return NextResponse.json({ error: `unsupported content type: ${contentType}` }, { status: 415 })
+    }
+
+    const pdfBuffer = Buffer.from(await pdfRes.arrayBuffer())
+    if (pdfBuffer.byteLength > MAX_PDF_BYTES) {
+      return NextResponse.json({ error: 'pdf too large to preview' }, { status: 413 })
+    }
+
+    await mkdir(workDir, { recursive: true })
+    const pdfPath = join(workDir, 'source.pdf')
+    const outputBase = join(workDir, 'page')
+    const outputPath = `${outputBase}.png`
+
+    await writeFile(pdfPath, pdfBuffer)
+    await execFileAsync(pdftoppm, [
+      '-png',
+      '-singlefile',
+      '-f',
+      String(page),
+      '-l',
+      String(page),
+      '-r',
+      String(dpi),
+      pdfPath,
+      outputBase,
+    ], { timeout: 20_000 })
+
+    const image = await readFile(outputPath)
+    return new NextResponse(image, {
+      headers: {
+        'Content-Type': 'image/png',
+        'Cache-Control': 'private, max-age=300',
+      },
+    })
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  } finally {
+    await rm(workDir, { recursive: true, force: true }).catch(() => undefined)
+  }
+}

--- a/apps/command-center/src/app/api/finance/receipt-evidence/route.ts
+++ b/apps/command-center/src/app/api/finance/receipt-evidence/route.ts
@@ -1,0 +1,592 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Buffer } from 'node:buffer'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+type Quarter = 'Q1' | 'Q2' | 'Q3' | 'Q4'
+
+const FY26_QUARTERS: Record<Quarter, { start: string; end: string }> = {
+  Q1: { start: '2025-07-01', end: '2025-09-30' },
+  Q2: { start: '2025-10-01', end: '2025-12-31' },
+  Q3: { start: '2026-01-01', end: '2026-03-31' },
+  Q4: { start: '2026-04-01', end: '2026-06-30' },
+}
+
+function quarterRange(quarter: string | null) {
+  const q = (quarter || 'Q2').toUpperCase() as Quarter
+  return FY26_QUARTERS[q] || FY26_QUARTERS.Q2
+}
+
+function isHttpUrl(value: unknown) {
+  return typeof value === 'string' && /^https?:\/\//i.test(value)
+}
+
+function storagePathFromCandidate(candidate: Record<string, unknown>) {
+  const storagePath = candidate.attachment_storage_path
+  if (typeof storagePath === 'string' && storagePath.length > 0) return storagePath.replace(/^receipt-attachments\//, '')
+
+  const attachmentUrl = candidate.attachment_url
+  if (typeof attachmentUrl === 'string' && attachmentUrl.length > 0 && !isHttpUrl(attachmentUrl)) {
+    return attachmentUrl.replace(/^receipt-attachments\//, '')
+  }
+
+  return null
+}
+
+async function signCandidate(candidate: Record<string, unknown>) {
+  const path = storagePathFromCandidate(candidate)
+  if (!path) {
+    return {
+      ...candidate,
+      signed_url: isHttpUrl(candidate.attachment_url) ? candidate.attachment_url : null,
+    }
+  }
+
+  const { data } = await supabase.storage
+    .from('receipt-attachments')
+    .createSignedUrl(path, 3600)
+
+  return {
+    ...candidate,
+    signed_url: data?.signedUrl || null,
+  }
+}
+
+async function withSignedCandidates(row: Record<string, unknown>) {
+  const rawCandidates = Array.isArray(row.receipt_candidates)
+    ? row.receipt_candidates as Record<string, unknown>[]
+    : []
+
+  const receiptCandidates = await Promise.all(rawCandidates.map(signCandidate))
+  return { ...row, receipt_candidates: receiptCandidates }
+}
+
+function safeFileName(value: string) {
+  return value
+    .replace(/[/\\?%*:|"<>]/g, '-')
+    .replace(/\s+/g, '-')
+    .slice(0, 120)
+}
+
+function asNumber(value: unknown) {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : 0
+}
+
+function activeReceiptCandidates(row: Record<string, unknown>) {
+  return Array.isArray(row.receipt_candidates)
+    ? row.receipt_candidates as Record<string, unknown>[]
+    : []
+}
+
+const GENERIC_VENDOR_WORDS = new Set([
+  'australia',
+  'australian',
+  'brisbane',
+  'sydney',
+  'melbourne',
+  'mascot',
+  'maleny',
+  'alice',
+  'springs',
+  'townsville',
+  'witta',
+  'pty',
+  'ltd',
+  'limited',
+  'inc',
+  'llc',
+  'corp',
+  'corporation',
+  'company',
+  'group',
+  'www',
+  'com',
+  'au',
+  'internet',
+  'banking',
+  'transfer',
+  'payment',
+  'payments',
+  'sales',
+  'service',
+  'services',
+  'station',
+  'store',
+  'stores',
+  'the',
+  'and',
+  'for',
+  'with',
+  'mount',
+  'mt',
+  'isa',
+])
+
+function cleanMatchText(value: unknown) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function meaningfulTokens(value: unknown) {
+  return cleanMatchText(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_VENDOR_WORDS.has(token))
+}
+
+function vendorMatchesPayee(candidate: Record<string, unknown>, row: Record<string, unknown>) {
+  const vendor = cleanMatchText(candidate.vendor_name)
+  const payee = cleanMatchText(row.payee)
+  if (!vendor || !payee) return false
+  if (vendor.includes(payee) || payee.includes(vendor)) return true
+
+  const payeeTokens = new Set(meaningfulTokens(payee))
+  return meaningfulTokens(vendor).some((token) => payeeTokens.has(token))
+}
+
+function amountCloseEnough(candidate: Record<string, unknown>, row: Record<string, unknown>) {
+  const lineAmount = Math.abs(asNumber(row.amount))
+  const delta = Math.abs(asNumber(candidate.amount_delta))
+  if (!lineAmount) return false
+  return delta <= Math.max(1, lineAmount * 0.02)
+}
+
+function dateCloseEnough(candidate: Record<string, unknown>) {
+  const matchMethod = String(candidate.match_method || '')
+  if (matchMethod === 'xero_id') return true
+
+  const rawDelta = candidate.date_delta_days
+  if (rawDelta === null || rawDelta === undefined || rawDelta === '') return false
+
+  return Math.abs(asNumber(rawDelta)) <= 14
+}
+
+function isLikelyForeignCurrencyVendor(candidate: Record<string, unknown>, row: Record<string, unknown>) {
+  const text = cleanMatchText([
+    candidate.vendor_name,
+    candidate.subject,
+    candidate.attachment_filename,
+    row.payee,
+    row.particulars,
+  ].join(' '))
+  const textTokens = new Set(text.split(' ').filter(Boolean))
+
+  const knownVendors = [
+    'anthropic',
+    'claude',
+    'codeguide',
+    'cognition',
+    'cursor',
+    'descript',
+    'exa',
+    'figma',
+    'firecrawl',
+    'github',
+    'holafly',
+    'jetboost',
+    'landingfolio',
+    'mighty',
+    'napkin',
+    'notion',
+    'openai',
+    'railway',
+    'serpapi',
+    'sideguide',
+    'supabase',
+    'superdesign',
+    'vercel',
+    'warp',
+    'webflow',
+    'x global',
+    'zapier',
+  ]
+
+  return knownVendors.some((vendor) => {
+    const cleanedVendor = cleanMatchText(vendor)
+    return cleanedVendor.includes(' ')
+      ? text.includes(cleanedVendor)
+      : textTokens.has(cleanedVendor)
+  })
+}
+
+function hasAttachment(candidate: Record<string, unknown>) {
+  return Boolean(
+    candidate.attachment_url
+    || candidate.attachment_storage_path
+    || candidate.attachment_filename,
+  )
+}
+
+function amountPlausibleForEvidence(candidate: Record<string, unknown>, row: Record<string, unknown>) {
+  if (amountCloseEnough(candidate, row)) return true
+
+  const lineAmount = Math.abs(asNumber(row.amount))
+  const documentAmount = Math.abs(asNumber(candidate.amount_total))
+  if (!lineAmount || !documentAmount) return false
+  if (!hasAttachment(candidate)) return false
+  if (!dateCloseEnough(candidate)) return false
+  if (!vendorMatchesPayee(candidate, row)) return false
+
+  const ratio = Math.max(lineAmount, documentAmount) / Math.min(lineAmount, documentAmount)
+  if (ratio < 1.15 || ratio > 2.25) return false
+
+  const source = String(candidate.source || '')
+  const sourceTable = String(candidate.source_table || '')
+  const currency = cleanMatchText(candidate.currency_code)
+
+  return Boolean(
+    isLikelyForeignCurrencyVendor(candidate, row)
+    && (
+      currency && currency !== 'aud'
+      || source.includes('dext')
+      || source.includes('receipt')
+      || source.includes('manual')
+      || source.includes('xero_me')
+      || sourceTable === 'receipt_emails'
+    ),
+  )
+}
+
+function hasReviewableReceiptCandidate(row: Record<string, unknown>) {
+  return activeReceiptCandidates(row).some((candidate) => {
+    const source = String(candidate.source || '')
+    const sourceTable = String(candidate.source_table || '')
+    const xeroAction = String(candidate.xero_action || '')
+
+    if (!vendorMatchesPayee(candidate, row) || !amountPlausibleForEvidence(candidate, row) || !dateCloseEnough(candidate)) {
+      return false
+    }
+
+    return Boolean(
+      xeroAction === 'attach_file'
+      || (xeroAction === 'find_match' && hasAttachment(candidate))
+      || source.includes('dext')
+      || source.includes('receipt')
+      || source.includes('xero_me')
+      || sourceTable === 'receipt_emails',
+    )
+  })
+}
+
+function reviewEvidenceStatus(row: Record<string, unknown>) {
+  const rawStatus = String(row.evidence_status || 'uncovered')
+  const legacyNoReceipt = String(row.receipt_match_status || '') === 'no_receipt_needed'
+
+  if (!legacyNoReceipt || !hasReviewableReceiptCandidate(row)) return rawStatus
+  if (row.has_approved_link === true) return 'covered_evidence'
+  if (asNumber(row.best_confidence) >= 0.85) return 'high_confidence_candidate'
+  if (asNumber(row.candidate_count) > 0) return 'candidate'
+  return rawStatus
+}
+
+function normalizeEvidenceRow(row: Record<string, unknown>) {
+  const legacyNoReceiptCandidate = String(row.receipt_match_status || '') === 'no_receipt_needed'
+    && hasReviewableReceiptCandidate(row)
+
+  return {
+    ...row,
+    legacy_evidence_status: row.evidence_status,
+    legacy_no_receipt_candidate: legacyNoReceiptCandidate,
+    evidence_status: reviewEvidenceStatus(row),
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const quarter = searchParams.get('quarter') || 'Q2'
+    const status = searchParams.get('status') || 'all'
+    const limit = Math.min(Number(searchParams.get('limit') || '200'), 500)
+    const search = (searchParams.get('search') || '').trim().toLowerCase()
+    const { start, end } = quarterRange(quarter)
+
+    const { data, error } = await supabase
+      .from('v_finance_bank_line_evidence')
+      .select('*')
+      .eq('direction', 'debit')
+      .gte('date', start)
+      .lte('date', end)
+      .order('amount', { ascending: false })
+      .limit(2000)
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    const rows = (data || []).map((row) => normalizeEvidenceRow(row as Record<string, unknown>))
+    const filtered = rows.filter((row: Record<string, unknown>) => {
+      const evidenceStatus = String(row.evidence_status || '')
+      const bankStatus = String(row.status || '').toLowerCase()
+      const isReconciled = bankStatus === 'reconciled'
+      const hasEvidence = ['covered_evidence', 'covered_legacy', 'no_receipt_needed'].includes(evidenceStatus)
+      const needsReceipt = ['uncovered', 'candidate', 'high_confidence_candidate'].includes(evidenceStatus)
+
+      if (status === 'unreconciled' && isReconciled) return false
+      else if (status === 'reconciled' && !isReconciled) return false
+      else if (status === 'needs_receipt' && !needsReceipt) return false
+      else if (status === 'ready_to_review' && !['candidate', 'high_confidence_candidate'].includes(evidenceStatus)) return false
+      else if (status === 'legacy_no_receipt_candidates' && row.legacy_no_receipt_candidate !== true) return false
+      else if (status === 'covered_unreconciled' && (!hasEvidence || isReconciled)) return false
+      else if (
+        ![
+          'all',
+          'unreconciled',
+          'reconciled',
+          'needs_receipt',
+          'ready_to_review',
+          'legacy_no_receipt_candidates',
+          'covered_unreconciled',
+        ].includes(status)
+        && evidenceStatus !== status
+      ) return false
+
+      if (!search) return true
+      const haystack = `${row.payee || ''} ${row.particulars || ''} ${row.reference || ''} ${row.best_vendor_name || ''}`.toLowerCase()
+      return haystack.includes(search)
+    })
+
+    const stats = rows.reduce((acc: Record<string, number>, row: Record<string, unknown>) => {
+      const key = String(row.evidence_status || 'unknown')
+      acc[key] = (acc[key] || 0) + 1
+      acc.total = (acc.total || 0) + 1
+      acc.spend = (acc.spend || 0) + Math.abs(Number(row.amount) || 0)
+      if (row.legacy_no_receipt_candidate === true) acc.legacyNoReceiptCandidates = (acc.legacyNoReceiptCandidates || 0) + 1
+      if (Number(row.best_confidence || 0) >= 0.85) acc.highConfidence = (acc.highConfidence || 0) + 1
+      if (Number(row.candidate_count || 0) > 0) acc.withCandidates = (acc.withCandidates || 0) + 1
+      if (String(row.status || '').toLowerCase() === 'reconciled') acc.bankReconciled = (acc.bankReconciled || 0) + 1
+      else acc.bankUnreconciled = (acc.bankUnreconciled || 0) + 1
+      if (['uncovered', 'candidate', 'high_confidence_candidate'].includes(key)) acc.needsReceipt = (acc.needsReceipt || 0) + 1
+      return acc
+    }, {})
+
+    const signedRows = await Promise.all(filtered.slice(0, limit).map(withSignedCandidates))
+
+    return NextResponse.json({
+      quarter,
+      dateStart: start,
+      dateEnd: end,
+      status,
+      rows: signedRows,
+      count: signedRows.length,
+      totalMatchingFilter: filtered.length,
+      stats,
+    })
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const contentType = request.headers.get('content-type') || ''
+    if (contentType.includes('multipart/form-data')) {
+      return await handleManualUpload(request)
+    }
+
+    const body = await request.json()
+    const action = body.action as string
+
+    if (action === 'approve_link' || action === 'reject_link' || action === 'needs_review') {
+      const linkId = body.linkId as string
+      if (!linkId) return NextResponse.json({ error: 'linkId required' }, { status: 400 })
+
+      let linkStatus = action === 'approve_link'
+        ? 'approved'
+        : action === 'reject_link'
+          ? 'rejected'
+          : 'needs_review'
+
+      if (action === 'needs_review') {
+        const { data: currentLink, error: currentLinkError } = await supabase
+          .from('finance_receipt_bank_line_links')
+          .select('link_status')
+          .eq('id', linkId)
+          .single()
+
+        if (currentLinkError) return NextResponse.json({ error: currentLinkError.message }, { status: 500 })
+
+        // Queueing a Xero follow-up is a workflow note, not evidence rejection.
+        // Preserve approval once a human has confirmed the receipt.
+        if (currentLink?.link_status === 'approved') linkStatus = 'approved'
+      }
+
+      const updates = {
+        link_status: linkStatus,
+        review_note: body.reviewNote || null,
+        review_owner: body.reviewOwner || null,
+        updated_at: new Date().toISOString(),
+      }
+
+      const { error } = await supabase
+        .from('finance_receipt_bank_line_links')
+        .update(updates)
+        .eq('id', linkId)
+
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+      if (action === 'approve_link' && body.syncLegacy === true) {
+        await syncApprovedLinkToBankLine(linkId)
+      }
+
+      return NextResponse.json({ ok: true, linkId, linkStatus })
+    }
+
+    if (action === 'no_receipt_needed') {
+      const bankLineId = body.bankLineId as string
+      if (!bankLineId) return NextResponse.json({ error: 'bankLineId required' }, { status: 400 })
+
+      const { error } = await supabase
+        .from('bank_statement_lines')
+        .update({
+          receipt_match_status: 'no_receipt_needed',
+          notes: body.reviewNote || 'Marked no receipt needed via receipt evidence hub',
+        })
+        .eq('id', bankLineId)
+
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+      return NextResponse.json({ ok: true, bankLineId, receiptStatus: 'no_receipt_needed' })
+    }
+
+    return NextResponse.json({ error: 'unsupported action' }, { status: 400 })
+  } catch (e) {
+    return NextResponse.json({ error: (e as Error).message }, { status: 500 })
+  }
+}
+
+async function syncApprovedLinkToBankLine(linkId: string) {
+  const { data: link, error: linkError } = await supabase
+    .from('finance_receipt_bank_line_links')
+    .select('id, bank_line_id, receipt_document_id, confidence')
+    .eq('id', linkId)
+    .single()
+
+  if (linkError || !link) throw new Error(linkError?.message || 'link not found')
+
+  const { data: doc, error: docError } = await supabase
+    .from('finance_receipt_documents')
+    .select('id, source, source_record_id, source_table')
+    .eq('id', link.receipt_document_id)
+    .single()
+
+  if (docError || !doc) throw new Error(docError?.message || 'document not found')
+
+  // The legacy bank_statement_lines.receipt_match_id field has historically
+  // pointed at receipt_emails.id. Do not write xero_bill/manual document IDs
+  // into it; the new evidence link itself is the coverage record for those.
+  if (doc.source_table !== 'receipt_emails') return
+
+  const updates: Record<string, unknown> = {
+    receipt_match_status: 'matched',
+    receipt_match_score: Number(link.confidence || 1),
+    notes: `Approved receipt evidence link ${linkId}`,
+  }
+
+  updates.receipt_match_id = doc.source_record_id
+  updates.matched_receipt_email_id = doc.source_record_id
+
+  const { error } = await supabase
+    .from('bank_statement_lines')
+    .update(updates)
+    .eq('id', link.bank_line_id)
+
+  if (error) throw new Error(error.message)
+}
+
+async function handleManualUpload(request: NextRequest) {
+  const form = await request.formData()
+  const file = form.get('file')
+  const bankLineId = String(form.get('bankLineId') || '')
+
+  if (!file || typeof file !== 'object' || !('arrayBuffer' in file)) {
+    return NextResponse.json({ error: 'file required' }, { status: 400 })
+  }
+
+  const uploadFile = file as File
+  const vendorName = String(form.get('vendorName') || '')
+  const amountTotalRaw = String(form.get('amountTotal') || '')
+  const documentDate = String(form.get('documentDate') || '')
+  const reviewNote = String(form.get('reviewNote') || '')
+  const amountTotal = amountTotalRaw ? Number(amountTotalRaw) : null
+
+  const arrayBuffer = await uploadFile.arrayBuffer()
+  const buffer = Buffer.from(arrayBuffer)
+  const now = Date.now()
+  const filename = safeFileName(uploadFile.name || `receipt-${now}`)
+  const storagePath = `manual-upload/${bankLineId || 'unlinked'}/${now}-${filename}`
+
+  const { error: uploadError } = await supabase.storage
+    .from('receipt-attachments')
+    .upload(storagePath, buffer, {
+      contentType: uploadFile.type || 'application/octet-stream',
+      upsert: false,
+    })
+
+  if (uploadError) return NextResponse.json({ error: uploadError.message }, { status: 500 })
+
+  const sourceRecordId = `manual:${bankLineId || 'unlinked'}:${now}:${filename}`
+  const { data: doc, error: docError } = await supabase
+    .from('finance_receipt_documents')
+    .insert({
+      source: 'manual_upload',
+      source_record_id: sourceRecordId,
+      source_table: 'finance_receipt_documents',
+      vendor_name: vendorName || null,
+      document_date: documentDate || null,
+      amount_total: amountTotal,
+      attachment_url: storagePath,
+      attachment_storage_path: storagePath,
+      attachment_filename: uploadFile.name || filename,
+      attachment_content_type: uploadFile.type || 'application/octet-stream',
+      attachment_size_bytes: buffer.length,
+      status: bankLineId ? 'approved' : 'candidate',
+      provenance: {
+        source: 'manual_upload',
+        review_note: reviewNote || null,
+        uploaded_via: '/finance/receipt-evidence',
+      },
+    })
+    .select('id')
+    .single()
+
+  if (docError || !doc) return NextResponse.json({ error: docError?.message || 'document insert failed' }, { status: 500 })
+
+  let linkId: string | null = null
+  if (bankLineId) {
+    const { data: link, error: linkError } = await supabase
+      .from('finance_receipt_bank_line_links')
+      .insert({
+        bank_line_id: bankLineId,
+        receipt_document_id: doc.id,
+        link_status: 'approved',
+        match_method: 'manual_upload',
+        confidence: 1,
+        rank: 1,
+        is_best_candidate: true,
+        review_note: reviewNote || 'Manual receipt upload',
+        xero_action: 'attach_file',
+        provenance: {
+          source: 'manual_upload',
+          uploaded_via: '/finance/receipt-evidence',
+        },
+        created_by: 'human',
+      })
+      .select('id')
+      .single()
+
+    if (linkError) return NextResponse.json({ error: linkError.message }, { status: 500 })
+    linkId = link?.id || null
+  }
+
+  return NextResponse.json({
+    ok: true,
+    documentId: doc.id,
+    linkId,
+    storagePath,
+  })
+}

--- a/apps/command-center/src/app/api/finance/today-actions/route.ts
+++ b/apps/command-center/src/app/api/finance/today-actions/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { existsSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+export const dynamic = 'force-dynamic'
+
+const FY_START = '2025-07-01'
+const FY_END = '2026-06-30'
+
+async function countUntaggedTransactions() {
+  const { count } = await supabase
+    .from('xero_transactions')
+    .select('*', { count: 'exact', head: true })
+    .gte('date', FY_START)
+    .lte('date', FY_END)
+    .or('project_code.is.null,project_code.eq.UNKNOWN')
+  return count ?? 0
+}
+
+async function countUntaggedInvoices() {
+  const { count } = await supabase
+    .from('xero_invoices')
+    .select('*', { count: 'exact', head: true })
+    .eq('type', 'ACCREC')
+    .gte('date', FY_START)
+    .or('project_code.is.null,project_code.eq.UNKNOWN')
+  return count ?? 0
+}
+
+async function countReceiptsReadyToAttach() {
+  // Approved best-candidate links with attach_file action — the attach_evidence queue.
+  const { count } = await supabase
+    .from('finance_receipt_bank_line_links')
+    .select('*', { count: 'exact', head: true })
+    .eq('link_status', 'approved')
+    .eq('is_best_candidate', true)
+    .eq('xero_action', 'attach_file')
+  return count ?? 0
+}
+
+async function countAIRoutingSuggestions() {
+  // Pending high-conf AI suggestions waiting for review/accept
+  const { count } = await supabase
+    .from('finance_ai_routing_suggestions')
+    .select('*', { count: 'exact', head: true })
+    .gte('confidence', 0.85)
+    .eq('applied_to_source', false)
+    .is('rejected_at', null)
+  return count ?? 0
+}
+
+async function countOverdueAR() {
+  const today = new Date().toISOString().slice(0, 10)
+  const { count } = await supabase
+    .from('xero_invoices')
+    .select('*', { count: 'exact', head: true })
+    .eq('type', 'ACCREC')
+    .eq('status', 'AUTHORISED')
+    .gt('amount_due', 0)
+    .lt('due_date', today)
+  return count ?? 0
+}
+
+function daysSinceLastWeeklyNarrative() {
+  // wiki/cockpit/weekly-narrative-YYYY-MM-DD.md
+  const wikiDir = path.resolve(process.cwd(), '..', '..', 'wiki', 'cockpit')
+  if (!existsSync(wikiDir)) return null
+  try {
+    const files = readdirSync(wikiDir).filter((f) => f.startsWith('weekly-narrative-') && f.endsWith('.md'))
+    if (!files.length) return null
+    files.sort()
+    const latest = files[files.length - 1]
+    const match = latest.match(/(\d{4}-\d{2}-\d{2})/)
+    if (!match) return null
+    const last = new Date(`${match[1]}T00:00:00Z`)
+    const now = new Date()
+    return Math.floor((now.getTime() - last.getTime()) / 86400000)
+  } catch {
+    return null
+  }
+}
+
+export async function GET() {
+  try {
+    const [
+      untaggedTxns,
+      untaggedInvs,
+      receiptsReady,
+      aiSuggestions,
+      overdueAR,
+    ] = await Promise.all([
+      countUntaggedTransactions(),
+      countUntaggedInvoices(),
+      countReceiptsReadyToAttach(),
+      countAIRoutingSuggestions(),
+      countOverdueAR(),
+    ])
+    const narrativeAge = daysSinceLastWeeklyNarrative()
+
+    const signals: Array<{
+      severity: 'high' | 'medium' | 'low'
+      label: string
+      detail: string
+      href: string
+      count?: number
+    }> = []
+
+    if (untaggedTxns > 0) {
+      signals.push({
+        severity: untaggedTxns > 50 ? 'high' : untaggedTxns > 10 ? 'medium' : 'low',
+        label: `${untaggedTxns} untagged transactions`,
+        detail: 'Workbench filter=needs_project',
+        href: '/finance/workbench?status=needs_project',
+        count: untaggedTxns,
+      })
+    }
+
+    if (receiptsReady > 0) {
+      signals.push({
+        severity: receiptsReady > 20 ? 'high' : 'medium',
+        label: `${receiptsReady} receipts ready to attach`,
+        detail: 'Run xero-copilot-execute --apply or use copilot',
+        href: '/finance/workbench?status=candidate_receipts',
+        count: receiptsReady,
+      })
+    }
+
+    if (aiSuggestions > 0) {
+      signals.push({
+        severity: aiSuggestions > 30 ? 'high' : 'medium',
+        label: `${aiSuggestions} AI suggestions ≥85%`,
+        detail: 'Review and accept in workbench',
+        href: '/finance/workbench?status=needs_project',
+        count: aiSuggestions,
+      })
+    }
+
+    if (overdueAR > 0) {
+      signals.push({
+        severity: overdueAR > 5 ? 'high' : 'medium',
+        label: `${overdueAR} overdue invoices`,
+        detail: 'AR past due_date',
+        href: '/finance/invoices?filter=overdue',
+        count: overdueAR,
+      })
+    }
+
+    if (untaggedInvs > 0) {
+      signals.push({
+        severity: untaggedInvs > 10 ? 'medium' : 'low',
+        label: `${untaggedInvs} untagged AR invoices`,
+        detail: 'Money Command drift queue',
+        href: '/finance/command',
+        count: untaggedInvs,
+      })
+    }
+
+    if (narrativeAge !== null && narrativeAge > 7) {
+      signals.push({
+        severity: 'medium',
+        label: `Last weekly narrative ${narrativeAge} days ago`,
+        detail: 'node scripts/narrate-weekly-digest.mjs --telegram',
+        href: '/finance/command',
+      })
+    }
+
+    // Top 3 by severity
+    const sevOrder = { high: 0, medium: 1, low: 2 } as const
+    signals.sort((a, b) => sevOrder[a.severity] - sevOrder[b.severity])
+    const top3 = signals.slice(0, 3)
+
+    return NextResponse.json({
+      generatedAt: new Date().toISOString(),
+      hasWork: top3.length > 0,
+      signals: top3,
+      counts: {
+        untaggedTxns,
+        untaggedInvs,
+        receiptsReady,
+        aiSuggestions,
+        overdueAR,
+        narrativeAgeDays: narrativeAge,
+      },
+    })
+  } catch (err) {
+    return NextResponse.json(
+      { error: (err as Error).message?.slice(0, 300) || 'failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/apps/command-center/src/app/api/finance/workbench/accept-suggestion/route.ts
+++ b/apps/command-center/src/app/api/finance/workbench/accept-suggestion/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+interface AcceptBody {
+  suggestionId?: string
+  rejectionReason?: string
+  action?: 'accept' | 'reject'
+}
+
+const SAFE_NEVER_AUTO = new Set(['ASK_USER', 'SL_REVIEW'])
+
+export async function POST(request: NextRequest) {
+  let body: AcceptBody
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { suggestionId, action = 'accept', rejectionReason } = body
+
+  if (!suggestionId) {
+    return NextResponse.json({ error: 'Missing suggestionId' }, { status: 400 })
+  }
+
+  const { data: suggestion, error: fetchErr } = await supabase
+    .from('finance_ai_routing_suggestions')
+    .select('id,source_table,source_record_id,suggested_project_code,confidence,applied_to_source,rejected_at,vendor_name,amount')
+    .eq('id', suggestionId)
+    .single()
+
+  if (fetchErr || !suggestion) {
+    return NextResponse.json({ error: `Suggestion not found: ${fetchErr?.message || 'no row'}` }, { status: 404 })
+  }
+
+  if (suggestion.applied_to_source) {
+    return NextResponse.json(
+      { ok: false, error: 'Already applied' },
+      { status: 409 },
+    )
+  }
+  if (suggestion.rejected_at) {
+    return NextResponse.json(
+      { ok: false, error: 'Already rejected' },
+      { status: 409 },
+    )
+  }
+
+  if (action === 'reject') {
+    const { error: rejErr } = await supabase
+      .from('finance_ai_routing_suggestions')
+      .update({
+        rejected_at: new Date().toISOString(),
+        rejected_reason: rejectionReason || 'rejected via workbench',
+      })
+      .eq('id', suggestionId)
+    if (rejErr) {
+      return NextResponse.json({ error: rejErr.message }, { status: 500 })
+    }
+    return NextResponse.json({ ok: true, action: 'reject', suggestionId })
+  }
+
+  // Accept path
+  const code = suggestion.suggested_project_code
+  if (SAFE_NEVER_AUTO.has(code)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `Cannot auto-apply ${code} — these codes require human review. Update the source row's project_code manually.`,
+      },
+      { status: 400 },
+    )
+  }
+
+  const updates: Record<string, unknown> = { project_code: code }
+  if (suggestion.source_table === 'xero_transactions') {
+    updates.project_code_source = 'ai_router'
+  }
+
+  const { error: updateErr } = await supabase
+    .from(suggestion.source_table)
+    .update(updates)
+    .eq('id', suggestion.source_record_id)
+
+  if (updateErr) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: `Failed to update ${suggestion.source_table}: ${updateErr.message.slice(0, 200)}`,
+      },
+      { status: 500 },
+    )
+  }
+
+  const { error: markErr } = await supabase
+    .from('finance_ai_routing_suggestions')
+    .update({
+      applied_at: new Date().toISOString(),
+      applied_to_source: true,
+    })
+    .eq('id', suggestionId)
+
+  if (markErr) {
+    console.warn('[accept-suggestion] Failed to mark applied:', markErr.message)
+  }
+
+  return NextResponse.json({
+    ok: true,
+    action: 'accept',
+    suggestionId,
+    appliedCode: code,
+    sourceTable: suggestion.source_table,
+    sourceRecordId: suggestion.source_record_id,
+  })
+}

--- a/apps/command-center/src/app/api/finance/workbench/ai-queue/route.ts
+++ b/apps/command-center/src/app/api/finance/workbench/ai-queue/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+type Filter = 'high_conf' | 'review' | 'all'
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url)
+  const filter = (url.searchParams.get('filter') as Filter) || 'high_conf'
+  const limit = Math.min(Number(url.searchParams.get('limit') || '50'), 200)
+
+  let query = supabase
+    .from('finance_ai_routing_suggestions')
+    .select('id,source_table,source_record_id,vendor_name,amount,txn_date,bank_account,description,suggested_project_code,confidence,reason,risk_flags,model,prompt_version,created_at,applied_to_source,rejected_at')
+    .eq('applied_to_source', false)
+    .is('rejected_at', null)
+    .order('confidence', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(limit)
+
+  if (filter === 'high_conf') {
+    query = query.gte('confidence', 0.85).not('suggested_project_code', 'in', '(ASK_USER,SL_REVIEW)')
+  } else if (filter === 'review') {
+    query = query.or('confidence.lt.0.85,suggested_project_code.in.(ASK_USER,SL_REVIEW)')
+  }
+
+  const { data, error } = await query
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  // Bucketed counts for the filter tab UI
+  const [{ count: totalHighConf }, { count: totalReview }, { count: totalApplied }] = await Promise.all([
+    supabase
+      .from('finance_ai_routing_suggestions')
+      .select('*', { count: 'exact', head: true })
+      .eq('applied_to_source', false)
+      .is('rejected_at', null)
+      .gte('confidence', 0.85)
+      .not('suggested_project_code', 'in', '(ASK_USER,SL_REVIEW)'),
+    supabase
+      .from('finance_ai_routing_suggestions')
+      .select('*', { count: 'exact', head: true })
+      .eq('applied_to_source', false)
+      .is('rejected_at', null)
+      .or('confidence.lt.0.85,suggested_project_code.in.(ASK_USER,SL_REVIEW)'),
+    supabase
+      .from('finance_ai_routing_suggestions')
+      .select('*', { count: 'exact', head: true })
+      .eq('applied_to_source', true),
+  ])
+
+  return NextResponse.json({
+    filter,
+    counts: {
+      highConf: totalHighConf ?? 0,
+      review: totalReview ?? 0,
+      applied: totalApplied ?? 0,
+    },
+    suggestions: data || [],
+  })
+}

--- a/apps/command-center/src/app/api/finance/workbench/route.ts
+++ b/apps/command-center/src/app/api/finance/workbench/route.ts
@@ -1,0 +1,630 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import { execSql } from '@/lib/finance/query'
+
+export const dynamic = 'force-dynamic'
+
+const FY_START = '2025-07-01'
+const FY_END = '2026-06-30'
+const RECEIPT_THRESHOLD = 82.5
+
+type SourceFilter = 'all' | 'bank_lines' | 'xero_transactions' | 'xero_invoices'
+type DirectionFilter = 'all' | 'spend' | 'income'
+type StatusFilter =
+  | 'needs_action'
+  | 'xero_drafts'
+  | 'receipt_gap'
+  | 'candidate_receipts'
+  | 'no_receipt_needed'
+  | 'needs_project'
+  | 'project_review'
+  | 'unreconciled'
+  | 'rd_review'
+  | 'all'
+
+interface ProjectOption {
+  code: string
+  name: string | null
+  tier: string | null
+  status: string | null
+}
+
+interface BankEvidenceRow {
+  id: string
+  date: string | null
+  direction: string | null
+  payee: string | null
+  particulars: string | null
+  reference: string | null
+  amount: number | string | null
+  status: string | null
+  bank_account: string | null
+  project_code: string | null
+  project_source: string | null
+  rd_eligible: boolean | null
+  receipt_match_status: string | null
+  evidence_status: string | null
+  candidate_count: number | null
+  best_confidence: number | string | null
+  best_source: string | null
+  best_vendor_name: string | null
+  has_approved_link: boolean | null
+  xero_transaction_id: string | null
+  matched_xero_transaction_id: string | null
+}
+
+interface XeroTransactionRow {
+  id: string
+  xero_transaction_id: string | null
+  type: string | null
+  contact_name: string | null
+  bank_account: string | null
+  project_code: string | null
+  project_code_source: string | null
+  total: number | string | null
+  status: string | null
+  date: string | null
+  line_items: unknown
+  has_attachments: boolean | null
+  is_reconciled: boolean | null
+  rd_eligible: boolean | null
+  rd_category: string | null
+}
+
+interface XeroInvoiceRow {
+  id: string
+  xero_id: string | null
+  invoice_number: string | null
+  type: string | null
+  status: string | null
+  contact_name: string | null
+  date: string | null
+  total: number | string | null
+  amount_due: number | string | null
+  amount_paid: number | string | null
+  line_items: unknown
+  has_attachments: boolean | null
+  reference: string | null
+  project_code: string | null
+  project_code_source: string | null
+  income_type: string | null
+}
+
+interface WorkbenchItem {
+  id: string
+  source: SourceFilter
+  direction: 'spend' | 'income'
+  date: string | null
+  vendor: string
+  description: string | null
+  amount: number
+  xeroStatus: string | null
+  isReconciled: boolean | null
+  projectCode: string | null
+  projectSource: string | null
+  hasReceipt: boolean
+  receiptState: string
+  receiptSignal: string | null
+  candidateCount: number
+  confidence: number | null
+  rdEligible: boolean | null
+  rdCategory: string | null
+  needsProject: boolean
+  needsProjectReview: boolean
+  needsReceipt: boolean
+  needsReconciliation: boolean
+  needsXeroDraft: boolean
+  xeroDraftHint: string | null
+  needsRdReview: boolean
+  xeroReference: string | null
+  receiptEvidenceUrl: string
+}
+
+interface SummaryRow {
+  bank_lines: number | string | null
+  bank_receipt_gaps: number | string | null
+  bank_receipt_gap_value: number | string | null
+  bank_candidates: number | string | null
+  xero_draft_candidates: number | string | null
+  xero_draft_candidate_value: number | string | null
+  bank_unreconciled: number | string | null
+  bank_unreconciled_value: number | string | null
+  bank_project_gaps: number | string | null
+  xero_project_gaps: number | string | null
+  invoice_project_gaps: number | string | null
+  act_in_review: number | string | null
+  rd_review: number | string | null
+  rd_eligible_spend: number | string | null
+}
+
+function asNumber(value: number | string | null | undefined): number {
+  if (value == null) return 0
+  const parsed = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function asPercent(value: number | string | null | undefined): number {
+  const number = asNumber(value)
+  return number > 0 && number <= 1 ? number * 100 : number
+}
+
+function isBlank(value: string | null | undefined): boolean {
+  return !value || value.trim().length === 0
+}
+
+function firstLineDescription(lineItems: unknown): string | null {
+  if (!Array.isArray(lineItems)) return null
+  for (const item of lineItems) {
+    if (!item || typeof item !== 'object') continue
+    const row = item as Record<string, unknown>
+    const desc = row.Description || row.description
+    if (typeof desc === 'string' && desc.trim()) {
+      return desc.trim().slice(0, 140)
+    }
+  }
+  return null
+}
+
+function quarterForDate(date: string | null): string {
+  if (!date) return 'Q2'
+  const month = new Date(`${date}T00:00:00`).getMonth() + 1
+  if (month >= 7 && month <= 9) return 'Q1'
+  if (month >= 10 && month <= 12) return 'Q2'
+  if (month >= 1 && month <= 3) return 'Q3'
+  return 'Q4'
+}
+
+function receiptEvidenceUrl(date: string | null, vendor: string): string {
+  const params = new URLSearchParams()
+  params.set('quarter', quarterForDate(date))
+  params.set('status', 'all')
+  if (vendor.trim()) params.set('search', vendor.trim())
+  return `/finance/receipt-evidence?${params.toString()}`
+}
+
+function receiptCovered(state: string | null | undefined, matchStatus?: string | null, approved?: boolean | null): boolean {
+  return Boolean(
+    approved ||
+      matchStatus === 'matched' ||
+      state === 'covered_legacy' ||
+      state === 'covered_evidence' ||
+      state === 'matched'
+  )
+}
+
+function isReceiptGap(state: string | null | undefined, matchStatus?: string | null): boolean {
+  return (
+    matchStatus === 'unmatched' ||
+    state === 'uncovered' ||
+    state === 'candidate' ||
+    state === 'high_confidence_candidate'
+  )
+}
+
+function hasXeroTarget(row: Pick<BankEvidenceRow, 'xero_transaction_id' | 'matched_xero_transaction_id'>): boolean {
+  return !isBlank(row.xero_transaction_id) || !isBlank(row.matched_xero_transaction_id)
+}
+
+function xeroDraftHint(row: BankEvidenceRow, hasReceipt: boolean, needsReceipt: boolean): string | null {
+  if (row.status !== 'unreconciled' || row.direction === 'credit' || hasXeroTarget(row)) return null
+  if (hasReceipt) {
+    return 'Local evidence exists. Open Xero Expenses drafts, approve the matching draft or create spend-money, then reconcile the bank line.'
+  }
+  if ((row.candidate_count || 0) > 0) {
+    return 'Receipt candidates exist. Confirm evidence here, then approve/create the matching Xero transaction.'
+  }
+  if (needsReceipt) {
+    return 'No Xero accounting target is mirrored yet. Check Xero Expenses drafts first, then Dext/Gmail/manual receipt capture if no draft exists.'
+  }
+  return 'No Xero accounting target is mirrored yet. Check Xero Expenses drafts or create the spend-money transaction before reconciling.'
+}
+
+function bankLineToItem(row: BankEvidenceRow): WorkbenchItem {
+  const direction = row.direction === 'credit' ? 'income' : 'spend'
+  const amount = Math.abs(asNumber(row.amount))
+  const vendor = row.best_vendor_name || row.payee || row.particulars || row.reference || 'Bank line'
+  const description = [row.particulars, row.reference, row.bank_account].filter(Boolean).join(' · ') || null
+  const receiptState = row.evidence_status || row.receipt_match_status || 'unknown'
+  const hasReceipt = receiptCovered(row.evidence_status, row.receipt_match_status, row.has_approved_link)
+  const needsReceipt = !hasReceipt && direction === 'spend' && isReceiptGap(row.evidence_status, row.receipt_match_status)
+  const needsProject = isBlank(row.project_code)
+  const needsProjectReview = row.project_code === 'ACT-IN'
+  const needsReconciliation = row.status === 'unreconciled'
+  const draftHint = xeroDraftHint(row, hasReceipt, needsReceipt)
+
+  return {
+    id: row.id,
+    source: 'bank_lines',
+    direction,
+    date: row.date,
+    vendor,
+    description,
+    amount,
+    xeroStatus: row.status,
+    isReconciled: row.status === 'reconciled',
+    projectCode: row.project_code,
+    projectSource: row.project_source,
+    hasReceipt,
+    receiptState,
+    receiptSignal: row.best_source,
+    candidateCount: row.candidate_count || 0,
+    confidence: row.best_confidence == null ? null : asPercent(row.best_confidence),
+    rdEligible: row.rd_eligible,
+    rdCategory: row.rd_eligible ? 'eligible' : null,
+    needsProject,
+    needsProjectReview,
+    needsReceipt,
+    needsReconciliation,
+    needsXeroDraft: Boolean(draftHint),
+    xeroDraftHint: draftHint,
+    needsRdReview: false,
+    xeroReference: row.xero_transaction_id || row.matched_xero_transaction_id,
+    receiptEvidenceUrl: receiptEvidenceUrl(row.date, vendor),
+  }
+}
+
+function xeroTransactionToItem(row: XeroTransactionRow): WorkbenchItem {
+  const type = row.type || ''
+  const direction = type.startsWith('RECEIVE') ? 'income' : 'spend'
+  const amount = Math.abs(asNumber(row.total))
+  const vendor = row.contact_name || 'Xero transaction'
+  const description = firstLineDescription(row.line_items) || row.bank_account || row.xero_transaction_id || null
+  const isTransfer = type.includes('TRANSFER')
+  const hasReceipt = Boolean(row.has_attachments)
+  const needsReceipt = direction === 'spend' && !hasReceipt && !isTransfer && amount > 0
+  const needsProject = isBlank(row.project_code)
+  const needsProjectReview = row.project_code === 'ACT-IN' || (row.project_code_source || '').includes('vendor')
+  const needsReconciliation = row.is_reconciled === false
+
+  return {
+    id: row.id,
+    source: 'xero_transactions',
+    direction,
+    date: row.date,
+    vendor,
+    description,
+    amount,
+    xeroStatus: row.status,
+    isReconciled: row.is_reconciled,
+    projectCode: row.project_code,
+    projectSource: row.project_code_source,
+    hasReceipt,
+    receiptState: hasReceipt ? 'xero_attachment' : isTransfer ? 'transfer' : amount <= RECEIPT_THRESHOLD ? 'low_value_no_file' : 'needs_file',
+    receiptSignal: hasReceipt ? 'xero transaction attachment' : null,
+    candidateCount: 0,
+    confidence: null,
+    rdEligible: row.rd_eligible,
+    rdCategory: row.rd_category,
+    needsProject,
+    needsProjectReview,
+    needsReceipt,
+    needsReconciliation,
+    needsXeroDraft: false,
+    xeroDraftHint: null,
+    needsRdReview: row.rd_category === 'review',
+    xeroReference: row.xero_transaction_id,
+    receiptEvidenceUrl: receiptEvidenceUrl(row.date, vendor),
+  }
+}
+
+function xeroInvoiceToItem(row: XeroInvoiceRow): WorkbenchItem {
+  const direction = row.type === 'ACCREC' ? 'income' : 'spend'
+  const amount = Math.abs(asNumber(row.total))
+  const amountDue = asNumber(row.amount_due)
+  const vendor = row.contact_name || 'Xero invoice'
+  const description = firstLineDescription(row.line_items) || row.reference || row.invoice_number || null
+  const hasReceipt = Boolean(row.has_attachments)
+  const needsReceipt = direction === 'spend' && !hasReceipt && amount > 0
+  const needsProject = isBlank(row.project_code)
+  const needsProjectReview = row.project_code === 'ACT-IN' || (row.project_code_source || '').includes('vendor')
+
+  return {
+    id: row.id,
+    source: 'xero_invoices',
+    direction,
+    date: row.date,
+    vendor,
+    description,
+    amount,
+    xeroStatus: row.status,
+    isReconciled: row.status === 'PAID' || amountDue <= 0,
+    projectCode: row.project_code,
+    projectSource: row.project_code_source || row.income_type,
+    hasReceipt,
+    receiptState: hasReceipt ? 'xero_attachment' : amount <= RECEIPT_THRESHOLD ? 'low_value_no_file' : 'needs_file',
+    receiptSignal: hasReceipt ? 'xero invoice attachment' : null,
+    candidateCount: 0,
+    confidence: null,
+    rdEligible: null,
+    rdCategory: null,
+    needsProject,
+    needsProjectReview,
+    needsReceipt,
+    needsReconciliation: false,
+    needsXeroDraft: false,
+    xeroDraftHint: null,
+    needsRdReview: false,
+    xeroReference: row.invoice_number || row.xero_id,
+    receiptEvidenceUrl: receiptEvidenceUrl(row.date, vendor),
+  }
+}
+
+async function fetchPaged<T>(
+  label: string,
+  makeQuery: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>
+): Promise<T[]> {
+  const pageSize = 1000
+  const rows: T[] = []
+
+  for (let from = 0; from < 10000; from += pageSize) {
+    const { data, error } = await makeQuery(from, from + pageSize - 1)
+    if (error) throw new Error(`${label}: ${error.message}`)
+    const page = data || []
+    rows.push(...page)
+    if (page.length < pageSize) break
+  }
+
+  return rows
+}
+
+function matchesText(item: WorkbenchItem, q: string): boolean {
+  if (!q) return true
+  const haystack = [
+    item.vendor,
+    item.description,
+    item.projectCode,
+    item.projectSource,
+    item.xeroStatus,
+    item.receiptState,
+    item.xeroReference,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(q.toLowerCase())
+}
+
+function matchesStatus(item: WorkbenchItem, status: StatusFilter): boolean {
+  if (status === 'all') return true
+  if (status === 'needs_action') {
+    return item.needsProject || item.needsReceipt || item.needsReconciliation || item.needsRdReview
+  }
+  if (status === 'xero_drafts') return item.needsXeroDraft
+  if (status === 'receipt_gap') return item.needsReceipt
+  if (status === 'candidate_receipts') {
+    return item.receiptState === 'candidate' || item.receiptState === 'high_confidence_candidate'
+  }
+  if (status === 'no_receipt_needed') {
+    return item.receiptState === 'no_receipt_needed' || item.receiptState === 'low_value_no_file' || item.receiptState === 'transfer'
+  }
+  if (status === 'needs_project') return item.needsProject
+  if (status === 'project_review') return item.needsProjectReview
+  if (status === 'unreconciled') return item.needsReconciliation
+  if (status === 'rd_review') return item.needsRdReview
+  return true
+}
+
+function matchesProject(item: WorkbenchItem, project: string): boolean {
+  if (!project || project === 'all') return true
+  if (project === '__blank__') return item.needsProject
+  return item.projectCode === project
+}
+
+async function loadSummary() {
+  const rows = await execSql<SummaryRow>(
+    'finance workbench summary',
+    `
+      SELECT
+        (SELECT COUNT(*) FROM bank_statement_lines WHERE date >= '${FY_START}' AND date <= '${FY_END}') AS bank_lines,
+        (SELECT COUNT(*) FROM v_finance_bank_line_evidence WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND direction = 'debit' AND evidence_status IN ('uncovered','candidate','high_confidence_candidate')) AS bank_receipt_gaps,
+        (SELECT COALESCE(SUM(amount),0) FROM v_finance_bank_line_evidence WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND direction = 'debit' AND evidence_status IN ('uncovered','candidate','high_confidence_candidate')) AS bank_receipt_gap_value,
+        (SELECT COUNT(*) FROM v_finance_bank_line_evidence WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND evidence_status IN ('candidate','high_confidence_candidate')) AS bank_candidates,
+        (SELECT COUNT(*) FROM v_finance_bank_line_evidence WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND direction = 'debit' AND status = 'unreconciled' AND (xero_transaction_id IS NULL OR xero_transaction_id = '') AND (matched_xero_transaction_id IS NULL OR matched_xero_transaction_id = '')) AS xero_draft_candidates,
+        (SELECT COALESCE(SUM(amount),0) FROM v_finance_bank_line_evidence WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND direction = 'debit' AND status = 'unreconciled' AND (xero_transaction_id IS NULL OR xero_transaction_id = '') AND (matched_xero_transaction_id IS NULL OR matched_xero_transaction_id = '')) AS xero_draft_candidate_value,
+        (SELECT COUNT(*) FROM bank_statement_lines WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND status = 'unreconciled') AS bank_unreconciled,
+        (SELECT COALESCE(SUM(amount),0) FROM bank_statement_lines WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND status = 'unreconciled') AS bank_unreconciled_value,
+        (SELECT COUNT(*) FROM bank_statement_lines WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND (project_code IS NULL OR project_code = '')) AS bank_project_gaps,
+        (SELECT COUNT(*) FROM xero_transactions WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND (project_code IS NULL OR project_code = '')) AS xero_project_gaps,
+        (SELECT COUNT(*) FROM xero_invoices WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND (project_code IS NULL OR project_code = '')) AS invoice_project_gaps,
+        (
+          (SELECT COUNT(*) FROM bank_statement_lines WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND project_code = 'ACT-IN')
+          + (SELECT COUNT(*) FROM xero_transactions WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND project_code = 'ACT-IN')
+          + (SELECT COUNT(*) FROM xero_invoices WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND project_code = 'ACT-IN')
+        ) AS act_in_review,
+        (SELECT COUNT(*) FROM xero_transactions WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND rd_category = 'review') AS rd_review,
+        (SELECT COALESCE(SUM(ABS(total)),0) FROM xero_transactions WHERE date >= '${FY_START}' AND date <= '${FY_END}' AND rd_eligible = true AND type LIKE 'SPEND%') AS rd_eligible_spend
+    `
+  )
+
+  const row = rows[0]
+  return {
+    bankLines: asNumber(row?.bank_lines),
+    receiptGaps: asNumber(row?.bank_receipt_gaps),
+    receiptGapValue: asNumber(row?.bank_receipt_gap_value),
+    candidateReceipts: asNumber(row?.bank_candidates),
+    xeroDraftCandidates: asNumber(row?.xero_draft_candidates),
+    xeroDraftCandidateValue: asNumber(row?.xero_draft_candidate_value),
+    unreconciledBankLines: asNumber(row?.bank_unreconciled),
+    unreconciledValue: asNumber(row?.bank_unreconciled_value),
+    bankProjectGaps: asNumber(row?.bank_project_gaps),
+    xeroProjectGaps: asNumber(row?.xero_project_gaps),
+    invoiceProjectGaps: asNumber(row?.invoice_project_gaps),
+    actInReview: asNumber(row?.act_in_review),
+    rdReview: asNumber(row?.rd_review),
+    rdEligibleSpend: asNumber(row?.rd_eligible_spend),
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams
+  const source = (params.get('source') || 'bank_lines') as SourceFilter
+  const direction = (params.get('direction') || 'all') as DirectionFilter
+  const status = (params.get('status') || 'needs_action') as StatusFilter
+  const project = params.get('project') || 'all'
+  const q = (params.get('q') || '').trim()
+  const limit = Math.min(Math.max(parseInt(params.get('limit') || '300', 10), 50), 800)
+
+  try {
+    const [projectsResult, summary] = await Promise.all([
+      supabase
+        .from('projects')
+        .select('code, name, tier, status')
+        .not('code', 'is', null)
+        .or('status.is.null,status.neq.archived')
+        .order('tier', { ascending: true, nullsFirst: false })
+        .order('name', { ascending: true })
+        .limit(500),
+      loadSummary(),
+    ])
+
+    if (projectsResult.error) {
+      throw new Error(`projects: ${projectsResult.error.message}`)
+    }
+
+    const items: WorkbenchItem[] = []
+
+    if (source === 'all' || source === 'bank_lines') {
+      const bankRows = await fetchPaged<BankEvidenceRow>('bank evidence', (from, to) =>
+        supabase
+          .from('v_finance_bank_line_evidence')
+          .select('id, date, direction, payee, particulars, reference, amount, status, bank_account, project_code, project_source, rd_eligible, receipt_match_status, evidence_status, candidate_count, best_confidence, best_source, best_vendor_name, has_approved_link, xero_transaction_id, matched_xero_transaction_id')
+          .gte('date', FY_START)
+          .lte('date', FY_END)
+          .order('date', { ascending: false })
+          .range(from, to)
+      )
+      items.push(...bankRows.map(bankLineToItem))
+    }
+
+    if (source === 'all' || source === 'xero_transactions') {
+      const txRows = await fetchPaged<XeroTransactionRow>('xero transactions', (from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('id, xero_transaction_id, type, contact_name, bank_account, project_code, project_code_source, total, status, date, line_items, has_attachments, is_reconciled, rd_eligible, rd_category')
+          .gte('date', FY_START)
+          .lte('date', FY_END)
+          .order('date', { ascending: false })
+          .range(from, to)
+      )
+      items.push(...txRows.map(xeroTransactionToItem))
+    }
+
+    if (source === 'all' || source === 'xero_invoices') {
+      const invoiceRows = await fetchPaged<XeroInvoiceRow>('xero invoices', (from, to) =>
+        supabase
+          .from('xero_invoices')
+          .select('id, xero_id, invoice_number, type, status, contact_name, date, total, amount_due, amount_paid, line_items, has_attachments, reference, project_code, project_code_source, income_type')
+          .gte('date', FY_START)
+          .lte('date', FY_END)
+          .order('date', { ascending: false })
+          .range(from, to)
+      )
+      items.push(...invoiceRows.map(xeroInvoiceToItem))
+    }
+
+    const filtered = items
+      .filter((item) => direction === 'all' || item.direction === direction)
+      .filter((item) => matchesStatus(item, status))
+      .filter((item) => matchesProject(item, project))
+      .filter((item) => matchesText(item, q))
+      .sort((a, b) => {
+        if (status === 'xero_drafts') {
+          if (a.hasReceipt !== b.hasReceipt) return a.hasReceipt ? -1 : 1
+          if ((a.candidateCount > 0) !== (b.candidateCount > 0)) return a.candidateCount > 0 ? -1 : 1
+          if (a.amount !== b.amount) return b.amount - a.amount
+        }
+        if (a.needsXeroDraft !== b.needsXeroDraft) return a.needsXeroDraft ? -1 : 1
+        if (a.needsReceipt !== b.needsReceipt) return a.needsReceipt ? -1 : 1
+        if (a.needsProject !== b.needsProject) return a.needsProject ? -1 : 1
+        if (a.needsReconciliation !== b.needsReconciliation) return a.needsReconciliation ? -1 : 1
+        return (new Date(b.date || '1900-01-01').getTime() || 0) - (new Date(a.date || '1900-01-01').getTime() || 0)
+      })
+
+    return NextResponse.json({
+      fy: { start: FY_START, end: FY_END },
+      filters: { source, direction, status, project, q, limit },
+      summary,
+      projects: ((projectsResult.data || []) as ProjectOption[]).map((p) => ({
+        code: p.code,
+        name: p.name,
+        tier: p.tier,
+        status: p.status,
+      })),
+      totalMatching: filtered.length,
+      items: filtered.slice(0, limit),
+    })
+  } catch (error) {
+    console.error('[finance/workbench] GET failed:', error)
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}
+
+function rdUpdate(rdCategory: unknown, source: SourceFilter) {
+  if (typeof rdCategory !== 'string') return {}
+  if (source === 'xero_invoices') return {}
+
+  if (source === 'bank_lines') {
+    if (rdCategory === 'core' || rdCategory === 'supporting') return { rd_eligible: true }
+    if (rdCategory === 'review' || rdCategory === 'none') return { rd_eligible: false }
+    return {}
+  }
+
+  if (rdCategory === 'core' || rdCategory === 'supporting') {
+    return { rd_eligible: true, rd_category: rdCategory }
+  }
+  if (rdCategory === 'review') return { rd_eligible: false, rd_category: 'review' }
+  if (rdCategory === 'none') return { rd_eligible: false, rd_category: null }
+  return {}
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const source = body.source as SourceFilter
+    const id = typeof body.id === 'string' ? body.id : null
+    const hasProjectCode = Object.prototype.hasOwnProperty.call(body, 'projectCode')
+    const projectCode = hasProjectCode && typeof body.projectCode === 'string' && body.projectCode.trim()
+      ? body.projectCode.trim()
+      : null
+
+    if (!id) return NextResponse.json({ error: 'id required' }, { status: 400 })
+    if (!['bank_lines', 'xero_transactions', 'xero_invoices'].includes(source)) {
+      return NextResponse.json({ error: 'invalid source' }, { status: 400 })
+    }
+
+    if (projectCode) {
+      const { data: project, error: projectError } = await supabase
+        .from('projects')
+        .select('code')
+        .eq('code', projectCode)
+        .maybeSingle()
+      if (projectError) return NextResponse.json({ error: projectError.message }, { status: 500 })
+      if (!project) return NextResponse.json({ error: `Unknown project code: ${projectCode}` }, { status: 400 })
+    }
+
+    const rd = rdUpdate(body.rdCategory, source)
+    const updates: Record<string, unknown> = { ...rd }
+    if (hasProjectCode) updates.project_code = projectCode
+
+    if (source === 'bank_lines') {
+      if (hasProjectCode) updates.project_source = 'manual_workbench'
+      const { error } = await supabase.from('bank_statement_lines').update(updates).eq('id', id)
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    } else if (source === 'xero_transactions') {
+      if (hasProjectCode) updates.project_code_source = 'manual_workbench'
+      updates.updated_at = new Date().toISOString()
+      const { error } = await supabase.from('xero_transactions').update(updates).eq('id', id)
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    } else if (source === 'xero_invoices') {
+      if (hasProjectCode) updates.project_code_source = 'manual_workbench'
+      updates.updated_at = new Date().toISOString()
+      const { error } = await supabase.from('xero_invoices').update(updates).eq('id', id)
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ ok: true, id, source, projectCode, rdCategory: body.rdCategory || null })
+  } catch (error) {
+    console.error('[finance/workbench] PATCH failed:', error)
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/api/finance/workbench/route.ts
+++ b/apps/command-center/src/app/api/finance/workbench/route.ts
@@ -90,6 +90,16 @@ interface XeroInvoiceRow {
   income_type: string | null
 }
 
+interface AISuggestion {
+  id: string
+  projectCode: string
+  confidence: number
+  reason: string | null
+  riskFlags: string[]
+  model: string
+  blockedForAutoApply: boolean
+}
+
 interface WorkbenchItem {
   id: string
   source: SourceFilter
@@ -118,6 +128,7 @@ interface WorkbenchItem {
   needsRdReview: boolean
   xeroReference: string | null
   receiptEvidenceUrl: string
+  aiSuggestion: AISuggestion | null
 }
 
 interface SummaryRow {
@@ -260,6 +271,7 @@ function bankLineToItem(row: BankEvidenceRow): WorkbenchItem {
     needsRdReview: false,
     xeroReference: row.xero_transaction_id || row.matched_xero_transaction_id,
     receiptEvidenceUrl: receiptEvidenceUrl(row.date, vendor),
+    aiSuggestion: null,
   }
 }
 
@@ -304,6 +316,7 @@ function xeroTransactionToItem(row: XeroTransactionRow): WorkbenchItem {
     needsRdReview: row.rd_category === 'review',
     xeroReference: row.xero_transaction_id,
     receiptEvidenceUrl: receiptEvidenceUrl(row.date, vendor),
+    aiSuggestion: null,
   }
 }
 
@@ -346,6 +359,7 @@ function xeroInvoiceToItem(row: XeroInvoiceRow): WorkbenchItem {
     needsRdReview: false,
     xeroReference: row.invoice_number || row.xero_id,
     receiptEvidenceUrl: receiptEvidenceUrl(row.date, vendor),
+    aiSuggestion: null,
   }
 }
 
@@ -455,6 +469,88 @@ async function loadSummary() {
   }
 }
 
+// Map workbench source -> AI suggestions source_table column value
+function sourceToAiTable(source: SourceFilter): string | null {
+  switch (source) {
+    case 'bank_lines': return 'bank_statement_lines'
+    case 'xero_transactions': return 'xero_transactions'
+    case 'xero_invoices': return null // grader does not currently emit suggestions for invoices
+    default: return null
+  }
+}
+
+const AI_NO_AUTO_APPLY = new Set(['ASK_USER', 'SL_REVIEW'])
+
+// Attach the best open suggestion (highest confidence, not applied, not rejected)
+// per (source_table, source_record_id) pair to each visible item.
+async function enrichWithAISuggestions(items: WorkbenchItem[]): Promise<void> {
+  // Build buckets by source_table
+  const buckets = new Map<string, string[]>()
+  for (const item of items) {
+    const tbl = sourceToAiTable(item.source)
+    if (!tbl) continue
+    if (!buckets.has(tbl)) buckets.set(tbl, [])
+    buckets.get(tbl)!.push(item.id)
+  }
+  if (!buckets.size) return
+
+  // Fetch all open suggestions for the visible IDs, per table
+  type Row = {
+    id: string
+    source_table: string
+    source_record_id: string
+    suggested_project_code: string
+    confidence: number
+    reason: string | null
+    risk_flags: string[] | null
+    model: string
+  }
+  const allRows: Row[] = []
+  await Promise.all(Array.from(buckets.entries()).map(async ([tbl, ids]) => {
+    if (!ids.length) return
+    const { data, error } = await supabase
+      .from('finance_ai_routing_suggestions')
+      .select('id, source_table, source_record_id, suggested_project_code, confidence, reason, risk_flags, model')
+      .eq('source_table', tbl)
+      .eq('applied_to_source', false)
+      .is('rejected_at', null)
+      .in('source_record_id', ids)
+      .order('confidence', { ascending: false })
+    if (error) {
+      console.warn(`[workbench] AI suggestions lookup (${tbl}) failed: ${error.message}`)
+      return
+    }
+    if (data) allRows.push(...(data as Row[]))
+  }))
+
+  // Best (highest-confidence) suggestion per (table, recordId)
+  const best = new Map<string, Row>()
+  for (const r of allRows) {
+    const key = `${r.source_table}:${r.source_record_id}`
+    const existing = best.get(key)
+    if (!existing || Number(r.confidence) > Number(existing.confidence)) {
+      best.set(key, r)
+    }
+  }
+
+  // Attach to items in place
+  for (const item of items) {
+    const tbl = sourceToAiTable(item.source)
+    if (!tbl) continue
+    const found = best.get(`${tbl}:${item.id}`)
+    if (!found) continue
+    item.aiSuggestion = {
+      id: found.id,
+      projectCode: found.suggested_project_code,
+      confidence: Number(found.confidence),
+      reason: found.reason,
+      riskFlags: Array.isArray(found.risk_flags) ? found.risk_flags : [],
+      model: found.model,
+      blockedForAutoApply: AI_NO_AUTO_APPLY.has(found.suggested_project_code),
+    }
+  }
+}
+
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams
   const source = (params.get('source') || 'bank_lines') as SourceFilter
@@ -540,6 +636,9 @@ export async function GET(request: NextRequest) {
         return (new Date(b.date || '1900-01-01').getTime() || 0) - (new Date(a.date || '1900-01-01').getTime() || 0)
       })
 
+    const visibleItems = filtered.slice(0, limit)
+    await enrichWithAISuggestions(visibleItems)
+
     return NextResponse.json({
       fy: { start: FY_START, end: FY_END },
       filters: { source, direction, status, project, q, limit },
@@ -551,7 +650,7 @@ export async function GET(request: NextRequest) {
         status: p.status,
       })),
       totalMatching: filtered.length,
-      items: filtered.slice(0, limit),
+      items: visibleItems,
     })
   } catch (error) {
     console.error('[finance/workbench] GET failed:', error)

--- a/apps/command-center/src/app/api/finance/xero-page-copilot/execute/route.ts
+++ b/apps/command-center/src/app/api/finance/xero-page-copilot/execute/route.ts
@@ -1,0 +1,336 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Buffer } from 'node:buffer'
+import { supabase } from '@/lib/supabase'
+
+// Server-side dynamic import to avoid bundling node libs in client.
+// xero-client lives in scripts/lib so we import it relative.
+import { createXeroClient } from '../../../../../../../../scripts/lib/finance/xero-client.mjs'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+type Action =
+  | 'attach_evidence'        // upload receipt file to existing Xero BankTransaction
+  | 'find_match_bill'        // create a Payment matching a bank line to an existing Bill
+  | 'transfer'               // create a BankTransfer between two accounts
+
+interface ExecuteRequestRow {
+  action: Action
+  // For attach_evidence:
+  xeroBankTransactionId?: string
+  receiptStoragePath?: string
+  receiptUrl?: string
+  receiptFilename?: string
+  // For find_match_bill:
+  xeroInvoiceId?: string
+  xeroInvoiceNumber?: string
+  amount?: number
+  date?: string
+  bankAccountCode?: string
+  // For transfer:
+  fromAccountCode?: string
+  toAccountCode?: string
+  reference?: string
+  // Bookkeeping
+  bankLineId?: string
+}
+
+interface ExecuteRequest {
+  rows: ExecuteRequestRow[]
+  dryRun?: boolean
+}
+
+interface RowResult {
+  index: number
+  action: Action
+  ok: boolean
+  message: string
+  xeroId?: string | null
+  dryRun?: boolean
+}
+
+function isHttpUrl(value: unknown) {
+  return typeof value === 'string' && /^https?:\/\//i.test(value)
+}
+
+async function loadReceiptBytes(row: ExecuteRequestRow): Promise<{ buffer: Buffer; filename: string; mime: string } | null> {
+  // Prefer storage path (signed URL won't work cross-region for Xero PUT).
+  if (row.receiptStoragePath) {
+    const cleaned = row.receiptStoragePath.replace(/^receipt-attachments\//, '')
+    const { data, error } = await supabase.storage.from('receipt-attachments').download(cleaned)
+    if (error || !data) return null
+    const arrayBuffer = await data.arrayBuffer()
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      filename: row.receiptFilename || cleaned.split('/').pop() || 'receipt.pdf',
+      mime: data.type || 'application/pdf',
+    }
+  }
+  if (row.receiptUrl && isHttpUrl(row.receiptUrl)) {
+    const res = await fetch(row.receiptUrl)
+    if (!res.ok) return null
+    const arrayBuffer = await res.arrayBuffer()
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      filename: row.receiptFilename || row.receiptUrl.split('/').pop() || 'receipt.pdf',
+      mime: res.headers.get('content-type') || 'application/pdf',
+    }
+  }
+  return null
+}
+
+async function executeAttachEvidence(
+  xero: Awaited<ReturnType<typeof createXeroClient>>,
+  row: ExecuteRequestRow,
+  dryRun: boolean,
+): Promise<RowResult> {
+  if (!row.xeroBankTransactionId) {
+    return {
+      index: 0,
+      action: 'attach_evidence',
+      ok: false,
+      message: 'Missing xeroBankTransactionId',
+    }
+  }
+  if (!row.receiptStoragePath && !row.receiptUrl) {
+    return {
+      index: 0,
+      action: 'attach_evidence',
+      ok: false,
+      message: 'Missing receiptStoragePath or receiptUrl',
+    }
+  }
+
+  if (dryRun) {
+    return {
+      index: 0,
+      action: 'attach_evidence',
+      ok: true,
+      message: `Would PUT receipt to BankTransactions/${row.xeroBankTransactionId}/Attachments/${row.receiptFilename || 'receipt.pdf'}`,
+      xeroId: row.xeroBankTransactionId,
+      dryRun: true,
+    }
+  }
+
+  const bytes = await loadReceiptBytes(row)
+  if (!bytes) {
+    return {
+      index: 0,
+      action: 'attach_evidence',
+      ok: false,
+      message: 'Failed to load receipt bytes from storage',
+    }
+  }
+
+  try {
+    await xero.uploadAttachment(
+      'BankTransactions',
+      row.xeroBankTransactionId,
+      bytes.filename,
+      bytes.buffer,
+      bytes.mime,
+    )
+
+    // Mark the bank txn mirror as having an attachment so future runs skip.
+    await supabase
+      .from('xero_transactions')
+      .update({ has_attachments: true })
+      .eq('xero_transaction_id', row.xeroBankTransactionId)
+
+    return {
+      index: 0,
+      action: 'attach_evidence',
+      ok: true,
+      message: `Attached ${bytes.filename} to BankTransactions/${row.xeroBankTransactionId}`,
+      xeroId: row.xeroBankTransactionId,
+    }
+  } catch (err) {
+    return {
+      index: 0,
+      action: 'attach_evidence',
+      ok: false,
+      message: (err as Error).message?.slice(0, 300) || 'Upload failed',
+    }
+  }
+}
+
+async function executeFindMatchBill(
+  xero: Awaited<ReturnType<typeof createXeroClient>>,
+  row: ExecuteRequestRow,
+  dryRun: boolean,
+): Promise<RowResult> {
+  if (!row.xeroInvoiceId || !row.amount || !row.date || !row.bankAccountCode) {
+    return {
+      index: 0,
+      action: 'find_match_bill',
+      ok: false,
+      message: 'Missing xeroInvoiceId / amount / date / bankAccountCode',
+    }
+  }
+
+  if (dryRun) {
+    return {
+      index: 0,
+      action: 'find_match_bill',
+      ok: true,
+      message: `Would POST Payment to Invoice ${row.xeroInvoiceNumber || row.xeroInvoiceId} for $${row.amount} dated ${row.date} from account ${row.bankAccountCode}`,
+      xeroId: row.xeroInvoiceId,
+      dryRun: true,
+    }
+  }
+
+  try {
+    const response = await xero.post('Payments', {
+      Payments: [
+        {
+          Invoice: { InvoiceID: row.xeroInvoiceId },
+          Account: { Code: row.bankAccountCode },
+          Date: row.date,
+          Amount: row.amount,
+          Reference: row.reference || `Match ${row.xeroInvoiceNumber || ''}`.trim(),
+        },
+      ],
+    })
+    const paymentId = response?.Payments?.[0]?.PaymentID || null
+
+    return {
+      index: 0,
+      action: 'find_match_bill',
+      ok: true,
+      message: `Created Payment ${paymentId} for Invoice ${row.xeroInvoiceNumber || row.xeroInvoiceId}`,
+      xeroId: paymentId,
+    }
+  } catch (err) {
+    return {
+      index: 0,
+      action: 'find_match_bill',
+      ok: false,
+      message: (err as Error).message?.slice(0, 300) || 'Payment creation failed',
+    }
+  }
+}
+
+async function executeTransfer(
+  xero: Awaited<ReturnType<typeof createXeroClient>>,
+  row: ExecuteRequestRow,
+  dryRun: boolean,
+): Promise<RowResult> {
+  if (!row.fromAccountCode || !row.toAccountCode || !row.amount || !row.date) {
+    return {
+      index: 0,
+      action: 'transfer',
+      ok: false,
+      message: 'Missing fromAccountCode / toAccountCode / amount / date',
+    }
+  }
+
+  if (dryRun) {
+    return {
+      index: 0,
+      action: 'transfer',
+      ok: true,
+      message: `Would POST BankTransfer ${row.fromAccountCode} → ${row.toAccountCode} for $${row.amount} dated ${row.date}`,
+      dryRun: true,
+    }
+  }
+
+  try {
+    const response = await xero.post('BankTransfers', {
+      BankTransfers: [
+        {
+          FromBankAccount: { Code: row.fromAccountCode },
+          ToBankAccount: { Code: row.toAccountCode },
+          Amount: row.amount,
+          Date: row.date,
+          Reference: row.reference || 'Internal transfer',
+        },
+      ],
+    })
+    const transferId = response?.BankTransfers?.[0]?.BankTransferID || null
+
+    return {
+      index: 0,
+      action: 'transfer',
+      ok: true,
+      message: `Created BankTransfer ${transferId}`,
+      xeroId: transferId,
+    }
+  } catch (err) {
+    return {
+      index: 0,
+      action: 'transfer',
+      ok: false,
+      message: (err as Error).message?.slice(0, 300) || 'Transfer creation failed',
+    }
+  }
+}
+
+export async function POST(request: NextRequest) {
+  let body: ExecuteRequest
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const rows = Array.isArray(body.rows) ? body.rows : []
+  const dryRun = Boolean(body.dryRun)
+
+  if (!rows.length) {
+    return NextResponse.json({ error: 'Empty rows[] payload' }, { status: 400 })
+  }
+
+  let xero
+  try {
+    xero = await createXeroClient(supabase)
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Xero client init failed: ${(err as Error).message}` },
+      { status: 500 },
+    )
+  }
+
+  const results: RowResult[] = []
+
+  for (let i = 0; i < rows.length; i += 1) {
+    const row = rows[i]
+    let res: RowResult
+
+    if (row.action === 'attach_evidence') {
+      res = await executeAttachEvidence(xero, row, dryRun)
+    } else if (row.action === 'find_match_bill') {
+      res = await executeFindMatchBill(xero, row, dryRun)
+    } else if (row.action === 'transfer') {
+      res = await executeTransfer(xero, row, dryRun)
+    } else {
+      res = {
+        index: i,
+        action: row.action,
+        ok: false,
+        message: `Unsupported action "${row.action}" — only attach_evidence, find_match_bill, transfer are wired. Use Xero UI for the rest.`,
+      }
+    }
+
+    res.index = i
+    results.push(res)
+  }
+
+  const summary = results.reduce(
+    (acc, r) => {
+      acc.total += 1
+      if (r.ok) acc.ok += 1
+      else acc.failed += 1
+      return acc
+    },
+    { total: 0, ok: 0, failed: 0 },
+  )
+
+  return NextResponse.json({
+    dryRun,
+    summary,
+    results,
+    note: dryRun
+      ? 'Dry run — no Xero writes. Pass dryRun=false to execute.'
+      : 'Executed against Xero. Check results[] for per-row status.',
+  })
+}

--- a/apps/command-center/src/app/api/finance/xero-page-copilot/route.ts
+++ b/apps/command-center/src/app/api/finance/xero-page-copilot/route.ts
@@ -1,0 +1,732 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+const DATE_WINDOW_DAYS = 5
+const BANK_LINE_WINDOW_DAYS = 3
+
+const MONTHS: Record<string, string> = {
+  jan: '01',
+  feb: '02',
+  mar: '03',
+  apr: '04',
+  may: '05',
+  jun: '06',
+  jul: '07',
+  aug: '08',
+  sep: '09',
+  oct: '10',
+  nov: '11',
+  dec: '12',
+}
+
+type SuggestedAction =
+  | 'click_ok_existing_match'
+  | 'wrong_xero_suggestion'
+  | 'transfer'
+  | 'find_match_bill'
+  | 'create_with_evidence'
+  | 'create_low_value'
+  | 'refund_review'
+  | 'skip_done'
+  | 'bookkeeper_review'
+  | 'unsafe_create'
+
+interface ParsedXeroRow {
+  rowNumber: number
+  date: string
+  description: string
+  transactionType: string
+  amount: number
+  hasOkButton: boolean
+  suggestedWho: string | null
+  suggestedAccount: string | null
+  suggestedWhy: string | null
+  suggestedTaxRate: string | null
+  existingMatchLabel: string | null
+  rawBlock: string[]
+}
+
+interface BankLineRow {
+  id: string
+  date: string | null
+  payee: string | null
+  particulars: string | null
+  reference: string | null
+  amount: number | string | null
+  direction: string | null
+  status: string | null
+  bank_account: string | null
+  project_code: string | null
+  project_source: string | null
+  receipt_match_status: string | null
+  receipt_match_score: number | string | null
+}
+
+interface EvidenceRow extends BankLineRow {
+  evidence_status?: string | null
+  best_confidence?: number | string | null
+  best_source?: string | null
+  best_vendor_name?: string | null
+  candidate_count?: number | string | null
+  has_approved_link?: boolean | null
+  receipt_candidates?: unknown
+}
+
+interface XeroInvoiceRow {
+  id: string
+  xero_id: string | null
+  invoice_number: string | null
+  type: string | null
+  status: string | null
+  contact_name: string | null
+  date: string | null
+  total: number | string | null
+  amount_due: number | string | null
+  amount_paid: number | string | null
+  has_attachments: boolean | null
+  reference: string | null
+  project_code: string | null
+  project_code_source: string | null
+}
+
+interface RecommendedFields {
+  who: string
+  account: string
+  why: string
+  taxRate: string
+}
+
+function asNumber(value: unknown): number {
+  const number = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(number) ? number : 0
+}
+
+function absAmount(value: unknown): number {
+  return Math.abs(asNumber(value))
+}
+
+function moneyCents(value: unknown): number {
+  return Math.round(absAmount(value) * 100)
+}
+
+function isAmountClose(a: unknown, b: unknown, toleranceCents = 2): boolean {
+  return Math.abs(moneyCents(a) - moneyCents(b)) <= toleranceCents
+}
+
+function cleanText(value: unknown): string {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+const GENERIC_WORDS = new Set([
+  'and',
+  'australia',
+  'australian',
+  'bank',
+  'brisbane',
+  'card',
+  'co',
+  'company',
+  'credit',
+  'group',
+  'internet',
+  'limited',
+  'ltd',
+  'melbourne',
+  'payment',
+  'purchase',
+  'pty',
+  'sydney',
+  'the',
+  'transfer',
+  'visa',
+])
+
+function tokens(value: unknown): string[] {
+  return cleanText(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_WORDS.has(token))
+}
+
+function vendorScore(needle: unknown, haystack: unknown): number {
+  const left = cleanText(needle)
+  const right = cleanText(haystack)
+  if (!left || !right) return 0
+  if (left === right) return 1
+  if (left.includes(right) || right.includes(left)) return 0.95
+
+  const leftTokens = tokens(left)
+  const rightTokens = new Set(tokens(right))
+  if (!leftTokens.length || !rightTokens.size) return 0
+  return leftTokens.filter((token) => rightTokens.has(token)).length / leftTokens.length
+}
+
+function dateDeltaDays(a: string | null, b: string | null): number | null {
+  if (!a || !b) return null
+  const first = new Date(`${a}T00:00:00`).getTime()
+  const second = new Date(`${b}T00:00:00`).getTime()
+  if (!Number.isFinite(first) || !Number.isFinite(second)) return null
+  return Math.round((second - first) / 86400000)
+}
+
+function addDays(date: string, delta: number): string {
+  const value = new Date(`${date}T00:00:00`)
+  value.setDate(value.getDate() + delta)
+  return value.toISOString().slice(0, 10)
+}
+
+function isDateLine(line: string): boolean {
+  return /^\d{1,2}\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{4}$/i.test(line.trim())
+}
+
+function parseDateLine(line: string): string | null {
+  const match = line.trim().match(/^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})$/)
+  if (!match) return null
+  const [, day, rawMonth, year] = match
+  const month = MONTHS[rawMonth.toLowerCase()]
+  if (!month) return null
+  return `${year}-${month}-${day.padStart(2, '0')}`
+}
+
+function parseMoneyLine(line: string): number | null {
+  const trimmed = line.trim()
+  if (!/^-?\$?\(?\d[\d,]*(?:\.\d{2})?\)?$/.test(trimmed)) return null
+  const negative = trimmed.includes('-') || (trimmed.startsWith('(') && trimmed.endsWith(')'))
+  const number = Number(trimmed.replace(/[$,()]/g, '').replace('-', ''))
+  if (!Number.isFinite(number)) return null
+  return negative ? -number : number
+}
+
+function looksLikeXeroRowStart(lines: string[], index: number): boolean {
+  if (!isDateLine(lines[index])) return false
+  for (let cursor = index + 1; cursor < lines.length; cursor += 1) {
+    if (isDateLine(lines[cursor])) return false
+    if (/X{6,}\d*/i.test(lines[cursor])) return true
+  }
+  return false
+}
+
+function valueAfterLabel(block: string[], label: string): string | null {
+  const index = block.findIndex((line) => line.toLowerCase() === label.toLowerCase())
+  if (index < 0) return null
+  for (const line of block.slice(index + 1)) {
+    if (['who', 'what', 'why', 'options', 'add details'].includes(line.toLowerCase())) return null
+    if (/^(name of the contact|choose the account|enter a description|select a bank account)/i.test(line)) return null
+    if (line.trim()) return line.trim()
+  }
+  return null
+}
+
+function parseExistingMatch(block: string[]): string | null {
+  const okIndex = block.findIndex((line) => line === 'OK')
+  const searchFrom = okIndex >= 0 ? okIndex + 1 : 0
+  const matchIndex = block.slice(searchFrom).findIndex((line) => /^Payment:/i.test(line))
+  if (matchIndex >= 0) return block[searchFrom + matchIndex]
+  return null
+}
+
+function matchedVendor(label: string | null): string {
+  return String(label || '')
+    .replace(/^Payment:\s*/i, '')
+    .replace(/^Bill:\s*/i, '')
+    .replace(/^Spend Money:\s*/i, '')
+    .replace(/\s+\d[\d,]*(?:\.\d{2})?$/, '')
+    .trim()
+}
+
+function recommendedFields(row: ParsedXeroRow, bankLine?: BankLineRow | null): RecommendedFields {
+  const text = cleanText(`${row.description} ${bankLine?.payee || ''} ${bankLine?.particulars || ''} ${bankLine?.reference || ''}`)
+  const vendor = row.suggestedWho || bankLine?.payee || row.description.split(/\s+/).slice(0, 4).join(' ')
+  const amount = absAmount(row.amount)
+  const underThreshold = amount <= 82.5
+  const underThresholdReason = underThreshold ? ' - no invoice required under $82.50; keep business purpose clear' : ''
+
+  if (isTransfer(row)) {
+    return {
+      who: '',
+      account: 'Transfer',
+      why: `NAB Visa card repayment/internal transfer - ${bankLine?.reference || 'card ending 1656'}`,
+      taxRate: 'BAS Excluded',
+    }
+  }
+
+  if (/belong|telstra|dialpad|starlink/.test(text)) {
+    return {
+      who: vendor,
+      account: '489 - Telephone & Internet',
+      why: `${vendor} phone/internet service${underThresholdReason}`,
+      taxRate: 'GST on Expenses',
+    }
+  }
+
+  if (/linktree|linkedin|squarespace|webflow|openai|anthropic|claude|notion|figma|vercel|railway|supabase|zapier|bitwarden|codeguide|descript|mighty|warp|cognition/.test(text)) {
+    const taxRate = /linkedin|openai|anthropic|claude|notion|figma|vercel|railway|supabase|zapier|bitwarden|codeguide|descript|mighty|warp|cognition|webflow/.test(text)
+      ? 'GST Free Expenses'
+      : 'GST on Expenses'
+    return {
+      who: vendor,
+      account: '485 - Subscriptions',
+      why: `${vendor} subscription${underThresholdReason}`,
+      taxRate,
+    }
+  }
+
+  if (/qantas|virgin|avis|budget|booking|airbnb|hotel|novotel|dayuse/.test(text)) {
+    return {
+      who: vendor,
+      account: '493 - Travel - National',
+      why: `${vendor} travel-related spend`,
+      taxRate: 'GST on Expenses',
+    }
+  }
+
+  if (/cabfare|taxi|uber/.test(text)) {
+    return {
+      who: vendor,
+      account: '452 - Parking, Tolls & Taxis',
+      why: `${vendor} travel/taxi/rideshare spend${underThresholdReason}`,
+      taxRate: 'GST on Expenses',
+    }
+  }
+
+  if (/fuel|ampol|bp |liberty|shell|caltex|eg group|reddy express/.test(text)) {
+    return {
+      who: vendor,
+      account: '449 - MV - Fuel & Oil',
+      why: `${vendor} fuel/motor vehicle spend`,
+      taxRate: 'GST on Expenses',
+    }
+  }
+
+  if (/bunnings|stratco|electrical|hardware|kennards|trailer|tools|sydney tools/.test(text)) {
+    return {
+      who: vendor,
+      account: '409 - Client to Advise',
+      why: `${vendor} supplies/equipment - confirm project and account`,
+      taxRate: 'GST on Expenses',
+    }
+  }
+
+  if (underThreshold) {
+    return {
+      who: vendor,
+      account: '429 - General Expenses',
+      why: `${vendor}${underThresholdReason}`,
+      taxRate: 'GST on Expenses',
+    }
+  }
+
+  return {
+    who: vendor,
+    account: '409 - Client to Advise',
+    why: `${vendor} - confirm receipt, project, and account before reconciling`,
+    taxRate: 'GST on Expenses',
+  }
+}
+
+function existingMatchVendorScore(row: ParsedXeroRow): number {
+  const vendor = matchedVendor(row.existingMatchLabel)
+  if (!vendor) return 0
+  return vendorScore(row.description, vendor)
+}
+
+function parseTaxRate(block: string[]): string | null {
+  return block.find((line) => /^(GST on Expenses|GST Free Expenses|BAS Excluded|Tax Rate)$/i.test(line.trim())) || null
+}
+
+function parseXeroPage(rawText: string): ParsedXeroRow[] {
+  const lines = rawText.split(/\r?\n/).map((line) => line.trim()).filter(Boolean)
+  const starts = lines
+    .map((line, index) => (looksLikeXeroRowStart(lines, index) ? index : -1))
+    .filter((index) => index >= 0)
+
+  return starts.map((start, rowIndex) => {
+    const end = starts[rowIndex + 1] ?? lines.length
+    const block = lines.slice(start, end)
+    const date = parseDateLine(block[0]) || ''
+    const maskedIndex = block.findIndex((line) => /X{6,}\d*/i.test(line))
+    const description = block.slice(1, maskedIndex >= 0 ? maskedIndex : 2).join(' ').trim()
+    const typeLine = block.slice(maskedIndex + 1).find((line) => /Credit Card|Bank|Payment|Refund|Purchase/i.test(line)) || ''
+    const amount = block.map(parseMoneyLine).find((value) => value !== null) ?? 0
+
+    return {
+      rowNumber: rowIndex + 1,
+      date,
+      description,
+      transactionType: typeLine,
+      amount,
+      hasOkButton: block.includes('OK'),
+      suggestedWho: valueAfterLabel(block, 'Who'),
+      suggestedAccount: valueAfterLabel(block, 'What'),
+      suggestedWhy: valueAfterLabel(block, 'Why'),
+      suggestedTaxRate: parseTaxRate(block),
+      existingMatchLabel: parseExistingMatch(block),
+      rawBlock: block,
+    }
+  }).filter((row) => row.date && row.description && row.amount !== 0)
+}
+
+function receiptEvidenceUrl(row: ParsedXeroRow): string {
+  const params = new URLSearchParams()
+  const month = Number(row.date.slice(5, 7))
+  const quarter = month >= 10 && month <= 12 ? 'Q2' : month >= 1 && month <= 3 ? 'Q3' : month >= 4 && month <= 6 ? 'Q4' : 'Q1'
+  params.set('quarter', quarter)
+  params.set('status', 'all')
+  params.set('search', row.description.split(/\s+/).slice(0, 3).join(' '))
+  return `/finance/receipt-evidence?${params.toString()}`
+}
+
+function xeroBillUrl(invoice: XeroInvoiceRow): string {
+  if (!invoice.xero_id) return 'https://go.xero.com/AccountsPayable/Search.aspx'
+  return `https://go.xero.com/AccountsPayable/View.aspx?InvoiceID=${encodeURIComponent(invoice.xero_id)}`
+}
+
+function bestBankLineMatch(row: ParsedXeroRow, bankLines: BankLineRow[]) {
+  const candidates = bankLines
+    .map((line) => {
+      const delta = dateDeltaDays(row.date, line.date)
+      const score = vendorScore(row.description, `${line.payee || ''} ${line.particulars || ''} ${line.reference || ''}`)
+      return { line, delta, score }
+    })
+    .filter(({ line, delta, score }) => (
+      isAmountClose(row.amount, line.amount)
+      && delta !== null
+      && Math.abs(delta) <= BANK_LINE_WINDOW_DAYS
+      && (score >= 0.25 || cleanText(row.description).includes('internet payment'))
+    ))
+    .sort((a, b) => {
+      const scoreDiff = b.score - a.score
+      if (Math.abs(scoreDiff) > 0.001) return scoreDiff
+      return Math.abs(a.delta || 0) - Math.abs(b.delta || 0)
+    })
+
+  return candidates[0] || null
+}
+
+function bestEvidenceMatch(row: ParsedXeroRow, evidenceRows: EvidenceRow[]) {
+  const candidates = evidenceRows
+    .map((line) => {
+      const delta = dateDeltaDays(row.date, line.date)
+      const score = vendorScore(row.description, `${line.payee || ''} ${line.particulars || ''} ${line.reference || ''} ${line.best_vendor_name || ''}`)
+      return { line, delta, score }
+    })
+    .filter(({ line, delta, score }) => (
+      isAmountClose(row.amount, line.amount)
+      && delta !== null
+      && Math.abs(delta) <= BANK_LINE_WINDOW_DAYS
+      && score >= 0.25
+    ))
+    .sort((a, b) => {
+      const confidenceDiff = asNumber(b.line.best_confidence) - asNumber(a.line.best_confidence)
+      if (Math.abs(confidenceDiff) > 0.001) return confidenceDiff
+      const scoreDiff = b.score - a.score
+      if (Math.abs(scoreDiff) > 0.001) return scoreDiff
+      return Math.abs(a.delta || 0) - Math.abs(b.delta || 0)
+    })
+
+  return candidates[0] || null
+}
+
+function billMatches(row: ParsedXeroRow, invoices: XeroInvoiceRow[]) {
+  return invoices
+    .map((invoice) => {
+      const delta = dateDeltaDays(row.date, invoice.date)
+      const score = vendorScore(row.description, invoice.contact_name)
+      return { invoice, delta, score }
+    })
+    .filter(({ invoice, delta, score }) => (
+      isAmountClose(row.amount, invoice.total)
+      && delta !== null
+      && Math.abs(delta) <= DATE_WINDOW_DAYS
+      && score >= 0.25
+    ))
+    .sort((a, b) => {
+      const attachedDiff = Number(Boolean(b.invoice.has_attachments)) - Number(Boolean(a.invoice.has_attachments))
+      if (attachedDiff !== 0) return attachedDiff
+      const scoreDiff = b.score - a.score
+      if (Math.abs(scoreDiff) > 0.001) return scoreDiff
+      return Math.abs(a.delta || 0) - Math.abs(b.delta || 0)
+    })
+}
+
+function isTransfer(row: ParsedXeroRow): boolean {
+  return /Credit Card Payment/i.test(row.transactionType)
+    || /^INTERNET PAYMENT/i.test(row.description)
+    || /linked acc/i.test(row.description)
+}
+
+function isRefund(row: ParsedXeroRow): boolean {
+  return /Refund/i.test(row.transactionType)
+}
+
+function isUnderThreshold(row: ParsedXeroRow): boolean {
+  return absAmount(row.amount) <= 82.5
+}
+
+function decideAction(params: {
+  row: ParsedXeroRow
+  bankMatch: ReturnType<typeof bestBankLineMatch>
+  evidenceMatch: ReturnType<typeof bestEvidenceMatch>
+  invoiceMatches: ReturnType<typeof billMatches>
+}) {
+  const { row, bankMatch, evidenceMatch, invoiceMatches } = params
+  const bankStatus = String(bankMatch?.line.status || '').toLowerCase()
+  const evidenceStatus = String(evidenceMatch?.line.evidence_status || '')
+  const evidenceConfidence = asNumber(evidenceMatch?.line.best_confidence)
+  const evidenceSource = String(evidenceMatch?.line.best_source || '').toLowerCase()
+  const sourceLooksLikeReceipt = /(dext|receipt|xero_me|xero bill)/i.test(evidenceSource)
+  const hasGoodEvidence = Boolean(
+    evidenceMatch
+    && (
+      evidenceMatch.line.has_approved_link
+      || ['covered_evidence', 'covered_legacy', 'high_confidence_candidate'].includes(evidenceStatus)
+      || (sourceLooksLikeReceipt && evidenceConfidence >= 0.85)
+    )
+  )
+
+  if (isTransfer(row)) {
+    return {
+      action: 'transfer' as SuggestedAction,
+      label: 'Transfer, not spend',
+      risk: row.hasOkButton ? 'low' as const : 'medium' as const,
+      nextStep: 'Use Xero Transfer to the correct ACT bank account/card. Do not Create a spend item.',
+    }
+  }
+
+  if (isRefund(row)) {
+    return {
+      action: 'refund_review' as SuggestedAction,
+      label: 'Refund/credit review',
+      risk: 'medium' as const,
+      nextStep: 'Treat as a refund or credit. Do not code it as new spend. Match to the original supplier/credit if available.',
+    }
+  }
+
+  if (row.existingMatchLabel) {
+    const matchVendor = matchedVendor(row.existingMatchLabel)
+    const matchScore = existingMatchVendorScore(row)
+    if (matchScore < 0.35) {
+      return {
+        action: 'wrong_xero_suggestion' as SuggestedAction,
+        label: 'Wrong Xero suggestion',
+        risk: 'high' as const,
+        nextStep: `Do not click OK. Xero is suggesting ${row.existingMatchLabel}, but that does not match ${row.description}. Use Find & Match only if you can find the true vendor, otherwise create/search the correct receipt.`,
+      }
+    }
+
+    return {
+      action: 'click_ok_existing_match' as SuggestedAction,
+      label: 'Xero has a match',
+      risk: 'low' as const,
+      nextStep: `OK is only safe if the right-hand match is exactly ${row.existingMatchLabel} and the source document/vendor confirms ${matchVendor}.`,
+    }
+  }
+
+  if (bankStatus === 'reconciled') {
+    return {
+      action: 'bookkeeper_review' as SuggestedAction,
+      label: 'Mirror drift / already reconciled',
+      risk: 'high' as const,
+      nextStep: 'ACT mirror says this bank line is already reconciled while Xero page still shows it. Do not click blindly; refresh/sync Xero or inspect the row before acting.',
+    }
+  }
+
+  if (invoiceMatches.length === 1) {
+    return {
+      action: 'find_match_bill' as SuggestedAction,
+      label: 'Find & Match bill',
+      risk: 'low' as const,
+      nextStep: 'Use Find & Match to match this bank line to the existing Xero bill. Do not Create a duplicate.',
+    }
+  }
+
+  if (invoiceMatches.length > 1) {
+    return {
+      action: 'bookkeeper_review' as SuggestedAction,
+      label: 'Multiple bill candidates',
+      risk: 'high' as const,
+      nextStep: 'Stop and inspect the Xero bill candidates. Pick the exact bill or leave for review.',
+    }
+  }
+
+  if (hasGoodEvidence) {
+    return {
+      action: 'create_with_evidence' as SuggestedAction,
+      label: 'Create with receipt evidence',
+      risk: 'medium' as const,
+      nextStep: 'Receipt evidence exists. Open the receipt preview, confirm vendor/date/amount, then create or match in Xero using the recommended fields.',
+    }
+  }
+
+  if (isUnderThreshold(row)) {
+    return {
+      action: 'create_low_value' as SuggestedAction,
+      label: 'Low-value create',
+      risk: 'low' as const,
+      nextStep: 'Safe to create as low-value/no-paperwork if business purpose, account, project, and tax treatment are correct. If a receipt exists, attach/approve it later.',
+    }
+  }
+
+  if (row.hasOkButton && row.suggestedWho && row.suggestedAccount) {
+    return {
+      action: 'unsafe_create' as SuggestedAction,
+      label: 'Xero suggests create',
+      risk: 'medium' as const,
+      nextStep: 'Xero has enough fields to create, but no local receipt/bill match was found. Confirm receipt need before OK.',
+    }
+  }
+
+  return {
+    action: 'bookkeeper_review' as SuggestedAction,
+    label: 'Needs human decision',
+    risk: 'high' as const,
+    nextStep: 'No safe bill/receipt/no-receipt path found. Search receipt evidence, Gmail, or leave for Standard Ledger.',
+  }
+}
+
+async function fetchPaged<T>(queryFactory: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>, pageSize = 1000): Promise<T[]> {
+  const rows: T[] = []
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await queryFactory(from, from + pageSize - 1)
+    if (error) throw new Error(error.message)
+    rows.push(...(data || []))
+    if (!data || data.length < pageSize) break
+  }
+  return rows
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json()
+    const rawText = String(body.text || '')
+    const parsedRows = parseXeroPage(rawText)
+
+    if (!parsedRows.length) {
+      return NextResponse.json({
+        parsedCount: 0,
+        summary: {},
+        rows: [],
+        warnings: ['No Xero bank reconciliation rows were parsed. Copy the page text from the Reconcile tab and paste it again.'],
+      })
+    }
+
+    const dates = parsedRows.map((row) => row.date).sort()
+    const start = addDays(dates[0], -DATE_WINDOW_DAYS)
+    const end = addDays(dates[dates.length - 1], DATE_WINDOW_DAYS)
+
+    const [bankLines, evidenceRows, invoices] = await Promise.all([
+      fetchPaged<BankLineRow>((from, to) => supabase
+        .from('bank_statement_lines')
+        .select('id,date,payee,particulars,reference,amount,direction,status,bank_account,project_code,project_source,receipt_match_status,receipt_match_score')
+        .gte('date', start)
+        .lte('date', end)
+        .range(from, to)),
+      fetchPaged<EvidenceRow>((from, to) => supabase
+        .from('v_finance_bank_line_evidence')
+        .select('*')
+        .gte('date', start)
+        .lte('date', end)
+        .range(from, to)),
+      fetchPaged<XeroInvoiceRow>((from, to) => supabase
+        .from('xero_invoices')
+        .select('id,xero_id,invoice_number,type,status,contact_name,date,total,amount_due,amount_paid,has_attachments,reference,project_code,project_code_source')
+        .eq('type', 'ACCPAY')
+        .gte('date', start)
+        .lte('date', end)
+        .range(from, to)),
+    ])
+
+    const rows = parsedRows.map((row) => {
+      const bankMatch = bestBankLineMatch(row, bankLines)
+      const evidenceMatch = bestEvidenceMatch(row, evidenceRows)
+      const invoicesForRow = billMatches(row, invoices).slice(0, 5)
+      const decision = decideAction({ row, bankMatch, evidenceMatch, invoiceMatches: invoicesForRow })
+      const fields = recommendedFields(row, bankMatch?.line || null)
+      const bestInvoice = invoicesForRow[0]?.invoice || null
+      const evidence = evidenceMatch?.line || null
+
+      return {
+        ...row,
+        suggestedAction: decision.action,
+        actionLabel: decision.label,
+        risk: decision.risk,
+        nextStep: decision.nextStep,
+        recommendedFields: fields,
+        receiptEvidenceUrl: receiptEvidenceUrl(row),
+        bankLine: bankMatch ? {
+          id: bankMatch.line.id,
+          date: bankMatch.line.date,
+          payee: bankMatch.line.payee,
+          amount: asNumber(bankMatch.line.amount),
+          status: bankMatch.line.status,
+          bankAccount: bankMatch.line.bank_account,
+          projectCode: bankMatch.line.project_code,
+          projectSource: bankMatch.line.project_source,
+          dateDeltaDays: bankMatch.delta,
+          vendorScore: bankMatch.score,
+        } : null,
+        evidence: evidence ? {
+          id: evidence.id,
+          status: evidence.evidence_status || evidence.receipt_match_status || 'unknown',
+          bestConfidence: asNumber(evidence.best_confidence),
+          bestSource: evidence.best_source || null,
+          bestVendorName: evidence.best_vendor_name || null,
+          candidateCount: asNumber(evidence.candidate_count),
+          hasApprovedLink: Boolean(evidence.has_approved_link),
+        } : null,
+        billCandidates: invoicesForRow.map(({ invoice, delta, score }) => ({
+          id: invoice.id,
+          xeroId: invoice.xero_id,
+          invoiceNumber: invoice.invoice_number,
+          contactName: invoice.contact_name,
+          date: invoice.date,
+          total: asNumber(invoice.total),
+          status: invoice.status,
+          amountPaid: asNumber(invoice.amount_paid),
+          amountDue: asNumber(invoice.amount_due),
+          hasAttachments: Boolean(invoice.has_attachments),
+          reference: invoice.reference,
+          projectCode: invoice.project_code,
+          dateDeltaDays: delta,
+          vendorScore: score,
+          xeroUrl: xeroBillUrl(invoice),
+        })),
+        bestXeroBillUrl: bestInvoice ? xeroBillUrl(bestInvoice) : null,
+      }
+    })
+
+    const summary = rows.reduce((acc: Record<string, number>, row) => {
+      acc.total = (acc.total || 0) + 1
+      acc[row.suggestedAction] = (acc[row.suggestedAction] || 0) + 1
+      if (row.risk === 'high') acc.highRisk = (acc.highRisk || 0) + 1
+      if (row.risk === 'low') acc.lowRisk = (acc.lowRisk || 0) + 1
+      return acc
+    }, {})
+
+    return NextResponse.json({
+      parsedCount: parsedRows.length,
+      dateRange: { start, end },
+      sourceCounts: {
+        bankLines: bankLines.length,
+        evidenceRows: evidenceRows.length,
+        xeroBills: invoices.length,
+      },
+      summary,
+      rows,
+      warnings: [
+        'This is a decision aid only. It does not mutate Xero or Supabase.',
+        'The bank-line/evidence matches are from the ACT Supabase mirror, not the live Xero Reconcile screen.',
+        'Treat Xero green matches as suggestions only. Vendor, amount, date, and business meaning must all line up.',
+      ],
+    })
+  } catch (error) {
+    console.error('[finance/xero-page-copilot] POST failed:', error)
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/api/ideas/route.ts
+++ b/apps/command-center/src/app/api/ideas/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
 
     let query = supabase
       .from('idea_board')
-      .select('*')
+      .select('*, idea_snoozes(id)')
       .order('updated_at', { ascending: false })
 
     if (category) query = query.eq('category', category)
@@ -21,7 +21,14 @@ export async function GET(request: NextRequest) {
 
     const { data, error } = await query
     if (error) return NextResponse.json({ error: error.message }, { status: 500 })
-    return NextResponse.json(data)
+
+    // Flatten the embedded snooze rows into a count for client convenience.
+    const enriched = (data ?? []).map((row: Record<string, unknown>) => {
+      const snoozes = (row.idea_snoozes ?? []) as Array<unknown>
+      const { idea_snoozes: _, ...rest } = row as { idea_snoozes?: unknown }
+      return { ...rest, snooze_count: snoozes.length }
+    })
+    return NextResponse.json(enriched)
   } catch {
     return NextResponse.json([], { status: 500 })
   }

--- a/apps/command-center/src/app/finance/ai-suggestions/page.tsx
+++ b/apps/command-center/src/app/finance/ai-suggestions/page.tsx
@@ -1,0 +1,330 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  ArrowLeft,
+  CheckCircle2,
+  X,
+  Sparkles,
+  AlertTriangle,
+  Loader2,
+  RefreshCw,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatMoney } from '@/lib/finance/format'
+
+type Filter = 'high_conf' | 'review' | 'all'
+
+interface Suggestion {
+  id: string
+  source_table: 'bank_statement_lines' | 'receipt_emails' | 'xero_transactions' | 'finance_receipt_documents'
+  source_record_id: string
+  vendor_name: string | null
+  amount: number | string | null
+  txn_date: string | null
+  bank_account: string | null
+  description: string | null
+  suggested_project_code: string
+  confidence: number
+  reason: string | null
+  risk_flags: string[] | null
+  model: string
+  prompt_version: string
+  created_at: string
+}
+
+interface QueueResponse {
+  filter: Filter
+  counts: {
+    highConf: number
+    review: number
+    applied: number
+  }
+  suggestions: Suggestion[]
+}
+
+const CODE_TONE: Record<string, string> = {
+  'ACT-IN': 'bg-emerald-500/15 border-emerald-500/30 text-emerald-200',
+  'ACT-HV': 'bg-amber-500/15 border-amber-500/30 text-amber-200',
+  'ACT-FM': 'bg-amber-500/15 border-amber-500/30 text-amber-200',
+  'ACT-GD': 'bg-orange-500/15 border-orange-500/30 text-orange-200',
+  'ACT-JH': 'bg-blue-500/15 border-blue-500/30 text-blue-200',
+  'ACT-CORE': 'bg-slate-500/15 border-slate-500/30 text-slate-200',
+  'ACT-EL': 'bg-pink-500/15 border-pink-500/30 text-pink-200',
+  'ACT-PS': 'bg-violet-500/15 border-violet-500/30 text-violet-200',
+  'ACT-MY': 'bg-cyan-500/15 border-cyan-500/30 text-cyan-200',
+  'ACT-OO': 'bg-rose-500/15 border-rose-500/30 text-rose-200',
+  ASK_USER: 'bg-yellow-500/15 border-yellow-500/30 text-yellow-100',
+  SL_REVIEW: 'bg-purple-500/15 border-purple-500/30 text-purple-200',
+}
+
+function confidenceTone(c: number) {
+  if (c >= 0.9) return 'text-emerald-300'
+  if (c >= 0.75) return 'text-cyan-300'
+  if (c >= 0.6) return 'text-amber-300'
+  return 'text-rose-300'
+}
+
+function sourceLabel(t: Suggestion['source_table']) {
+  switch (t) {
+    case 'bank_statement_lines':
+      return 'bank line'
+    case 'receipt_emails':
+      return 'receipt email'
+    case 'xero_transactions':
+      return 'Xero txn'
+    case 'finance_receipt_documents':
+      return 'Dext doc'
+    default:
+      return t
+  }
+}
+
+export default function AISuggestionsPage() {
+  const queryClient = useQueryClient()
+  const [filter, setFilter] = useState<Filter>('high_conf')
+  const [pending, setPending] = useState<string | null>(null)
+
+  const { data, isLoading, refetch, isRefetching } = useQuery<QueueResponse>({
+    queryKey: ['ai-suggestions', filter],
+    queryFn: () =>
+      fetch(`/api/finance/workbench/ai-queue?filter=${filter}&limit=100`, { cache: 'no-store' }).then((r) => r.json()),
+    staleTime: 30 * 1000,
+  })
+
+  const accept = useMutation({
+    mutationFn: (suggestionId: string) =>
+      fetch('/api/finance/workbench/accept-suggestion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ suggestionId, action: 'accept' }),
+      }).then((r) => r.json()),
+    onMutate: (id) => setPending(id),
+    onSettled: () => setPending(null),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['ai-suggestions'] }),
+  })
+
+  const reject = useMutation({
+    mutationFn: (suggestionId: string) =>
+      fetch('/api/finance/workbench/accept-suggestion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ suggestionId, action: 'reject', rejectionReason: 'rejected via workbench AI queue' }),
+      }).then((r) => r.json()),
+    onMutate: (id) => setPending(id),
+    onSettled: () => setPending(null),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['ai-suggestions'] }),
+  })
+
+  const acceptAllSafe = useMutation({
+    mutationFn: async () => {
+      const safe = (data?.suggestions || []).filter(
+        (s) => s.confidence >= 0.85 && !['ASK_USER', 'SL_REVIEW'].includes(s.suggested_project_code),
+      )
+      const results: Array<{ id: string; ok: boolean }> = []
+      for (const s of safe) {
+        try {
+          const res = await fetch('/api/finance/workbench/accept-suggestion', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ suggestionId: s.id, action: 'accept' }),
+          })
+          const j = await res.json()
+          results.push({ id: s.id, ok: !!j.ok })
+        } catch {
+          results.push({ id: s.id, ok: false })
+        }
+      }
+      return results
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['ai-suggestions'] }),
+  })
+
+  const suggestions = data?.suggestions || []
+  const counts = data?.counts || { highConf: 0, review: 0, applied: 0 }
+
+  return (
+    <main className="min-h-screen bg-neutral-950 p-6 lg:p-8 text-neutral-100">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <Link href="/finance" className="inline-flex items-center gap-2 text-sm text-white/55 transition hover:text-white">
+          <ArrowLeft className="h-4 w-4" />
+          Finance
+        </Link>
+
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <p className="flex items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-emerald-300">
+              <Sparkles className="h-3 w-3" />
+              AI suggestions
+            </p>
+            <h1 className="mt-1 text-3xl font-semibold tracking-tight">Review AI grades</h1>
+            <p className="mt-1 max-w-2xl text-sm text-white/55">
+              Sonnet 4.6 graded these rows. Accept applies the project code to the source row; reject marks the suggestion dead. ASK_USER and SL_REVIEW codes never auto-apply — those need your call.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="inline-flex items-center gap-2 rounded-md border border-white/10 px-3 py-1.5 text-sm text-white/70 transition hover:border-white/30 hover:text-white"
+            disabled={isRefetching}
+          >
+            <RefreshCw className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
+            Refresh
+          </button>
+        </header>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {(['high_conf', 'review', 'all'] as Filter[]).map((f) => (
+            <button
+              key={f}
+              type="button"
+              onClick={() => setFilter(f)}
+              className={cn(
+                'flex items-center gap-2 rounded-full border px-4 py-1.5 text-xs font-medium transition',
+                filter === f
+                  ? 'border-emerald-400/50 bg-emerald-500/15 text-emerald-100'
+                  : 'border-white/10 text-white/55 hover:border-white/25 hover:text-white',
+              )}
+            >
+              {f === 'high_conf' ? 'High confidence ≥85%' : f === 'review' ? 'Need review' : 'All open'}
+              <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] font-bold tabular-nums">
+                {f === 'high_conf' ? counts.highConf : f === 'review' ? counts.review : counts.highConf + counts.review}
+              </span>
+            </button>
+          ))}
+          <div className="ml-auto flex items-center gap-3 text-xs text-white/45">
+            <span>{counts.applied.toLocaleString()} accepted to date</span>
+            {filter === 'high_conf' && suggestions.length > 0 && (
+              <button
+                type="button"
+                onClick={() => acceptAllSafe.mutate()}
+                disabled={acceptAllSafe.isPending}
+                className="inline-flex items-center gap-2 rounded-full bg-emerald-400 px-4 py-1.5 text-xs font-semibold text-slate-950 transition hover:bg-emerald-300 disabled:opacity-50"
+              >
+                {acceptAllSafe.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle2 className="h-3 w-3" />}
+                Accept all {suggestions.length} safe
+              </button>
+            )}
+          </div>
+        </div>
+
+        {isLoading && (
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-8 text-center text-sm text-white/55">
+            Loading suggestions…
+          </div>
+        )}
+
+        {!isLoading && suggestions.length === 0 && (
+          <div className="flex items-center gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-6 text-sm text-emerald-100">
+            <CheckCircle2 className="h-5 w-5 shrink-0" />
+            <div>
+              <p className="font-semibold">Nothing in this bucket.</p>
+              <p className="mt-0.5 text-emerald-200/70">
+                {filter === 'high_conf'
+                  ? 'No safe high-confidence suggestions waiting. The poller queues them every 15 min; check back.'
+                  : 'No suggestions need review right now.'}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {!isLoading && suggestions.length > 0 && (
+          <ul className="space-y-2">
+            {suggestions.map((s) => {
+              const isPending = pending === s.id
+              const blockedCode = ['ASK_USER', 'SL_REVIEW'].includes(s.suggested_project_code)
+              const tone = CODE_TONE[s.suggested_project_code] || 'bg-white/10 border-white/15 text-white'
+
+              return (
+                <li
+                  key={s.id}
+                  className={cn(
+                    'flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/[0.03] p-4 transition hover:border-white/20 lg:flex-row lg:items-center lg:gap-4',
+                    isPending && 'opacity-50',
+                  )}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 text-xs text-white/45">
+                      <span>{sourceLabel(s.source_table)}</span>
+                      {s.txn_date && <span>·</span>}
+                      {s.txn_date && <span>{s.txn_date}</span>}
+                      {s.bank_account && <span>·</span>}
+                      {s.bank_account && <span className="truncate">{s.bank_account}</span>}
+                    </div>
+                    <div className="mt-1 flex items-baseline gap-3">
+                      <p className="truncate text-base font-semibold text-white">
+                        {s.vendor_name || '(no vendor)'}
+                      </p>
+                      <p className="text-sm font-medium text-white/75 tabular-nums">
+                        {s.amount != null ? formatMoney(Number(s.amount)) : '—'}
+                      </p>
+                    </div>
+                    {s.reason && <p className="mt-1 text-xs leading-snug text-white/50">{s.reason}</p>}
+                    {s.risk_flags && s.risk_flags.length > 0 && (
+                      <div className="mt-1.5 flex flex-wrap gap-1.5">
+                        {s.risk_flags.map((flag) => (
+                          <span
+                            key={flag}
+                            className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-200"
+                          >
+                            <AlertTriangle className="-mt-px mr-1 inline h-2.5 w-2.5" />
+                            {flag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-3 lg:flex-col lg:items-end">
+                    <div className="flex items-center gap-2">
+                      <span className={cn('rounded-md border px-2.5 py-1 text-xs font-bold tabular-nums', tone)}>
+                        {s.suggested_project_code}
+                      </span>
+                      <span className={cn('text-sm font-bold tabular-nums', confidenceTone(s.confidence))}>
+                        {(s.confidence * 100).toFixed(0)}%
+                      </span>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => reject.mutate(s.id)}
+                        disabled={isPending}
+                        title="Reject this suggestion"
+                        className="inline-flex items-center gap-1 rounded-md border border-white/10 px-3 py-1.5 text-xs text-white/55 transition hover:border-rose-400/40 hover:text-rose-200 disabled:opacity-50"
+                      >
+                        <X className="h-3 w-3" />
+                        Reject
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => accept.mutate(s.id)}
+                        disabled={isPending || blockedCode}
+                        title={
+                          blockedCode
+                            ? `Cannot auto-apply ${s.suggested_project_code} — needs human review`
+                            : `Apply ${s.suggested_project_code} to ${sourceLabel(s.source_table)}`
+                        }
+                        className={cn(
+                          'inline-flex items-center gap-1 rounded-md px-3 py-1.5 text-xs font-semibold transition',
+                          blockedCode
+                            ? 'bg-white/5 text-white/30 cursor-not-allowed'
+                            : 'bg-emerald-400 text-slate-950 hover:bg-emerald-300',
+                        )}
+                      >
+                        {isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <CheckCircle2 className="h-3 w-3" />}
+                        Accept
+                      </button>
+                    </div>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </main>
+  )
+}

--- a/apps/command-center/src/app/finance/command/page.tsx
+++ b/apps/command-center/src/app/finance/command/page.tsx
@@ -123,6 +123,31 @@ interface LifetimeResponse {
   topCustomers: LifetimeCustomer[]
 }
 
+interface ComplianceObligation {
+  id: string
+  title: string
+  type: string
+  entity: string
+  due_date: string | null
+  status: string
+  notes?: string
+  owner: string
+  expected_refund_aud?: number
+  monetary_value?: number
+  days_until_due: number | null
+  severity: 'critical' | 'high' | 'medium' | null
+  at_risk: boolean
+  source: 'wiki' | 'ghl_opportunities'
+}
+
+interface ComplianceResponse {
+  generatedAt: string
+  source: 'snapshot' | 'live'
+  sources: { wiki: { count: number }; grants: { count: number } }
+  counters: { critical: number; high: number; medium: number; filed: number }
+  obligations: ComplianceObligation[]
+}
+
 interface DeltaResponse {
   available: boolean
   reason?: string
@@ -175,6 +200,15 @@ export default function MoneyCommandPage() {
     },
     staleTime: 10 * 60 * 1000,
   })
+  const { data: compliance } = useQuery<ComplianceResponse>({
+    queryKey: ['finance', 'compliance-calendar'],
+    queryFn: async () => {
+      const res = await fetch('/api/finance/compliance-calendar', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    staleTime: 10 * 60 * 1000,
+  })
 
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100 p-6 lg:p-10">
@@ -211,6 +245,8 @@ export default function MoneyCommandPage() {
 
         {data && (
           <>
+            {/* AT RISK TODAY — unified attention pane */}
+            <AtRiskTodaySection compliance={compliance} top={data.top} drift={data.middle.drift} />
             {/* TOP LAYER */}
             <TopLayer top={data.top} />
             {/* MIDDLE LAYER */}
@@ -228,6 +264,139 @@ export default function MoneyCommandPage() {
       </div>
     </div>
   )
+}
+
+function AtRiskTodaySection({
+  compliance,
+  top,
+  drift,
+}: {
+  compliance: ComplianceResponse | undefined
+  top: CommandResponse['top']
+  drift: DriftItem[]
+}) {
+  // Build risk items in severity order: critical (red), high (orange), medium (yellow)
+  type Risk = {
+    severity: 'critical' | 'high' | 'medium'
+    icon: string
+    label: string
+    note: string
+    href: string
+  }
+  const items: Risk[] = []
+
+  // Compliance items
+  if (compliance) {
+    for (const o of compliance.obligations) {
+      if (!o.severity) continue
+      const dd = o.days_until_due
+      const tag = dd == null ? '' : dd < 0 ? `T+${Math.abs(dd)}d` : `T-${dd}d`
+      items.push({
+        severity: o.severity,
+        icon: '📋',
+        label: `[${tag}] ${o.title}`,
+        note: o.notes ? o.notes.split('\n')[0].slice(0, 60) : `${o.type} · ${o.entity}`,
+        href:
+          o.source === 'ghl_opportunities'
+            ? '/finance/workbench'
+            : 'https://github.com/Acurioustractor/act-global-infrastructure/blob/main/wiki/finance/compliance-calendar.md',
+      })
+    }
+  }
+
+  // Cash / runway derived risks (compute from top totals if cash is known)
+  if (top.cashInBank != null) {
+    const monthlyBurn = (top.fyExpenses - top.fyIncome) / Math.max(1, monthsSince('2025-07-01'))
+    if (monthlyBurn > 0) {
+      const runwayMonths = top.cashInBank / monthlyBurn
+      if (runwayMonths < 2) {
+        items.push({
+          severity: 'critical',
+          icon: '🔥',
+          label: `runway ${runwayMonths.toFixed(1)} months`,
+          note: `cash ${formatMoneyCompact(top.cashInBank)} · monthly burn ${formatMoneyCompact(monthlyBurn)}`,
+          href: '/finance/overview',
+        })
+      } else if (runwayMonths < 3) {
+        items.push({
+          severity: 'medium',
+          icon: '⏱️',
+          label: `runway ${runwayMonths.toFixed(1)} months`,
+          note: `cash ${formatMoneyCompact(top.cashInBank)} · monthly burn ${formatMoneyCompact(monthlyBurn)}`,
+          href: '/finance/overview',
+        })
+      }
+    }
+  }
+
+  // Drift items above $5K
+  for (const d of drift.slice(0, 3)) {
+    if (Math.abs(d.amount) < 5000) continue
+    items.push({
+      severity: Math.abs(d.amount) >= 50000 ? 'high' : 'medium',
+      icon: '🔀',
+      label: `drift ${formatMoneyCompact(Math.abs(d.amount))}`,
+      note: d.label.slice(0, 60),
+      href: d.workbenchUrl ?? '/finance/workbench',
+    })
+  }
+
+  // Sort by severity (critical first, then high, then medium)
+  const sevOrder = { critical: 0, high: 1, medium: 2 }
+  items.sort((a, b) => sevOrder[a.severity] - sevOrder[b.severity])
+
+  const SEV_TONE: Record<Risk['severity'], { icon: string; bg: string; text: string }> = {
+    critical: { icon: '🔴', bg: 'border-rose-900/60 bg-rose-950/30', text: 'text-rose-300' },
+    high: { icon: '🟠', bg: 'border-amber-900/60 bg-amber-950/20', text: 'text-amber-300' },
+    medium: { icon: '🟡', bg: 'border-yellow-900/40 bg-yellow-950/10', text: 'text-yellow-300' },
+  }
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2 text-neutral-400 text-xs font-medium uppercase tracking-wider">
+        <AlertTriangle size={14} className="text-rose-400" />
+        At risk today
+        <span className="text-neutral-600 normal-case font-normal tracking-normal">
+          · {items.length} {items.length === 1 ? 'item' : 'items'}
+          {compliance ? ` · compliance refreshed ${new Date(compliance.generatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
+        </span>
+      </div>
+      {items.length === 0 ? (
+        <div className="rounded-lg border border-emerald-900/40 bg-emerald-950/15 p-4 text-sm text-emerald-300">
+          <CheckCircle2 size={14} className="inline mr-2 -mt-0.5" />
+          All clear — you have a clean board today.
+        </div>
+      ) : (
+        <div className="rounded-lg border border-neutral-800 bg-neutral-900/60 p-3 space-y-1.5">
+          {items.map((r, i) => {
+            const tone = SEV_TONE[r.severity]
+            return (
+              <Link
+                key={i}
+                href={r.href}
+                target={r.href.startsWith('http') ? '_blank' : undefined}
+                className={cn(
+                  'flex items-center gap-3 px-3 py-2 rounded border hover:bg-neutral-800/50 transition-colors',
+                  tone.bg,
+                )}
+              >
+                <span className="text-base shrink-0">{tone.icon}</span>
+                <span className={cn('text-sm font-medium shrink-0', tone.text)}>{r.label}</span>
+                <span className="text-xs text-neutral-500 flex-1 truncate">{r.note}</span>
+                <ArrowRight size={12} className="text-neutral-600 shrink-0" />
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function monthsSince(isoDate: string): number {
+  const start = new Date(isoDate + 'T00:00:00Z').getTime()
+  const now = Date.now()
+  return Math.max(1, (now - start) / (1000 * 60 * 60 * 24 * 30.44))
 }
 
 function TopLayer({ top }: { top: CommandResponse['top'] }) {

--- a/apps/command-center/src/app/finance/command/page.tsx
+++ b/apps/command-center/src/app/finance/command/page.tsx
@@ -148,6 +148,25 @@ interface ComplianceResponse {
   obligations: ComplianceObligation[]
 }
 
+interface PilotRiskItem {
+  id: string
+  severity: 'high' | 'medium'
+  stage: 'scope' | 'fundraise'
+  text: string
+  owner: string
+  age_days: number
+  snooze_count: number
+  snooze_burned: boolean
+  value_estimate: number
+  href: string
+}
+
+interface PilotRisksResponse {
+  generatedAt: string
+  items: PilotRiskItem[]
+  counters: { high: number; medium: number; snooze_burned: number }
+}
+
 interface DeltaResponse {
   available: boolean
   reason?: string
@@ -209,6 +228,15 @@ export default function MoneyCommandPage() {
     },
     staleTime: 10 * 60 * 1000,
   })
+  const { data: pilotRisks } = useQuery<PilotRisksResponse>({
+    queryKey: ['finance', 'pilot-risks'],
+    queryFn: async () => {
+      const res = await fetch('/api/finance/pilot-risks', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    staleTime: 10 * 60 * 1000,
+  })
 
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100 p-6 lg:p-10">
@@ -246,7 +274,7 @@ export default function MoneyCommandPage() {
         {data && (
           <>
             {/* AT RISK TODAY — unified attention pane */}
-            <AtRiskTodaySection compliance={compliance} top={data.top} drift={data.middle.drift} />
+            <AtRiskTodaySection compliance={compliance} pilotRisks={pilotRisks} top={data.top} drift={data.middle.drift} />
             {/* TOP LAYER */}
             <TopLayer top={data.top} />
             {/* MIDDLE LAYER */}
@@ -268,10 +296,12 @@ export default function MoneyCommandPage() {
 
 function AtRiskTodaySection({
   compliance,
+  pilotRisks,
   top,
   drift,
 }: {
   compliance: ComplianceResponse | undefined
+  pilotRisks: PilotRisksResponse | undefined
   top: CommandResponse['top']
   drift: DriftItem[]
 }) {
@@ -339,6 +369,22 @@ function AtRiskTodaySection({
       note: d.label.slice(0, 60),
       href: d.workbenchUrl ?? '/finance/workbench',
     })
+  }
+
+  // Pilot lifecycle risks (Pass 2B B6) — stale scope/fundraise + snooze-burned
+  if (pilotRisks) {
+    for (const p of pilotRisks.items.slice(0, 5)) {
+      const stageIcon = p.stage === 'fundraise' ? '💸' : '🔍'
+      const valueTag = p.value_estimate > 0 ? ` · ~${formatMoneyCompact(p.value_estimate)}` : ''
+      const burnTag = p.snooze_burned ? ' · 💤×3 forced decision' : p.snooze_count > 0 ? ` · 💤×${p.snooze_count}` : ''
+      items.push({
+        severity: p.severity,
+        icon: stageIcon,
+        label: `[${p.stage} ${p.age_days}d idle${valueTag}${burnTag}]`,
+        note: p.text.slice(0, 60),
+        href: p.href,
+      })
+    }
   }
 
   // Sort by severity (critical first, then high, then medium)

--- a/apps/command-center/src/app/finance/dext-push-audit/page.tsx
+++ b/apps/command-center/src/app/finance/dext-push-audit/page.tsx
@@ -1,0 +1,602 @@
+'use client'
+
+import { startTransition, useDeferredValue, useState } from 'react'
+import Link from 'next/link'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  ExternalLink,
+  FileSearch,
+  Filter,
+  Loader2,
+  Receipt,
+  RefreshCcw,
+  Search,
+  ShieldAlert,
+  Sparkles,
+  Tags,
+} from 'lucide-react'
+import { formatMoney } from '@/lib/finance/format'
+import { cn } from '@/lib/utils'
+
+type StatusFilter =
+  | 'needs_action'
+  | 'duplicate_risk'
+  | 'match_candidate'
+  | 'ambiguous'
+  | 'project_review'
+  | 'done'
+  | 'all'
+
+interface ProjectOption {
+  code: string
+  name: string | null
+  tier: string | null
+  status: string | null
+}
+
+interface AuditCandidate {
+  id: string
+  date: string | null
+  payee: string
+  amount: number
+  status: string | null
+  bankAccount: string | null
+  dateDeltaDays: number | null
+  vendorScore: number
+  amountDelta: number
+  projectCode: string | null
+  projectSource: string | null
+}
+
+interface AuditItem {
+  id: string
+  xeroId: string | null
+  date: string | null
+  vendor: string
+  amount: number
+  amountDue: number
+  amountPaid: number
+  xeroStatus: string | null
+  reference: string | null
+  dextRef: string | null
+  hasAttachment: boolean
+  projectCode: string | null
+  projectSource: string | null
+  accountCode: string | null
+  taxType: string | null
+  description: string | null
+  paymentCount: number
+  paymentReconciled: boolean
+  payments: Array<{
+    id: string
+    xeroPaymentId: string | null
+    date: string | null
+    amount: number
+    status: string | null
+    isReconciled: boolean | null
+    accountName: string | null
+    reference: string | null
+  }>
+  candidates: AuditCandidate[]
+  decision: 'done' | 'find_match' | 'duplicate_risk' | 'ambiguous' | 'project_review' | 'bookkeeper' | 'unknown'
+  decisionLabel: string
+  nextStep: string
+  riskLevel: 'low' | 'medium' | 'high'
+  needsProjectReview: boolean
+  receiptEvidenceUrl: string
+}
+
+interface DextPushAuditResponse {
+  fy: { start: string; end: string }
+  filters: {
+    status: StatusFilter
+    project: string
+    q: string
+    limit: number
+  }
+  summary: {
+    total: number
+    totalAmount: number
+    needsAction: number
+    duplicateRisk: number
+    matchCandidates: number
+    ambiguous: number
+    projectReview: number
+    done: number
+    paymentReconciled: number
+  }
+  projects: ProjectOption[]
+  caveat: string
+  totalMatching: number
+  items: AuditItem[]
+}
+
+const statusOptions: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'needs_action', label: 'Needs action' },
+  { value: 'duplicate_risk', label: 'Duplicate risk' },
+  { value: 'match_candidate', label: 'Find & Match' },
+  { value: 'ambiguous', label: 'Ambiguous' },
+  { value: 'project_review', label: 'Project review' },
+  { value: 'done', label: 'Done' },
+  { value: 'all', label: 'All Dext pushes' },
+]
+
+function initialOption<T extends string>(
+  param: string,
+  options: Array<{ value: T }>,
+  fallback: T
+): T {
+  if (typeof window === 'undefined') return fallback
+  const value = new URLSearchParams(window.location.search).get(param)
+  return options.some((option) => option.value === value) ? (value as T) : fallback
+}
+
+function initialParam(param: string, fallback = ''): string {
+  if (typeof window === 'undefined') return fallback
+  return new URLSearchParams(window.location.search).get(param) || fallback
+}
+
+function dateLabel(date: string | null): string {
+  if (!date) return 'No date'
+  return new Intl.DateTimeFormat('en-AU', { day: '2-digit', month: 'short', year: 'numeric' }).format(new Date(`${date}T00:00:00`))
+}
+
+function riskClass(risk: AuditItem['riskLevel']) {
+  if (risk === 'high') return 'border-red-400/40 bg-red-500/10 text-red-100'
+  if (risk === 'medium') return 'border-amber-400/40 bg-amber-500/10 text-amber-100'
+  return 'border-emerald-400/35 bg-emerald-500/10 text-emerald-100'
+}
+
+function decisionClass(decision: AuditItem['decision']) {
+  if (decision === 'duplicate_risk') return 'bg-red-400/15 text-red-100'
+  if (decision === 'ambiguous' || decision === 'bookkeeper') return 'bg-amber-400/15 text-amber-100'
+  if (decision === 'find_match') return 'bg-cyan-400/15 text-cyan-100'
+  if (decision === 'done') return 'bg-emerald-400/15 text-emerald-100'
+  return 'bg-white/10 text-white/55'
+}
+
+function paymentLabel(item: AuditItem): string {
+  if (item.paymentReconciled) return 'Payment reconciled'
+  if (item.paymentCount > 0) return 'Manual payment not reconciled'
+  if (item.amountPaid > 0) return 'Paid in Xero, no payment mirror'
+  return 'Bill exists, no payment'
+}
+
+function xeroBillUrl(item: AuditItem): string {
+  if (!item.xeroId) return 'https://go.xero.com/AccountsPayable/Search.aspx'
+  return `https://go.xero.com/AccountsPayable/View.aspx?InvoiceID=${encodeURIComponent(item.xeroId)}`
+}
+
+async function fetchAudit(params: {
+  status: StatusFilter
+  project: string
+  q: string
+}): Promise<DextPushAuditResponse> {
+  const qs = new URLSearchParams()
+  qs.set('status', params.status)
+  qs.set('project', params.project)
+  qs.set('limit', '300')
+  if (params.q.trim()) qs.set('q', params.q.trim())
+
+  const res = await fetch(`/api/finance/dext-push-audit?${qs.toString()}`)
+  const data = await res.json()
+  if (!res.ok) throw new Error(data.error || 'Failed to load Dext push audit')
+  return data
+}
+
+function StatCard({
+  title,
+  value,
+  detail,
+  icon: Icon,
+  active,
+  onClick,
+}: {
+  title: string
+  value: string
+  detail: string
+  icon: typeof Receipt
+  active?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-3xl border border-white/10 bg-white/[0.04] p-4 text-left shadow-[0_0_40px_rgba(34,211,238,0.03)] transition hover:border-cyan-300/40 hover:bg-cyan-300/10',
+        active && 'border-cyan-300/50 bg-cyan-300/10'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.24em] text-white/40">{title}</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-white">{value}</p>
+        </div>
+        <Icon className="h-5 w-5 text-cyan-200" />
+      </div>
+      <p className="mt-2 text-xs leading-5 text-white/50">{detail}</p>
+    </button>
+  )
+}
+
+export default function DextPushAuditPage() {
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<StatusFilter>(() => initialOption('status', statusOptions, 'needs_action'))
+  const [project, setProject] = useState(() => initialParam('project', 'all'))
+  const [search, setSearch] = useState(() => initialParam('q'))
+  const deferredSearch = useDeferredValue(search)
+  const [pendingProjects, setPendingProjects] = useState<Record<string, string>>({})
+
+  const query = useQuery({
+    queryKey: ['finance', 'dext-push-audit', status, project, deferredSearch],
+    queryFn: () => fetchAudit({ status, project, q: deferredSearch }),
+  })
+
+  const mutation = useMutation({
+    mutationFn: async (payload: { id: string; projectCode: string }) => {
+      const res = await fetch('/api/finance/dext-push-audit', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save project')
+      return data
+    },
+    onSuccess: () => {
+      setPendingProjects({})
+      queryClient.invalidateQueries({ queryKey: ['finance', 'dext-push-audit'] })
+    },
+  })
+
+  const data = query.data
+  const rows = data?.items || []
+  const projects = data?.projects || []
+  const summary = data?.summary
+
+  return (
+    <main className="min-h-screen overflow-hidden bg-[#05070a] text-white">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_90%_20%,rgba(248,113,113,0.16),transparent_30%),linear-gradient(135deg,rgba(15,23,42,0.9),rgba(2,6,23,0.94))]" />
+      <div className="relative mx-auto max-w-[1560px] px-6 py-8">
+        <Link href="/finance" className="mb-6 inline-flex items-center gap-2 text-sm text-white/45 transition hover:text-white">
+          <ArrowLeft className="h-4 w-4" />
+          Finance
+        </Link>
+
+        <header className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_420px] lg:items-start">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs uppercase tracking-[0.24em] text-cyan-100/75">
+              <Sparkles className="h-3.5 w-3.5" />
+              Dext Push Audit
+            </div>
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight md:text-5xl">
+              Stop duplicates. Match what Dext already pushed.
+            </h1>
+            <p className="mt-4 max-w-4xl text-sm leading-6 text-white/60">
+              This page isolates Xero ACCPAY bills created by Dext using the
+              <span className="mx-1 rounded bg-white/10 px-1.5 py-0.5 font-mono text-xs">auto-pushed dext_import</span>
+              reference. It does not reconcile in Xero. It tells us whether to leave it, Find & Match, or escalate.
+            </p>
+          </div>
+
+          <aside className="rounded-3xl border border-red-300/20 bg-red-500/[0.08] p-5">
+            <div className="flex gap-3">
+              <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-red-200" />
+              <div>
+                <h2 className="font-semibold text-red-50">Hard rule</h2>
+                <p className="mt-2 text-sm leading-6 text-red-50/70">
+                  If Dext already created a paid bill/payment, do not create another Xero transaction from the bank feed.
+                  Use Find & Match only when the live Xero bank line is visible and correct.
+                </p>
+              </div>
+            </div>
+          </aside>
+        </header>
+
+        {summary && (
+          <section className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-6">
+            <StatCard
+              title="Dext pushed"
+              value={summary.total.toLocaleString()}
+              detail={`${formatMoney(summary.totalAmount)} in Dext-created Xero bills`}
+              icon={Receipt}
+              active={status === 'all'}
+              onClick={() => setStatus('all')}
+            />
+            <StatCard
+              title="Duplicate risk"
+              value={summary.duplicateRisk.toLocaleString()}
+              detail="Paid in Xero and bank-line mirror still has candidate"
+              icon={ShieldAlert}
+              active={status === 'duplicate_risk'}
+              onClick={() => setStatus('duplicate_risk')}
+            />
+            <StatCard
+              title="Find & Match"
+              value={summary.matchCandidates.toLocaleString()}
+              detail="One mirror candidate. Verify in live Xero before clicking"
+              icon={FileSearch}
+              active={status === 'match_candidate'}
+              onClick={() => setStatus('match_candidate')}
+            />
+            <StatCard
+              title="Ambiguous"
+              value={summary.ambiguous.toLocaleString()}
+              detail="Multiple candidates or uncertain match path"
+              icon={AlertTriangle}
+              active={status === 'ambiguous'}
+              onClick={() => setStatus('ambiguous')}
+            />
+            <StatCard
+              title="Project review"
+              value={summary.projectReview.toLocaleString()}
+              detail="Missing or broad project tagging on Dext bill"
+              icon={Tags}
+              active={status === 'project_review'}
+              onClick={() => setStatus('project_review')}
+            />
+            <StatCard
+              title="Done"
+              value={summary.done.toLocaleString()}
+              detail={`${summary.paymentReconciled.toLocaleString()} payments marked reconciled`}
+              icon={CheckCircle2}
+              active={status === 'done'}
+              onClick={() => setStatus('done')}
+            />
+          </section>
+        )}
+
+        <section className="mt-6 rounded-3xl border border-white/10 bg-white/[0.035] p-4 backdrop-blur">
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-[220px_260px_1fr_auto]">
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Queue</span>
+              <select value={status} onChange={(e) => setStatus(e.target.value as StatusFilter)} className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white">
+                {statusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Project</span>
+              <select value={project} onChange={(e) => setProject(e.target.value)} className="w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-white">
+                <option value="all">All projects</option>
+                <option value="__blank__">No project</option>
+                {projects.map((p) => (
+                  <option key={p.code} value={p.code}>
+                    {p.code} - {p.name || 'Unnamed'}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Search</span>
+              <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-black/40 px-4 py-3">
+                <Search className="h-4 w-4 text-white/30" />
+                <input
+                  value={search}
+                  onChange={(e) => startTransition(() => setSearch(e.target.value))}
+                  placeholder="Vendor, dext ref, project, bank candidate..."
+                  className="w-full bg-transparent text-sm text-white outline-none placeholder:text-white/25"
+                />
+              </div>
+            </label>
+            <button
+              type="button"
+              onClick={() => query.refetch()}
+              className="mt-5 inline-flex items-center justify-center gap-2 rounded-2xl border border-white/10 bg-white/5 px-5 py-3 text-sm text-white/70 transition hover:bg-white/10 hover:text-white"
+            >
+              <RefreshCcw className={cn('h-4 w-4', query.isFetching && 'animate-spin')} />
+              Refresh
+            </button>
+          </div>
+        </section>
+
+        {data?.caveat && (
+          <section className="mt-5 rounded-3xl border border-amber-300/20 bg-amber-300/[0.08] px-5 py-4 text-sm leading-6 text-amber-50/75">
+            <div className="flex gap-3">
+              <Filter className="mt-0.5 h-4 w-4 shrink-0 text-amber-100" />
+              <p>{data.caveat}</p>
+            </div>
+          </section>
+        )}
+
+        {query.error && (
+          <div className="mt-6 rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {(query.error as Error).message}
+          </div>
+        )}
+
+        {mutation.error && (
+          <div className="mt-4 rounded-3xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {(mutation.error as Error).message}
+          </div>
+        )}
+
+        <section className="mt-6 overflow-hidden rounded-3xl border border-white/10 bg-white/[0.025] shadow-2xl shadow-black/30">
+          <div className="flex flex-col gap-2 border-b border-white/10 px-5 py-4 lg:flex-row lg:items-center lg:justify-between">
+            <p className="text-sm text-white/55">
+              Showing <span className="font-semibold text-white">{rows.length.toLocaleString()}</span>
+              {data ? ` of ${data.totalMatching.toLocaleString()} matching Dext-pushed bills` : ''}.
+            </p>
+            <p className="text-xs text-white/35">Project saves update Supabase/Xero mirror only. No Xero accounting state is changed here.</p>
+          </div>
+
+          <div className="max-h-[760px] overflow-auto">
+            <table className="w-full min-w-[1320px] border-collapse text-sm">
+              <thead className="sticky top-0 z-10 bg-[#101722] text-left text-[11px] uppercase tracking-[0.22em] text-white/35">
+                <tr>
+                  <th className="px-5 py-4">Dext-created Xero bill</th>
+                  <th className="px-5 py-4">Payment state</th>
+                  <th className="px-5 py-4">Decision</th>
+                  <th className="px-5 py-4">Bank-line mirror candidates</th>
+                  <th className="px-5 py-4">Project</th>
+                  <th className="px-5 py-4">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {query.isLoading && (
+                  <tr>
+                    <td colSpan={6} className="px-5 py-12 text-center text-white/45">Loading Dext push audit...</td>
+                  </tr>
+                )}
+
+                {!query.isLoading && rows.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-5 py-12 text-center text-white/45">No Dext-pushed bills match these filters.</td>
+                  </tr>
+                )}
+
+                {rows.map((item) => {
+                  const selectedProject = pendingProjects[item.id] ?? item.projectCode ?? ''
+                  const projectChanged = selectedProject !== (item.projectCode ?? '')
+
+                  return (
+                    <tr key={item.id} className="border-b border-white/5 align-top transition hover:bg-white/[0.035]">
+                      <td className="max-w-[380px] px-5 py-5">
+                        <div className="flex items-start gap-3">
+                          <div className={cn('mt-1 h-3 w-3 rounded-full border', riskClass(item.riskLevel))} />
+                          <div>
+                            <p className="text-base font-semibold text-white">{item.vendor}</p>
+                            <p className="mt-1 text-xs text-white/45">{dateLabel(item.date)} - {formatMoney(item.amount)}</p>
+                            <p className="mt-2 font-mono text-[11px] text-cyan-100/65">{item.reference || 'No reference'}</p>
+                            <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+                              <span className="rounded-full bg-white/10 px-2 py-1 text-white/55">{item.xeroStatus || 'unknown'}</span>
+                              <span className={cn('rounded-full px-2 py-1', item.hasAttachment ? 'bg-emerald-400/15 text-emerald-100' : 'bg-red-400/15 text-red-100')}>
+                                {item.hasAttachment ? 'receipt attached' : 'no attachment'}
+                              </span>
+                              {item.accountCode && <span className="rounded-full bg-white/10 px-2 py-1 text-white/55">acct {item.accountCode}</span>}
+                              {item.taxType && <span className="rounded-full bg-white/10 px-2 py-1 text-white/55">{item.taxType}</span>}
+                            </div>
+                            {item.description && <p className="mt-3 line-clamp-2 text-xs leading-5 text-white/38">{item.description}</p>}
+                          </div>
+                        </div>
+                      </td>
+
+                      <td className="px-5 py-5">
+                        <span
+                          className={cn(
+                            'inline-flex rounded-full px-3 py-1 text-xs',
+                            item.paymentReconciled ? 'bg-emerald-400/15 text-emerald-100' : 'bg-amber-400/15 text-amber-100'
+                          )}
+                        >
+                          {paymentLabel(item)}
+                        </span>
+                        <div className="mt-3 space-y-2">
+                          <p className="text-xs text-white/45">Paid {formatMoney(item.amountPaid)} - Due {formatMoney(item.amountDue)}</p>
+                          {item.payments.slice(0, 2).map((payment) => (
+                            <div key={payment.id} className="rounded-xl border border-white/10 bg-black/25 px-3 py-2 text-xs text-white/55">
+                              {dateLabel(payment.date)} - {formatMoney(payment.amount)}
+                              <br />
+                              {payment.accountName || 'No account'} - {payment.isReconciled ? 'reconciled' : 'not reconciled'}
+                            </div>
+                          ))}
+                        </div>
+                      </td>
+
+                      <td className="max-w-[320px] px-5 py-5">
+                        <span className={cn('inline-flex rounded-full px-3 py-1 text-xs font-semibold', decisionClass(item.decision))}>
+                          {item.decisionLabel}
+                        </span>
+                        <p className="mt-3 text-sm leading-6 text-white/60">{item.nextStep}</p>
+                      </td>
+
+                      <td className="max-w-[380px] px-5 py-5">
+                        {item.candidates.length === 0 ? (
+                          <div className="rounded-2xl border border-white/10 bg-black/25 p-3 text-xs leading-5 text-white/45">
+                            No local bank-line mirror candidate. This can still exist in live Xero, but this page cannot prove it.
+                          </div>
+                        ) : (
+                          <div className="space-y-2">
+                            {item.candidates.map((candidate) => (
+                              <div key={candidate.id} className="rounded-2xl border border-white/10 bg-black/25 p-3">
+                                <div className="flex items-start justify-between gap-3">
+                                  <div>
+                                    <p className="text-sm font-medium text-white">{candidate.payee}</p>
+                                    <p className="mt-1 text-xs text-white/45">
+                                      {dateLabel(candidate.date)} - {formatMoney(candidate.amount)} - {candidate.bankAccount || 'bank account unknown'}
+                                    </p>
+                                  </div>
+                                  <span
+                                    className={cn(
+                                      'rounded-full px-2 py-1 text-[11px]',
+                                      candidate.status === 'reconciled' ? 'bg-emerald-400/15 text-emerald-100' : 'bg-amber-400/15 text-amber-100'
+                                    )}
+                                  >
+                                    {candidate.status || 'unknown'}
+                                  </span>
+                                </div>
+                                <p className="mt-2 text-[11px] text-white/35">
+                                  vendor {candidate.vendorScore}% - date delta {candidate.dateDeltaDays ?? '?'}d - project {candidate.projectCode || 'none'}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </td>
+
+                      <td className="px-5 py-5">
+                        <select
+                          value={selectedProject}
+                          onChange={(e) => setPendingProjects((current) => ({ ...current, [item.id]: e.target.value }))}
+                          className={cn(
+                            'w-60 rounded-xl border bg-black/35 px-3 py-2 text-xs text-white outline-none',
+                            item.needsProjectReview ? 'border-amber-400/50' : 'border-white/10'
+                          )}
+                        >
+                          <option value="">No project</option>
+                          {projects.map((p) => (
+                            <option key={p.code} value={p.code}>
+                              {p.code} - {p.name || 'Unnamed'}
+                            </option>
+                          ))}
+                        </select>
+                        <p className="mt-2 text-[11px] text-white/35">
+                          {item.projectSource || 'no source'}
+                          {item.needsProjectReview ? ' - review' : ''}
+                        </p>
+                      </td>
+
+                      <td className="px-5 py-5">
+                        <div className="flex flex-col gap-2">
+                          <button
+                            type="button"
+                            disabled={!projectChanged || mutation.isPending}
+                            onClick={() => mutation.mutate({ id: item.id, projectCode: selectedProject })}
+                            className="inline-flex items-center justify-center gap-2 rounded-xl bg-cyan-400/15 px-3 py-2 text-xs font-semibold text-cyan-100 transition hover:bg-cyan-400/25 disabled:cursor-not-allowed disabled:opacity-35"
+                          >
+                            {mutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : <Tags className="h-3 w-3" />}
+                            Save project
+                          </button>
+                          <a
+                            href={xeroBillUrl(item)}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-white/60 transition hover:bg-white/10 hover:text-white"
+                          >
+                            Open Xero bill
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                          <Link
+                            href={item.receiptEvidenceUrl}
+                            className="inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 px-3 py-2 text-xs text-white/60 transition hover:bg-white/10 hover:text-white"
+                          >
+                            Receipt evidence
+                            <ExternalLink className="h-3 w-3" />
+                          </Link>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/command-center/src/app/finance/page.tsx
+++ b/apps/command-center/src/app/finance/page.tsx
@@ -13,6 +13,7 @@ import {
   ShieldAlert,
   Bot,
 } from 'lucide-react'
+import { TodayActionsHero } from '@/components/finance/TodayActionsHero'
 
 // Canonical /finance index page (2026-05-08 cleanup).
 // Per the 4-surface model in CLAUDE.md: command-center owns *operate* tasks.
@@ -131,7 +132,7 @@ const otherSurfaces: Array<{
 export default function FinanceIndexPage() {
   return (
     <main className="mx-auto max-w-6xl px-6 py-10">
-      <header className="mb-8">
+      <header className="mb-6">
         <p className="text-xs uppercase tracking-wider text-muted-foreground">Finance</p>
         <h1 className="mt-1 text-3xl font-semibold tracking-tight">Operate</h1>
         <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
@@ -139,6 +140,8 @@ export default function FinanceIndexPage() {
           drill into a project. For reading and planning use Notion. For pushes use Telegram.
         </p>
       </header>
+
+      <TodayActionsHero />
 
       <section aria-labelledby="cards" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         <h2 id="cards" className="sr-only">Operate</h2>

--- a/apps/command-center/src/app/finance/page.tsx
+++ b/apps/command-center/src/app/finance/page.tsx
@@ -9,11 +9,14 @@ import {
   ExternalLink,
   Tag,
   Layers,
+  ClipboardList,
+  ShieldAlert,
+  Bot,
 } from 'lucide-react'
 
 // Canonical /finance index page (2026-05-08 cleanup).
 // Per the 4-surface model in CLAUDE.md: command-center owns *operate* tasks.
-// This page is the front door to the 7 keeper routes. Notion/scripts/Telegram
+// This page is the front door to the keeper routes. Notion/scripts/Telegram
 // links sit in the footer for cross-surface awareness.
 
 const cards: Array<{
@@ -23,6 +26,27 @@ const cards: Array<{
   icon: typeof DollarSign
   accent: string
 }> = [
+  {
+    title: 'Finance workbench',
+    href: '/finance/workbench',
+    description: 'One table for receipts, project codes, income/outgoing, and R&D review.',
+    icon: ClipboardList,
+    accent: 'from-cyan-500/10 to-cyan-500/5 border-cyan-500/30',
+  },
+  {
+    title: 'Dext push audit',
+    href: '/finance/dext-push-audit',
+    description: 'Audit Dext-created Xero bills before Find & Match. Prevent duplicate spend.',
+    icon: ShieldAlert,
+    accent: 'from-red-500/10 to-red-500/5 border-red-500/30',
+  },
+  {
+    title: 'Xero page copilot',
+    href: '/finance/xero-page-copilot',
+    description: 'Paste one Xero Reconcile page and get a safe row-by-row action queue.',
+    icon: Bot,
+    accent: 'from-cyan-500/10 to-amber-500/5 border-cyan-500/30',
+  },
   {
     title: 'CEO money cockpit',
     href: '/finance/overview',

--- a/apps/command-center/src/app/finance/receipt-evidence/page.tsx
+++ b/apps/command-center/src/app/finance/receipt-evidence/page.tsx
@@ -1,0 +1,1283 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import Link from 'next/link'
+import {
+  ArrowLeft,
+  CalendarDays,
+  CheckCircle2,
+  ExternalLink,
+  FileSearch,
+  Link2,
+  Loader2,
+  Mail,
+  MapPin,
+  Receipt,
+  RefreshCw,
+  Search,
+  Upload,
+  XCircle,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatMoney } from '@/lib/finance'
+
+type Quarter = 'Q2' | 'Q3' | 'Q4' | 'Q1'
+
+interface EvidenceCandidate {
+  link_id: string
+  document_id: string
+  source: string
+  source_record_id: string
+  source_table?: string | null
+  vendor_name: string | null
+  document_number?: string | null
+  document_date: string | null
+  received_at: string | null
+  amount_total: number | null
+  attachment_filename: string | null
+  attachment_content_type: string | null
+  status: string
+  link_status: string
+  match_method: string
+  confidence: number | null
+  rank: number | null
+  amount_delta: number | null
+  date_delta_days: number | null
+  xero_action: string
+  xero_invoice_id?: string | null
+  xero_bank_transaction_id?: string | null
+  signed_url?: string | null
+}
+
+interface EvidenceRow {
+  id: string
+  date: string
+  payee: string | null
+  particulars: string | null
+  reference: string | null
+  amount: number
+  status: string | null
+  bank_account: string | null
+  matched_xero_transaction_id: string | null
+  xero_transaction_id: string | null
+  project_code: string | null
+  rd_eligible: boolean | null
+  receipt_match_status: string | null
+  candidate_count: number
+  best_confidence: number | null
+  best_source: string | null
+  best_vendor_name: string | null
+  evidence_status: string
+  legacy_evidence_status?: string | null
+  legacy_no_receipt_candidate?: boolean
+  receipt_candidates: EvidenceCandidate[]
+}
+
+interface CalendarEvent {
+  id: string
+  title: string | null
+  start_time: string
+  end_time?: string | null
+  location?: string | null
+  relevance?: number
+}
+
+interface CalendarContext {
+  count: number
+  hint: string | null
+  vendor_matched: CalendarEvent[]
+  contextual: CalendarEvent[]
+}
+
+interface EvidenceResponse {
+  quarter: Quarter
+  dateStart: string
+  dateEnd: string
+  status: string
+  rows: EvidenceRow[]
+  count: number
+  totalMatchingFilter: number
+  stats: Record<string, number>
+  error?: string
+}
+
+const STATUSES = [
+  { value: 'needs_receipt', label: 'Need receipt' },
+  { value: 'ready_to_review', label: 'Review candidates' },
+  { value: 'high_confidence_candidate', label: 'High confidence' },
+  { value: 'legacy_no_receipt_candidates', label: 'Small receipts found' },
+  { value: 'candidate', label: 'Candidates' },
+  { value: 'uncovered', label: 'Uncovered' },
+  { value: 'covered_unreconciled', label: 'Covered, unreconciled' },
+  { value: 'unreconciled', label: 'Xero mirror unreconciled' },
+  { value: 'reconciled', label: 'Xero mirror reconciled' },
+  { value: 'covered_evidence', label: 'Evidence covered' },
+  { value: 'covered_legacy', label: 'Legacy covered' },
+  { value: 'no_receipt_needed', label: 'No receipt needed' },
+  { value: 'all', label: 'All' },
+]
+
+function pct(value: number | null | undefined) {
+  if (!value) return '0%'
+  return `${Math.round(value * 100)}%`
+}
+
+function statusLabel(value: string) {
+  return value.replace(/_/g, ' ')
+}
+
+function statusClass(value: string) {
+  if (value === 'covered_evidence' || value === 'covered_legacy' || value === 'no_receipt_needed') {
+    return 'bg-emerald-500/10 text-emerald-300'
+  }
+  if (value === 'high_confidence_candidate') return 'bg-amber-500/10 text-amber-300'
+  if (value === 'candidate') return 'bg-blue-500/10 text-blue-300'
+  return 'bg-red-500/10 text-red-300'
+}
+
+function sourceLabel(source: string) {
+  return source.replace(/_/g, ' ')
+}
+
+function isImage(candidate: EvidenceCandidate) {
+  const mime = candidate.attachment_content_type || ''
+  const filename = candidate.attachment_filename || ''
+  return mime.startsWith('image/') || /\.(png|jpe?g|webp|gif|tiff?)$/i.test(filename)
+}
+
+function isPdf(candidate: EvidenceCandidate) {
+  const mime = candidate.attachment_content_type || ''
+  const filename = candidate.attachment_filename || ''
+  return mime.includes('pdf') || /\.pdf$/i.test(filename)
+}
+
+function hasPreviewableFile(candidate: EvidenceCandidate) {
+  return Boolean(candidate.signed_url && (isImage(candidate) || isPdf(candidate)))
+}
+
+function hasLinkedFile(candidate: EvidenceCandidate) {
+  return Boolean(candidate.signed_url)
+}
+
+function isReceiptEvidenceCandidate(candidate: EvidenceCandidate) {
+  const source = candidate.source || ''
+  const sourceTable = candidate.source_table || ''
+  return Boolean(
+    candidate.signed_url ||
+    candidate.xero_action === 'attach_file' ||
+    source.includes('receipt') ||
+    source.includes('dext') ||
+    source.includes('xero_me') ||
+    sourceTable === 'receipt_emails',
+  )
+}
+
+function bestReceiptCandidate(candidates: EvidenceCandidate[]) {
+  return candidates.find((candidate) => isReceiptEvidenceCandidate(candidate) && hasPreviewableFile(candidate))
+    || candidates.find((candidate) => isReceiptEvidenceCandidate(candidate) && hasLinkedFile(candidate))
+    || candidates.find(isReceiptEvidenceCandidate)
+    || candidates.find(hasLinkedFile)
+    || candidates[0]
+    || null
+}
+
+function bestXeroCandidate(candidates: EvidenceCandidate[]) {
+  return candidates.find((candidate) => candidate.source === 'xero_bill' && candidate.xero_invoice_id)
+    || candidates.find((candidate) => Boolean(candidate.xero_invoice_id))
+    || candidates.find((candidate) => candidate.source === 'xero_transaction' && candidate.xero_bank_transaction_id)
+    || candidates.find((candidate) => Boolean(candidate.xero_bank_transaction_id))
+    || candidates.find((candidate) => candidate.source.startsWith('xero_'))
+    || null
+}
+
+function addDays(dateString: string, days: number) {
+  const d = new Date(`${dateString}T00:00:00+10:00`)
+  d.setDate(d.getDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+function gmailSearchUrl(row: EvidenceRow) {
+  const vendor = (row.payee || row.best_vendor_name || '').replace(/["()]/g, ' ').trim()
+  const after = addDays(row.date, -7).replace(/-/g, '/')
+  const before = addDays(row.date, 8).replace(/-/g, '/')
+  const query = `"${vendor}" (receipt OR invoice OR tax OR booking OR confirmation) after:${after} before:${before}`
+  return `https://mail.google.com/mail/u/0/#search/${encodeURIComponent(query)}`
+}
+
+function xeroInvoiceUrl(id: string) {
+  return `https://go.xero.com/AccountsPayable/View.aspx?InvoiceID=${id}`
+}
+
+function xeroBankTransactionUrl(id: string) {
+  return `https://go.xero.com/Bank/ViewTransaction.aspx?bankTransactionID=${id}`
+}
+
+function pdfPreviewUrl(candidate: EvidenceCandidate, dpi = 180) {
+  if (!candidate.signed_url) return ''
+  const params = new URLSearchParams({
+    url: candidate.signed_url,
+    page: '1',
+    dpi: String(dpi),
+  })
+  return `/api/finance/receipt-evidence/pdf-preview?${params.toString()}`
+}
+
+function initialParam(name: string, fallback: string) {
+  if (typeof window === 'undefined') return fallback
+  return new URLSearchParams(window.location.search).get(name) || fallback
+}
+
+function xeroNextAction(row: EvidenceRow, candidate?: EvidenceCandidate | null, xeroCandidate?: EvidenceCandidate | null) {
+  if (!candidate) {
+    return {
+      tone: 'missing',
+      title: 'Find or upload a receipt first',
+      body: 'No usable receipt candidate is linked to this bank line yet.',
+      steps: ['Search Gmail', 'Check Dext/Xero Files', 'Upload a PDF/image here if you have it'],
+      href: gmailSearchUrl(row),
+      label: 'Search Gmail',
+    }
+  }
+
+  const invoiceCandidate = candidate.xero_invoice_id
+    ? candidate
+    : xeroCandidate?.xero_invoice_id
+      ? xeroCandidate
+      : null
+
+  if (invoiceCandidate?.xero_invoice_id) {
+    return {
+      tone: 'match',
+      title: 'Receipt is already on a Xero bill',
+      body: 'Best next step: open the bill, then use Xero bank reconciliation Find & Match to match this bank-feed line to that bill. No receipt upload needed first.',
+      steps: [
+        'Approve this evidence link here',
+        'Open the Xero bill and confirm amount/vendor/date',
+        'In Xero bank reconciliation, Find & Match this bank line to the bill',
+      ],
+      href: xeroInvoiceUrl(invoiceCandidate.xero_invoice_id),
+      label: 'Open Xero bill',
+    }
+  }
+
+  const bankTxnId = candidate.xero_bank_transaction_id
+    || xeroCandidate?.xero_bank_transaction_id
+    || row.xero_transaction_id
+    || row.matched_xero_transaction_id
+  if (bankTxnId && candidate.signed_url) {
+    return {
+      tone: 'attach',
+      title: 'Receipt can be attached to Xero',
+      body: 'This file is in our receipt store and we have a Xero bank transaction ID. Actual upload should stay approval-gated because it writes to Xero.',
+      steps: [
+        'Approve this evidence link here',
+        'Queue/approve Xero attachment upload',
+        'Reopen Xero and reconcile the bank-feed line',
+      ],
+      href: xeroBankTransactionUrl(bankTxnId),
+      label: 'Open Xero bank txn',
+    }
+  }
+
+  if (candidate.signed_url && candidate.xero_action === 'attach_file') {
+    return {
+      tone: 'attach_after_reconcile',
+      title: 'Receipt is ready; Xero target is not linked yet',
+      body: 'The receipt file is in our evidence store, but this mirror does not know the exact Xero transaction ID yet. Reconcile/create the transaction in Xero UI, rerun Xero sync, then the attachment step can be automated safely.',
+      steps: [
+        'Confirm this receipt image matches amount/vendor/date',
+        'Approve this evidence link here',
+        'Use Xero UI to reconcile/create the bank transaction, then rerun Xero sync',
+      ],
+      href: candidate.signed_url,
+      label: 'Open receipt file',
+    }
+  }
+
+  return {
+    tone: 'review',
+    title: 'Receipt found, Xero target unclear',
+    body: 'The receipt looks useful, but this mirror does not yet know the exact Xero bank transaction to attach it to.',
+    steps: [
+      'Approve the receipt evidence if it is correct',
+      'Use Xero Find & Match if there is a matching bill',
+      'If Xero was changed manually, rerun the Xero sync before upload',
+    ],
+    href: candidate.signed_url || gmailSearchUrl(row),
+    label: candidate.signed_url ? 'Open receipt file' : 'Search Gmail',
+  }
+}
+
+function ReceiptPreview({
+  candidate,
+  maxHeightClass = 'max-h-[560px]',
+  frameHeightClass = 'h-[560px]',
+}: {
+  candidate: EvidenceCandidate
+  maxHeightClass?: string
+  frameHeightClass?: string
+}) {
+  const [largeOpen, setLargeOpen] = useState(false)
+
+  useEffect(() => {
+    if (!largeOpen) return
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setLargeOpen(false)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [largeOpen])
+
+  if (isImage(candidate) && candidate.signed_url) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setLargeOpen(true)}
+          className="group relative w-full cursor-zoom-in overflow-hidden rounded-xl border border-white/10 bg-white"
+        >
+          <img
+            src={candidate.signed_url}
+            alt={candidate.attachment_filename || 'Receipt preview'}
+            className={cn(maxHeightClass, 'w-full select-none object-contain')}
+            draggable={false}
+          />
+          <div className="pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3 text-left text-xs font-semibold text-white opacity-0 transition-opacity group-hover:opacity-100">
+            Click to view large
+          </div>
+        </button>
+        {largeOpen && <ReceiptLargeModal candidate={candidate} onClose={() => setLargeOpen(false)} />}
+      </>
+    )
+  }
+
+  if (isPdf(candidate) && candidate.signed_url) {
+    const previewUrl = pdfPreviewUrl(candidate)
+    return (
+      <div className="overflow-hidden rounded-xl border border-white/10 bg-white">
+        <div className="flex items-center justify-between gap-3 border-b border-slate-200 bg-slate-100 px-3 py-2">
+          <span className="truncate text-xs font-semibold text-slate-600">PDF receipt, page 1</span>
+          <button
+            type="button"
+            onClick={() => setLargeOpen(true)}
+            className="rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-slate-700"
+          >
+            View large
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={() => setLargeOpen(true)}
+          className="group block w-full bg-white"
+        >
+          <img
+            src={previewUrl}
+            alt={candidate.attachment_filename || 'Receipt PDF page 1 preview'}
+            className={cn(frameHeightClass, 'mx-auto w-full object-contain')}
+          />
+          <div className="border-t border-slate-200 bg-slate-50 px-3 py-2 text-left text-xs text-slate-600 group-hover:bg-cyan-50">
+            Rendered preview. Click to view large.
+          </div>
+        </button>
+        {largeOpen && <ReceiptLargeModal candidate={candidate} onClose={() => setLargeOpen(false)} />}
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white p-5 text-sm text-slate-700">
+      Preview unavailable for this file type. Open the file directly.
+    </div>
+  )
+}
+
+function ReceiptLargeModal({
+  candidate,
+  onClose,
+}: {
+  candidate: EvidenceCandidate
+  onClose: () => void
+}) {
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/80 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="flex h-[92vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl border border-white/15 bg-slate-950 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-3 border-b border-white/10 bg-slate-900 px-4 py-3">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold text-white">
+              {candidate.attachment_filename || candidate.vendor_name || 'Receipt'}
+            </p>
+            <p className="mt-0.5 text-xs text-white/45">{sourceLabel(candidate.source)} · {candidate.document_date || 'unknown date'}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg bg-white/10 px-3 py-2 text-xs font-semibold text-white/75 hover:bg-white/15"
+          >
+            Close
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 bg-white">
+          {candidate.signed_url && isImage(candidate) ? (
+            <div className="flex h-full items-center justify-center overflow-auto bg-slate-100 p-4">
+              <img
+                src={candidate.signed_url}
+                alt={candidate.attachment_filename || 'Receipt large preview'}
+                className="max-h-full max-w-full object-contain"
+              />
+            </div>
+          ) : candidate.signed_url && isPdf(candidate) ? (
+            <div className="h-full overflow-auto bg-slate-100 p-4">
+              <img
+                src={pdfPreviewUrl(candidate, 220)}
+                alt={candidate.attachment_filename || 'Receipt PDF large preview'}
+                className="mx-auto h-auto max-w-full rounded-lg bg-white shadow"
+              />
+            </div>
+          ) : (
+            <div className="p-6 text-sm text-slate-700">Preview unavailable for this file type.</div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+function BestReceiptPanel({
+  row,
+  candidate,
+  xeroCandidate,
+  onAction,
+  busy,
+}: {
+  row: EvidenceRow
+  candidate: EvidenceCandidate | null
+  xeroCandidate: EvidenceCandidate | null
+  onAction: (action: string, payload: Record<string, unknown>) => void
+  busy: boolean
+}) {
+  const next = xeroNextAction(row, candidate, xeroCandidate)
+  const confidence = candidate?.confidence || 0
+  const evidenceApproved = candidate?.link_status === 'approved'
+  const queueLabel = next.tone === 'match'
+    ? 'Queue Find & Match'
+    : next.tone === 'attach'
+      ? 'Queue Xero upload'
+      : 'Queue Xero follow-up'
+
+  return (
+    <div className="rounded-2xl border border-cyan-400/25 bg-cyan-500/[0.07] p-4 shadow-[0_0_40px_rgba(34,211,238,0.08)]">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-cyan-100">Best receipt</p>
+          <p className="mt-1 text-xs text-cyan-100/55">
+            Confirm the image first, then approve the evidence and do the Xero step.
+          </p>
+          {candidate && (
+            <p className="mt-1 truncate text-xs text-cyan-100/40">
+              {sourceLabel(candidate.source)}
+              {candidate.attachment_filename ? ` · ${candidate.attachment_filename}` : ''}
+              {candidate.document_number ? ` · ${candidate.document_number}` : ''}
+            </p>
+          )}
+          {candidate && xeroCandidate && xeroCandidate.link_id !== candidate.link_id && (
+            <p className="mt-1 truncate text-xs text-cyan-100/35">
+              Xero signal: {sourceLabel(xeroCandidate.source)} · {pct(xeroCandidate.confidence)}
+              {xeroCandidate.document_number ? ` · ${xeroCandidate.document_number}` : ''}
+            </p>
+          )}
+        </div>
+        {candidate && (
+          <span
+            className={cn(
+              'rounded-full px-2.5 py-1 text-xs font-bold tabular-nums',
+              confidence >= 0.85 ? 'bg-emerald-400/15 text-emerald-200' :
+                confidence >= 0.65 ? 'bg-amber-400/15 text-amber-200' :
+                  'bg-white/10 text-white/55',
+            )}
+          >
+            {pct(confidence)}
+          </span>
+        )}
+      </div>
+
+      {candidate?.signed_url ? (
+        <ReceiptPreview candidate={candidate} />
+      ) : (
+        <div className="rounded-xl border border-dashed border-white/15 bg-black/25 p-5 text-sm text-white/45">
+          No receipt preview is available yet. Search Gmail or upload a file below.
+        </div>
+      )}
+
+      {candidate && (
+        <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
+          <div>
+            <p className="text-cyan-100/35">Vendor</p>
+            <p className="truncate text-cyan-50/80">{candidate.vendor_name || row.best_vendor_name || 'unknown'}</p>
+          </div>
+          <div>
+            <p className="text-cyan-100/35">Amount</p>
+            <p className="text-cyan-50/80">{candidate.amount_total ? formatMoney(Number(candidate.amount_total)) : 'unknown'}</p>
+          </div>
+          <div>
+            <p className="text-cyan-100/35">Date delta</p>
+            <p className="text-cyan-50/80">
+              {candidate.date_delta_days !== null ? `${candidate.date_delta_days}d` : 'unknown'}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4 rounded-xl border border-white/10 bg-black/25 p-3">
+        <p className="text-sm font-semibold text-white/90">Xero next step: {next.title}</p>
+        <p className="mt-1 text-xs leading-relaxed text-white/55">{next.body}</p>
+        <div className="mt-3 space-y-1 text-xs text-white/55">
+          {next.steps.map((step, index) => (
+            <p key={step}>{index + 1}. {step}</p>
+          ))}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {candidate && (
+            <button
+              disabled={busy || evidenceApproved}
+              onClick={() => onAction('approve_link', { linkId: candidate.link_id, syncLegacy: true })}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-500/15 px-3 py-1.5 text-xs font-semibold text-emerald-200 hover:bg-emerald-500/25 disabled:opacity-40"
+            >
+              {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+              {evidenceApproved ? 'Evidence approved' : 'Approve evidence'}
+            </button>
+          )}
+          {candidate && !evidenceApproved && (
+            <button
+              disabled={busy}
+              onClick={() => onAction('reject_link', {
+                linkId: candidate.link_id,
+                reviewOwner: 'Ben',
+                reviewNote: 'Rejected from best receipt preview: wrong amount/date/vendor for this bank line.',
+              })}
+              className="inline-flex items-center gap-1 rounded-md bg-red-500/10 px-3 py-1.5 text-xs font-semibold text-red-200 hover:bg-red-500/20 disabled:opacity-40"
+            >
+              <XCircle className="h-3.5 w-3.5" />
+              Wrong receipt
+            </button>
+          )}
+          {candidate && (
+            <button
+              disabled={busy}
+              onClick={() => onAction('needs_review', {
+                linkId: candidate.link_id,
+                reviewOwner: 'Ben/Xero',
+                reviewNote: `Queued from receipt evidence hub: ${next.title}`,
+              })}
+              className="inline-flex items-center gap-1 rounded-md bg-cyan-500/15 px-3 py-1.5 text-xs font-semibold text-cyan-100 hover:bg-cyan-500/25 disabled:opacity-40"
+            >
+              <Link2 className="h-3.5 w-3.5" />
+              {queueLabel}
+            </button>
+          )}
+          <a
+            href={next.href}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 rounded-md bg-white/10 px-3 py-1.5 text-xs font-semibold text-white/70 hover:bg-white/15"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            {next.label}
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function CandidateCard({
+  row,
+  candidate,
+  showPreview,
+  onAction,
+  busy,
+}: {
+  row: EvidenceRow
+  candidate: EvidenceCandidate
+  showPreview: boolean
+  onAction: (action: string, payload: Record<string, unknown>) => void
+  busy: boolean
+}) {
+  const confidence = candidate.confidence || 0
+  const [previewOpen, setPreviewOpen] = useState(showPreview)
+  const canPreview = Boolean(candidate.signed_url)
+
+  useEffect(() => {
+    setPreviewOpen(showPreview)
+  }, [showPreview, candidate.link_id])
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/[0.03] p-3">
+      <div className="flex items-start gap-3">
+        <div className="mt-1 rounded-lg bg-cyan-500/10 p-2">
+          <Receipt className="h-4 w-4 text-cyan-300" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-white/90">
+                {candidate.vendor_name || row.best_vendor_name || 'Unknown document'}
+              </p>
+              <p className="mt-1 text-xs text-white/45">
+                {sourceLabel(candidate.source)} · {candidate.match_method} · {candidate.xero_action}
+              </p>
+            </div>
+            <span
+              className={cn(
+                'rounded-full px-2 py-1 text-xs font-semibold tabular-nums',
+                confidence >= 0.85 ? 'bg-emerald-500/15 text-emerald-300' :
+                  confidence >= 0.65 ? 'bg-amber-500/15 text-amber-300' :
+                    'bg-white/10 text-white/50',
+              )}
+            >
+              {pct(confidence)}
+            </span>
+          </div>
+
+          <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
+            <div>
+              <p className="text-white/30">Amount</p>
+              <p className="text-white/70">{candidate.amount_total ? formatMoney(Number(candidate.amount_total)) : 'unknown'}</p>
+            </div>
+            <div>
+              <p className="text-white/30">Date</p>
+              <p className="text-white/70">{candidate.document_date || candidate.received_at?.slice(0, 10) || 'unknown'}</p>
+            </div>
+            <div>
+              <p className="text-white/30">Delta</p>
+              <p className="text-white/70">
+                {candidate.amount_delta !== null ? formatMoney(Number(candidate.amount_delta)) : 'n/a'}
+                {candidate.date_delta_days !== null ? ` · ${candidate.date_delta_days}d` : ''}
+              </p>
+            </div>
+          </div>
+
+          {candidate.attachment_filename && (
+            <p className="mt-2 truncate text-xs text-white/35">{candidate.attachment_filename}</p>
+          )}
+
+          {previewOpen && candidate.signed_url && (
+            <div className="mt-3">
+              <ReceiptPreview
+                candidate={candidate}
+                maxHeightClass="max-h-[420px]"
+                frameHeightClass="h-[420px]"
+              />
+            </div>
+          )}
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            {canPreview && (
+              <button
+                type="button"
+                onClick={() => setPreviewOpen((current) => !current)}
+                className="inline-flex items-center gap-1 rounded-md bg-white/10 px-3 py-1.5 text-xs font-medium text-white/70 hover:bg-white/15"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                {previewOpen ? 'Hide receipt' : 'Show receipt'}
+              </button>
+            )}
+            <button
+              disabled={busy}
+              onClick={() => onAction('approve_link', { linkId: candidate.link_id, syncLegacy: true })}
+              className="inline-flex items-center gap-1 rounded-md bg-emerald-500/15 px-3 py-1.5 text-xs font-medium text-emerald-300 hover:bg-emerald-500/25 disabled:opacity-40"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              Approve + mark covered
+            </button>
+            <button
+              disabled={busy}
+              onClick={() => onAction('reject_link', { linkId: candidate.link_id })}
+              className="inline-flex items-center gap-1 rounded-md bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/20 disabled:opacity-40"
+            >
+              <XCircle className="h-3.5 w-3.5" />
+              Reject
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function UploadBox({
+  row,
+  onUploaded,
+}: {
+  row: EvidenceRow
+  onUploaded: () => void
+}) {
+  const [file, setFile] = useState<File | null>(null)
+  const [vendorName, setVendorName] = useState(row.payee || '')
+  const [amountTotal, setAmountTotal] = useState(String(Math.abs(Number(row.amount) || 0)))
+  const [documentDate, setDocumentDate] = useState(row.date)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function upload() {
+    if (!file) {
+      setError('Choose a receipt file first.')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      const form = new FormData()
+      form.set('file', file)
+      form.set('bankLineId', row.id)
+      form.set('vendorName', vendorName)
+      form.set('amountTotal', amountTotal)
+      form.set('documentDate', documentDate)
+      form.set('reviewNote', 'Manual upload from receipt evidence hub')
+      const res = await fetch('/api/finance/receipt-evidence', { method: 'POST', body: form })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Upload failed')
+      setFile(null)
+      onUploaded()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-dashed border-white/15 bg-black/20 p-4">
+      <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-white/80">
+        <Upload className="h-4 w-4 text-cyan-300" />
+        Add receipt manually
+      </div>
+      <div className="grid gap-3 md:grid-cols-4">
+        <input
+          type="file"
+          onChange={(e) => setFile(e.target.files?.[0] || null)}
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/70 file:mr-3 file:rounded-md file:border-0 file:bg-white/10 file:px-2 file:py-1 file:text-white/80"
+        />
+        <input
+          value={vendorName}
+          onChange={(e) => setVendorName(e.target.value)}
+          placeholder="Vendor"
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/80 outline-none focus:border-cyan-400/50"
+        />
+        <input
+          value={amountTotal}
+          onChange={(e) => setAmountTotal(e.target.value)}
+          type="number"
+          step="0.01"
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/80 outline-none focus:border-cyan-400/50"
+        />
+        <input
+          value={documentDate}
+          onChange={(e) => setDocumentDate(e.target.value)}
+          type="date"
+          className="rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs text-white/80 outline-none focus:border-cyan-400/50"
+        />
+      </div>
+      <div className="mt-3 flex items-center gap-3">
+        <button
+          disabled={busy || !file}
+          onClick={upload}
+          className="inline-flex items-center gap-2 rounded-lg bg-cyan-500/15 px-4 py-2 text-xs font-semibold text-cyan-200 hover:bg-cyan-500/25 disabled:opacity-40"
+        >
+          {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
+          Upload + link
+        </button>
+        {error && <p className="text-xs text-red-300">{error}</p>}
+      </div>
+    </div>
+  )
+}
+
+export default function ReceiptEvidencePage() {
+  const [quarter, setQuarter] = useState<Quarter>(() => initialParam('quarter', 'Q2').toUpperCase() as Quarter)
+  const [status, setStatus] = useState(() => initialParam('status', 'needs_receipt'))
+  const [search, setSearch] = useState(() => initialParam('search', ''))
+  const [data, setData] = useState<EvidenceResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [calendarContext, setCalendarContext] = useState<CalendarContext | null>(null)
+  const [calendarLoading, setCalendarLoading] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    setError(null)
+    try {
+      const params = new URLSearchParams({ quarter, status, limit: '300' })
+      if (search.trim()) params.set('search', search.trim())
+      const res = await fetch(`/api/finance/receipt-evidence?${params.toString()}`)
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Failed to load receipt evidence')
+      setData(json)
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    load()
+  }, [quarter, status])
+
+  const rows = data?.rows || []
+  const stats = data?.stats || {}
+  const totalSpend = Number(stats.spend || 0)
+  const covered = Number(stats.covered_evidence || 0) + Number(stats.covered_legacy || 0) + Number(stats.no_receipt_needed || 0)
+  const total = Number(stats.total || 0)
+  const coveragePct = total ? Math.round((covered / total) * 100) : 0
+
+  useEffect(() => {
+    if (!rows.length) {
+      if (expandedId) setExpandedId(null)
+      return
+    }
+
+    if (!expandedId || !rows.some((row) => row.id === expandedId)) {
+      setExpandedId(rows[0].id)
+    }
+  }, [rows, expandedId])
+
+  const selected = useMemo(() => rows.find((row) => row.id === expandedId) || null, [rows, expandedId])
+  const receiptCandidate = useMemo(
+    () => bestReceiptCandidate(selected?.receipt_candidates || []),
+    [selected],
+  )
+  const xeroCandidate = useMemo(
+    () => bestXeroCandidate(selected?.receipt_candidates || []),
+    [selected],
+  )
+  const xeroTargetLabel = selected?.xero_transaction_id || selected?.matched_xero_transaction_id
+    ? 'transaction linked'
+    : xeroCandidate?.xero_bank_transaction_id
+      ? 'transaction candidate'
+      : xeroCandidate?.xero_invoice_id
+        ? 'bill candidate'
+        : 'not linked'
+  const hasXeroTarget = xeroTargetLabel !== 'not linked'
+
+  useEffect(() => {
+    if (!selected) {
+      setCalendarContext(null)
+      return
+    }
+
+    let cancelled = false
+    async function loadCalendarContext() {
+      setCalendarLoading(true)
+      try {
+        const vendor = encodeURIComponent(selected?.payee || selected?.best_vendor_name || '')
+        const res = await fetch(`/api/receipts/calendar-context/${selected?.date}?vendor=${vendor}&days=7`)
+        const json = await res.json()
+        if (!cancelled) setCalendarContext(json)
+      } catch {
+        if (!cancelled) setCalendarContext(null)
+      } finally {
+        if (!cancelled) setCalendarLoading(false)
+      }
+    }
+
+    loadCalendarContext()
+    return () => {
+      cancelled = true
+    }
+  }, [selected])
+
+  async function action(actionName: string, payload: Record<string, unknown>) {
+    const busyKey = String(payload.linkId || payload.bankLineId || actionName)
+    setBusyId(busyKey)
+    setError(null)
+    try {
+      const res = await fetch('/api/finance/receipt-evidence', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: actionName, ...payload }),
+      })
+      const json = await res.json()
+      if (!res.ok) throw new Error(json.error || 'Action failed')
+      await load()
+    } catch (e) {
+      setError((e as Error).message)
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <div className="min-h-screen p-8">
+      <header className="mb-6 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <Link href="/finance" className="mt-1 text-white/40 hover:text-white/70">
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <div>
+            <h1 className="flex items-center gap-2 text-2xl font-bold text-white">
+              <FileSearch className="h-6 w-6 text-cyan-300" />
+              Receipt Evidence Hub
+            </h1>
+            <p className="mt-1 max-w-3xl text-sm text-white/50">
+              One bank-line mirror across Gmail, Dext, Xero bills, Xero Me, Xero attachments, and manual uploads.
+              This does not reconcile in Xero; it makes the evidence visible and linkable first.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-white/70 hover:bg-white/15 disabled:opacity-40"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          Refresh
+        </button>
+      </header>
+
+      <section className="glass-card mb-6 p-4">
+        <div className="grid gap-4 md:grid-cols-7">
+          <div>
+            <p className="text-xs text-white/35">Lines</p>
+            <p className="mt-1 text-2xl font-bold text-white">{total}</p>
+          </div>
+          <div>
+            <p className="text-xs text-white/35">Debit spend</p>
+            <p className="mt-1 text-2xl font-bold text-white">{formatMoney(totalSpend)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-white/35">Evidence coverage</p>
+            <p className={cn('mt-1 text-2xl font-bold', coveragePct >= 90 ? 'text-emerald-300' : 'text-amber-300')}>
+              {coveragePct}%
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-white/35">High-confidence</p>
+            <p className="mt-1 text-2xl font-bold text-cyan-300">{Number(stats.highConfidence || 0)}</p>
+          </div>
+          <div>
+            <p className="text-xs text-white/35">Xero mirror unreconciled</p>
+            <p className="mt-1 text-2xl font-bold text-amber-300">{Number(stats.bankUnreconciled || 0)}</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => { setStatus('legacy_no_receipt_candidates'); setExpandedId(null) }}
+            className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-3 text-left hover:bg-cyan-500/15"
+          >
+            <p className="text-xs text-cyan-100/60">Small receipts found</p>
+            <p className="mt-1 text-2xl font-bold text-cyan-100">{Number(stats.legacyNoReceiptCandidates || 0)}</p>
+          </button>
+          <div>
+            <p className="text-xs text-white/35">Still uncovered</p>
+            <p className="mt-1 text-2xl font-bold text-red-300">{Number(stats.uncovered || 0)}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mb-5 grid gap-2 md:grid-cols-6">
+        {[
+          { value: 'needs_receipt', label: '1. Find missing receipts', hint: 'Uncovered + candidate lines' },
+          { value: 'ready_to_review', label: '2. Review matches', hint: 'Approve or reject evidence' },
+          { value: 'legacy_no_receipt_candidates', label: '3. Small receipts found', hint: 'Dext export/Gmail receipts hidden by old no-receipt labels' },
+          { value: 'covered_unreconciled', label: '4. Covered but not reconciled', hint: 'Ready for Xero UI work' },
+          { value: 'unreconciled', label: '5. Xero mirror unreconciled', hint: 'What the last Xero sync still shows open' },
+          { value: 'all', label: 'All lines', hint: 'Full bank mirror' },
+        ].map((item) => (
+          <button
+            key={item.value}
+            onClick={() => { setStatus(item.value); setExpandedId(null) }}
+            className={cn(
+              'rounded-xl border p-3 text-left transition-colors',
+              status === item.value
+                ? 'border-cyan-400/40 bg-cyan-500/10'
+                : 'border-white/10 bg-white/[0.03] hover:bg-white/[0.06]',
+            )}
+          >
+            <p className="text-sm font-semibold text-white/85">{item.label}</p>
+            <p className="mt-1 text-xs text-white/40">{item.hint}</p>
+          </button>
+        ))}
+      </section>
+
+      <section className="mb-5 flex flex-wrap items-center gap-3">
+        <div className="flex rounded-lg bg-white/5 p-1">
+          {(['Q2', 'Q3', 'Q4', 'Q1'] as Quarter[]).map((q) => (
+            <button
+              key={q}
+              onClick={() => { setQuarter(q); setExpandedId(null) }}
+              className={cn(
+                'rounded-md px-3 py-1.5 text-xs font-semibold',
+                quarter === q ? 'bg-white/15 text-white' : 'text-white/40 hover:text-white/70',
+              )}
+            >
+              {q}
+            </button>
+          ))}
+        </div>
+        <select
+          value={status}
+          onChange={(e) => { setStatus(e.target.value); setExpandedId(null) }}
+          className="rounded-lg border border-white/10 bg-black/30 px-3 py-2 text-sm text-white/70 outline-none"
+        >
+          {STATUSES.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+        <div className="flex min-w-[260px] flex-1 items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-3 py-2">
+          <Search className="h-4 w-4 text-white/30" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') load() }}
+            placeholder="Search vendor, reference, particulars..."
+            className="w-full bg-transparent text-sm text-white/80 outline-none placeholder:text-white/25"
+          />
+        </div>
+      </section>
+
+      {error && (
+        <div className="mb-5 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_460px]">
+        <section className="glass-card overflow-hidden">
+          <div className="border-b border-white/10 px-5 py-3 text-sm text-white/50">
+            Showing {rows.length} of {data?.totalMatchingFilter || 0} matching lines
+          </div>
+
+          {loading && !rows.length ? (
+            <div className="p-12 text-center text-white/40">Loading evidence...</div>
+          ) : rows.length === 0 ? (
+            <div className="p-12 text-center text-white/40">No rows for this filter.</div>
+          ) : (
+            <div className="divide-y divide-white/5">
+              {rows.map((row) => (
+                <button
+                  key={row.id}
+                  onClick={() => setExpandedId(expandedId === row.id ? null : row.id)}
+                  className={cn(
+                    'grid w-full grid-cols-[110px_minmax(0,1fr)_100px_120px_130px_110px] items-center gap-3 px-5 py-3 text-left transition-colors hover:bg-white/[0.04]',
+                    expandedId === row.id && 'bg-cyan-500/[0.06]',
+                  )}
+                >
+                  <div>
+                    <p className="text-sm font-bold tabular-nums text-white">{formatMoney(Math.abs(Number(row.amount) || 0))}</p>
+                    <p className="text-xs text-white/35">{row.date}</p>
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-white/85">{row.payee || 'Unknown payee'}</p>
+                    <p className="truncate text-xs text-white/35">{row.particulars || row.reference || '-'}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-white/35">Candidates</p>
+                    <p className="text-sm font-semibold text-white/75">{row.candidate_count}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs text-white/35">Xero</p>
+                    <span className={cn(
+                      'mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium capitalize',
+                      row.status === 'reconciled' ? 'bg-emerald-500/10 text-emerald-300' : 'bg-amber-500/10 text-amber-300',
+                    )}>
+                      {row.status || 'unknown'}
+                    </span>
+                  </div>
+                  <span className={cn('w-fit rounded-full px-2 py-1 text-xs font-medium capitalize', statusClass(row.evidence_status))}>
+                    {statusLabel(row.evidence_status)}
+                  </span>
+                  {row.legacy_no_receipt_candidate && (
+                    <span className="w-fit rounded-full bg-cyan-500/10 px-2 py-1 text-xs font-medium text-cyan-200">
+                      was no receipt needed
+                    </span>
+                  )}
+                  <div className="text-right">
+                    <p className="text-sm font-semibold tabular-nums text-cyan-200">{pct(row.best_confidence)}</p>
+                    <p className="truncate text-xs text-white/35">{row.best_source ? sourceLabel(row.best_source) : 'no source'}</p>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <aside className="glass-card h-fit p-5">
+          {!selected ? (
+            <div className="py-12 text-center text-white/35">
+              <Link2 className="mx-auto mb-3 h-8 w-8" />
+              Select a bank line to review candidates or upload a receipt.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-lg font-bold text-white">{formatMoney(Math.abs(Number(selected.amount) || 0))}</p>
+                    <p className="mt-1 text-sm text-white/80">{selected.payee || 'Unknown payee'}</p>
+                    <p className="mt-1 text-xs text-white/40">{selected.date} · {selected.particulars || selected.reference || '-'}</p>
+                  </div>
+                  <div className="flex flex-wrap justify-end gap-2">
+                    <span className={cn('rounded-full px-2 py-1 text-xs font-medium capitalize', statusClass(selected.evidence_status))}>
+                      {statusLabel(selected.evidence_status)}
+                    </span>
+                    {selected.legacy_no_receipt_candidate && (
+                      <span className="rounded-full bg-cyan-500/10 px-2 py-1 text-xs font-medium text-cyan-200">
+                        legacy no-receipt, receipt candidate found
+                      </span>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <span className={cn(
+                    'rounded-full px-2 py-1 text-xs font-medium capitalize',
+                    selected.status === 'reconciled' ? 'bg-emerald-500/10 text-emerald-300' : 'bg-amber-500/10 text-amber-300',
+                  )}>
+                    Xero mirror: {selected.status || 'unknown'}
+                  </span>
+                  <span className="rounded-full bg-white/10 px-2 py-1 text-xs font-medium text-white/60">
+                    Receipt: {selected.receipt_match_status || 'unknown'}
+                  </span>
+                  <span className={cn(
+                    'rounded-full px-2 py-1 text-xs font-medium',
+                    hasXeroTarget
+                      ? 'bg-cyan-500/10 text-cyan-300'
+                      : 'bg-white/10 text-white/45',
+                  )}>
+                    Xero target: {xeroTargetLabel}
+                  </span>
+                </div>
+
+                <div className="mt-4">
+                  <BestReceiptPanel
+                    row={selected}
+                    candidate={receiptCandidate}
+                    xeroCandidate={xeroCandidate}
+                    busy={receiptCandidate ? busyId === receiptCandidate.link_id : false}
+                    onAction={action}
+                  />
+                </div>
+
+                <div className="mt-4 grid gap-2 md:grid-cols-2">
+                  <a
+                    href={gmailSearchUrl(selected)}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center justify-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-xs font-semibold text-white/70 hover:bg-white/15"
+                  >
+                    <Mail className="h-3.5 w-3.5" />
+                    Search Gmail
+                  </a>
+                  <Link
+                    href={`/finance/reconciliation?quarter=${quarter}`}
+                    className="inline-flex items-center justify-center gap-2 rounded-lg bg-white/10 px-3 py-2 text-xs font-semibold text-white/70 hover:bg-white/15"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Open receipt inbox
+                  </Link>
+                </div>
+
+                <button
+                  disabled={busyId === selected.id}
+                  onClick={() => action('no_receipt_needed', { bankLineId: selected.id })}
+                  className="mt-3 inline-flex items-center gap-1 rounded-md bg-white/10 px-3 py-1.5 text-xs font-medium text-white/60 hover:bg-white/15 disabled:opacity-40"
+                >
+                  <CheckCircle2 className="h-3.5 w-3.5" />
+                  Mark no receipt needed
+                </button>
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
+                    <CalendarDays className="h-4 w-4 text-amber-300" />
+                    Calendar context
+                  </div>
+                  {calendarLoading && <Loader2 className="h-4 w-4 animate-spin text-white/30" />}
+                </div>
+                {!calendarLoading && !calendarContext?.count ? (
+                  <p className="text-xs text-white/40">
+                    No synced calendar context found within 7 days. Use Gmail/vendor search, Dext, Xero Files, or manual upload next.
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {calendarContext?.hint && <p className="text-xs text-amber-200/80">{calendarContext.hint}</p>}
+                    {[...(calendarContext?.vendor_matched || []), ...(calendarContext?.contextual || [])].slice(0, 4).map((event) => (
+                      <div key={event.id} className="rounded-lg bg-black/20 p-2">
+                        <p className="truncate text-xs font-semibold text-white/75">{event.title || 'Calendar event'}</p>
+                        <p className="mt-1 flex items-center gap-1 text-[11px] text-white/40">
+                          <MapPin className="h-3 w-3" />
+                          {new Date(event.start_time).toLocaleString('en-AU', {
+                            dateStyle: 'medium',
+                            timeStyle: 'short',
+                          })}
+                          {event.location ? ` · ${event.location}` : ''}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-xl border border-cyan-500/20 bg-cyan-500/10 p-4">
+                <p className="text-sm font-semibold text-cyan-100">Where to look next</p>
+                <div className="mt-2 space-y-1 text-xs text-cyan-100/70">
+                  <p>1. Use the top receipt preview as the source of truth for amount/date/vendor.</p>
+                  <p>2. Approve correct evidence, or reject bad matches so they stop confusing the queue.</p>
+                  <p>3. If Xero mirror is unreconciled, use Xero UI Find & Match or reconcile/create the transaction next.</p>
+                  <p>4. After Xero sync exposes a bill/transaction ID, attachment upload can be batched with approval.</p>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                {selected.receipt_candidates.length > 0 ? (
+                  selected.receipt_candidates.map((candidate) => (
+                    <CandidateCard
+                      key={candidate.link_id}
+                      row={selected}
+                      candidate={candidate}
+                      showPreview={false}
+                      busy={busyId === candidate.link_id}
+                      onAction={action}
+                    />
+                  ))
+                ) : (
+                  <div className="rounded-xl border border-white/10 bg-white/[0.03] p-4 text-sm text-white/40">
+                    No candidate receipts found yet.
+                  </div>
+                )}
+              </div>
+
+              <UploadBox row={selected} onUploaded={load} />
+            </div>
+          )}
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/apps/command-center/src/app/finance/reconciliation/page.tsx
+++ b/apps/command-center/src/app/finance/reconciliation/page.tsx
@@ -399,13 +399,36 @@ export default function ReconciliationPage() {
               <ArrowLeft className="h-5 w-5" />
             </Link>
             <div>
-              <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-                <Shield className="h-6 w-6 text-cyan-400" />
-                Spending Intelligence
+              <p className="flex items-center gap-2 text-[10px] uppercase tracking-[0.22em] text-white/40">
+                <Shield className="h-3 w-3 text-cyan-400" />
+                Spending Intelligence · {QUARTER_LABELS[quarter]}
+              </p>
+              <h1 className="mt-1 flex items-baseline gap-3 text-white">
+                <span
+                  className={cn(
+                    'text-5xl font-bold tabular-nums tracking-tight',
+                    bas
+                      ? bas.coveragePct >= 90
+                        ? 'text-emerald-400'
+                        : bas.coveragePct >= 70
+                          ? 'text-amber-400'
+                          : 'text-rose-400'
+                      : 'text-white/50',
+                  )}
+                >
+                  {bas ? `${bas.coveragePct}%` : '—'}
+                </span>
+                <span className="text-lg font-medium text-white/70">receipts matched</span>
               </h1>
-              <p className="text-sm text-white/50 mt-0.5">
-                {items.length > 0 ? `${items.length} items need attention` : 'All clear'}
-                {' · '}{QUARTER_LABELS[quarter]}
+              <p className="mt-0.5 text-sm text-white/50">
+                {items.length > 0 ? `${items.length} items still need attention` : 'All clear — nothing in the inbox'}
+                {bas && (
+                  <>
+                    {' · '}
+                    {bas.covered} of {bas.total} covered
+                    {bas.unmatched > 0 ? ` · ${bas.unmatched} unmatched` : ''}
+                  </>
+                )}
               </p>
             </div>
           </div>

--- a/apps/command-center/src/app/finance/workbench/page.tsx
+++ b/apps/command-center/src/app/finance/workbench/page.tsx
@@ -42,6 +42,16 @@ interface ProjectOption {
   status: string | null
 }
 
+interface AISuggestion {
+  id: string
+  projectCode: string
+  confidence: number
+  reason: string | null
+  riskFlags: string[]
+  model: string
+  blockedForAutoApply: boolean
+}
+
 interface WorkbenchItem {
   id: string
   source: Exclude<SourceFilter, 'all'>
@@ -70,6 +80,7 @@ interface WorkbenchItem {
   needsRdReview: boolean
   xeroReference: string | null
   receiptEvidenceUrl: string
+  aiSuggestion: AISuggestion | null
 }
 
 interface WorkbenchResponse {
@@ -215,6 +226,62 @@ function StatCard({
   )
 }
 
+function AISuggestionChip({
+  item,
+  onAccept,
+  pending,
+}: {
+  item: WorkbenchItem
+  onAccept: () => void
+  pending: boolean
+}) {
+  const s = item.aiSuggestion
+  if (!s) return null
+  const alreadyApplied = item.projectCode && item.projectCode === s.projectCode
+  const tone =
+    s.confidence >= 0.9
+      ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-200'
+      : s.confidence >= 0.75
+        ? 'border-cyan-400/40 bg-cyan-500/10 text-cyan-200'
+        : s.confidence >= 0.6
+          ? 'border-amber-400/40 bg-amber-500/10 text-amber-200'
+          : 'border-rose-400/40 bg-rose-500/10 text-rose-200'
+
+  return (
+    <div className={cn('mt-2 rounded-lg border px-2 py-1.5 text-[11px]', tone)}>
+      <div className="flex items-center gap-1.5">
+        <FlaskConical className="h-3 w-3" />
+        <span className="font-semibold tabular-nums">{s.projectCode}</span>
+        <span className="tabular-nums">{(s.confidence * 100).toFixed(0)}%</span>
+        {alreadyApplied ? (
+          <span className="ml-auto text-[10px] uppercase tracking-[0.18em] opacity-60">applied</span>
+        ) : s.blockedForAutoApply ? (
+          <span className="ml-auto text-[10px] uppercase tracking-[0.18em] opacity-60">human review</span>
+        ) : (
+          <button
+            type="button"
+            onClick={onAccept}
+            disabled={pending}
+            className="ml-auto rounded-md bg-emerald-400 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-slate-950 transition hover:bg-emerald-300 disabled:opacity-50"
+          >
+            {pending ? '…' : 'Accept'}
+          </button>
+        )}
+      </div>
+      {s.reason && <p className="mt-1 leading-tight opacity-80">{s.reason}</p>}
+      {s.riskFlags.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-1">
+          {s.riskFlags.slice(0, 3).map((f) => (
+            <span key={f} className="rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em]">
+              {f}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 async function fetchWorkbench(params: {
   source: SourceFilter
   status: StatusFilter
@@ -275,6 +342,26 @@ export default function FinanceWorkbenchPage() {
     onSuccess: () => {
       setPendingProjects({})
       setPendingRd({})
+      queryClient.invalidateQueries({ queryKey: ['finance', 'workbench'] })
+    },
+  })
+
+  const [pendingAi, setPendingAi] = useState<string | null>(null)
+  const acceptAiMutation = useMutation({
+    mutationFn: async (item: WorkbenchItem) => {
+      if (!item.aiSuggestion) throw new Error('No AI suggestion to accept')
+      setPendingAi(item.aiSuggestion.id)
+      const res = await fetch('/api/finance/workbench/accept-suggestion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ suggestionId: item.aiSuggestion.id, action: 'accept' }),
+      })
+      const data = await res.json()
+      if (!res.ok || !data.ok) throw new Error(data.error || 'Accept failed')
+      return data
+    },
+    onSettled: () => setPendingAi(null),
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['finance', 'workbench'] })
     },
   })
@@ -779,6 +866,7 @@ export default function FinanceWorkbenchPage() {
                           {item.projectSource || 'no source'}
                           {item.needsProjectReview ? ' · review broad tag' : ''}
                         </p>
+                        <AISuggestionChip item={item} onAccept={() => acceptAiMutation.mutate(item)} pending={pendingAi === item.aiSuggestion?.id} />
                       </td>
                       <td className="px-4 py-4">
                         {canEditRd ? (

--- a/apps/command-center/src/app/finance/workbench/page.tsx
+++ b/apps/command-center/src/app/finance/workbench/page.tsx
@@ -1,0 +1,868 @@
+'use client'
+
+import { startTransition, useDeferredValue, useState } from 'react'
+import Link from 'next/link'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  FlaskConical,
+  Loader2,
+  RefreshCcw,
+  Receipt,
+  Search,
+  Tags,
+  Upload,
+  X,
+} from 'lucide-react'
+import { formatMoney } from '@/lib/finance/format'
+import { cn } from '@/lib/utils'
+
+type SourceFilter = 'all' | 'bank_lines' | 'xero_transactions' | 'xero_invoices'
+type DirectionFilter = 'all' | 'spend' | 'income'
+type StatusFilter =
+  | 'needs_action'
+  | 'xero_drafts'
+  | 'receipt_gap'
+  | 'candidate_receipts'
+  | 'no_receipt_needed'
+  | 'needs_project'
+  | 'project_review'
+  | 'unreconciled'
+  | 'rd_review'
+  | 'all'
+
+interface ProjectOption {
+  code: string
+  name: string | null
+  tier: string | null
+  status: string | null
+}
+
+interface WorkbenchItem {
+  id: string
+  source: Exclude<SourceFilter, 'all'>
+  direction: 'spend' | 'income'
+  date: string | null
+  vendor: string
+  description: string | null
+  amount: number
+  xeroStatus: string | null
+  isReconciled: boolean | null
+  projectCode: string | null
+  projectSource: string | null
+  hasReceipt: boolean
+  receiptState: string
+  receiptSignal: string | null
+  candidateCount: number
+  confidence: number | null
+  rdEligible: boolean | null
+  rdCategory: string | null
+  needsProject: boolean
+  needsProjectReview: boolean
+  needsReceipt: boolean
+  needsReconciliation: boolean
+  needsXeroDraft: boolean
+  xeroDraftHint: string | null
+  needsRdReview: boolean
+  xeroReference: string | null
+  receiptEvidenceUrl: string
+}
+
+interface WorkbenchResponse {
+  fy: { start: string; end: string }
+  filters: {
+    source: SourceFilter
+    direction: DirectionFilter
+    status: StatusFilter
+    project: string
+    q: string
+    limit: number
+  }
+  summary: {
+    bankLines: number
+    receiptGaps: number
+    receiptGapValue: number
+    candidateReceipts: number
+    xeroDraftCandidates: number
+    xeroDraftCandidateValue: number
+    unreconciledBankLines: number
+    unreconciledValue: number
+    bankProjectGaps: number
+    xeroProjectGaps: number
+    invoiceProjectGaps: number
+    actInReview: number
+    rdReview: number
+    rdEligibleSpend: number
+  }
+  projects: ProjectOption[]
+  totalMatching: number
+  items: WorkbenchItem[]
+}
+
+const sourceOptions: Array<{ value: SourceFilter; label: string }> = [
+  { value: 'bank_lines', label: 'Bank lines' },
+  { value: 'xero_transactions', label: 'Xero txns' },
+  { value: 'xero_invoices', label: 'Xero invoices' },
+  { value: 'all', label: 'All mirrors' },
+]
+
+const statusOptions: Array<{ value: StatusFilter; label: string }> = [
+  { value: 'needs_action', label: 'Needs action' },
+  { value: 'xero_drafts', label: 'Xero draft assist' },
+  { value: 'receipt_gap', label: 'Receipt gaps' },
+  { value: 'candidate_receipts', label: 'Receipt candidates' },
+  { value: 'no_receipt_needed', label: 'No receipt needed' },
+  { value: 'needs_project', label: 'No project' },
+  { value: 'project_review', label: 'Review ACT-IN' },
+  { value: 'unreconciled', label: 'Unreconciled' },
+  { value: 'rd_review', label: 'R&D review' },
+  { value: 'all', label: 'All rows' },
+]
+
+const directionOptions: Array<{ value: DirectionFilter; label: string }> = [
+  { value: 'all', label: 'In + out' },
+  { value: 'spend', label: 'Outgoing' },
+  { value: 'income', label: 'Incoming' },
+]
+
+const rdOptions = [
+  { value: 'none', label: 'Not R&D' },
+  { value: 'review', label: 'Review' },
+  { value: 'supporting', label: 'R&D supporting' },
+  { value: 'core', label: 'R&D core' },
+]
+
+function initialOption<T extends string>(
+  param: string,
+  options: Array<{ value: T }>,
+  fallback: T
+): T {
+  if (typeof window === 'undefined') return fallback
+  const value = new URLSearchParams(window.location.search).get(param)
+  return options.some((option) => option.value === value) ? (value as T) : fallback
+}
+
+function initialParam(param: string, fallback = ''): string {
+  if (typeof window === 'undefined') return fallback
+  return new URLSearchParams(window.location.search).get(param) || fallback
+}
+
+function dateLabel(date: string | null): string {
+  if (!date) return 'No date'
+  return new Intl.DateTimeFormat('en-AU', { day: '2-digit', month: 'short', year: 'numeric' }).format(new Date(`${date}T00:00:00`))
+}
+
+function sourceLabel(source: WorkbenchItem['source']): string {
+  if (source === 'bank_lines') return 'Bank line'
+  if (source === 'xero_transactions') return 'Xero txn'
+  return 'Xero invoice'
+}
+
+function receiptLabel(item: WorkbenchItem): string {
+  if (item.hasReceipt) return 'Receipt linked'
+  if (item.receiptState === 'no_receipt_needed') return 'No receipt needed'
+  if (item.receiptState === 'low_value_no_file') return 'Low value no file'
+  if (item.receiptState === 'transfer') return 'Transfer'
+  if (item.needsReceipt) return 'Needs receipt'
+  return item.receiptState.replaceAll('_', ' ')
+}
+
+function rdValue(item: WorkbenchItem): string {
+  if (item.rdCategory === 'core' || item.rdCategory === 'supporting' || item.rdCategory === 'review') {
+    return item.rdCategory
+  }
+  if (item.rdEligible) return 'supporting'
+  return 'none'
+}
+
+function StatCard({
+  title,
+  value,
+  detail,
+  icon: Icon,
+  active,
+  onClick,
+}: {
+  title: string
+  value: string
+  detail: string
+  icon: typeof Receipt
+  active?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-left transition hover:border-cyan-400/40 hover:bg-cyan-400/10',
+        active && 'border-cyan-400/50 bg-cyan-400/10'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-white/40">{title}</p>
+          <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+        </div>
+        <Icon className="h-5 w-5 text-cyan-300" />
+      </div>
+      <p className="mt-2 text-xs text-white/50">{detail}</p>
+    </button>
+  )
+}
+
+async function fetchWorkbench(params: {
+  source: SourceFilter
+  status: StatusFilter
+  direction: DirectionFilter
+  project: string
+  q: string
+}): Promise<WorkbenchResponse> {
+  const qs = new URLSearchParams()
+  qs.set('source', params.source)
+  qs.set('status', params.status)
+  qs.set('direction', params.direction)
+  qs.set('project', params.project)
+  qs.set('limit', '300')
+  if (params.q.trim()) qs.set('q', params.q.trim())
+
+  const res = await fetch(`/api/finance/workbench?${qs.toString()}`)
+  const data = await res.json()
+  if (!res.ok) throw new Error(data.error || 'Failed to load finance workbench')
+  return data
+}
+
+export default function FinanceWorkbenchPage() {
+  const queryClient = useQueryClient()
+  const [source, setSource] = useState<SourceFilter>(() => initialOption('source', sourceOptions, 'bank_lines'))
+  const [status, setStatus] = useState<StatusFilter>(() => initialOption('status', statusOptions, 'needs_action'))
+  const [direction, setDirection] = useState<DirectionFilter>(() => initialOption('direction', directionOptions, 'all'))
+  const [project, setProject] = useState(() => initialParam('project', 'all'))
+  const [search, setSearch] = useState(() => initialParam('q'))
+  const deferredSearch = useDeferredValue(search)
+  const [pendingProjects, setPendingProjects] = useState<Record<string, string>>({})
+  const [pendingRd, setPendingRd] = useState<Record<string, string>>({})
+  const [uploadTarget, setUploadTarget] = useState<WorkbenchItem | null>(null)
+  const [uploadFiles, setUploadFiles] = useState<File[]>([])
+  const [uploadVendor, setUploadVendor] = useState('')
+  const [uploadAmount, setUploadAmount] = useState('')
+  const [uploadDate, setUploadDate] = useState('')
+  const [uploadBusy, setUploadBusy] = useState(false)
+  const [uploadDragging, setUploadDragging] = useState(false)
+  const [uploadError, setUploadError] = useState<string | null>(null)
+  const [uploadMessage, setUploadMessage] = useState<string | null>(null)
+
+  const query = useQuery({
+    queryKey: ['finance', 'workbench', source, status, direction, project, deferredSearch],
+    queryFn: () => fetchWorkbench({ source, status, direction, project, q: deferredSearch }),
+  })
+
+  const mutation = useMutation({
+    mutationFn: async (payload: { id: string; source: WorkbenchItem['source']; projectCode?: string; rdCategory?: string }) => {
+      const res = await fetch('/api/finance/workbench', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to save row')
+      return data
+    },
+    onSuccess: () => {
+      setPendingProjects({})
+      setPendingRd({})
+      queryClient.invalidateQueries({ queryKey: ['finance', 'workbench'] })
+    },
+  })
+
+  const data = query.data
+  const projects = data?.projects || []
+  const rows = data?.items || []
+  const summary = data?.summary
+
+  function selectUploadTarget(item: WorkbenchItem) {
+    setUploadTarget(item)
+    setUploadVendor(item.vendor)
+    setUploadAmount(item.amount ? String(item.amount) : '')
+    setUploadDate(item.date || '')
+    setUploadError(null)
+    setUploadMessage(null)
+  }
+
+  function clearUploadTarget() {
+    setUploadTarget(null)
+    setUploadVendor('')
+    setUploadAmount('')
+    setUploadDate('')
+  }
+
+  function addUploadFiles(files: FileList | File[]) {
+    const next = Array.from(files).filter((file) => file.size > 0)
+    if (!next.length) return
+    setUploadFiles((current) => [...current, ...next])
+    setUploadError(null)
+    setUploadMessage(null)
+  }
+
+  async function uploadReceipts() {
+    if (!uploadFiles.length) {
+      setUploadError('Drop or choose at least one receipt file first.')
+      return
+    }
+
+    setUploadBusy(true)
+    setUploadError(null)
+    setUploadMessage(null)
+
+    try {
+      for (const file of uploadFiles) {
+        const form = new FormData()
+        form.set('file', file)
+        if (uploadTarget?.source === 'bank_lines') {
+          form.set('bankLineId', uploadTarget.id)
+        }
+        if (uploadVendor.trim()) form.set('vendorName', uploadVendor.trim())
+        if (uploadAmount.trim()) form.set('amountTotal', uploadAmount.trim())
+        if (uploadDate) form.set('documentDate', uploadDate)
+        form.set('reviewNote', uploadTarget
+          ? `Manual upload from finance workbench for ${uploadTarget.vendor}`
+          : 'Manual unlinked upload from finance workbench')
+
+        const res = await fetch('/api/finance/receipt-evidence', { method: 'POST', body: form })
+        const json = await res.json()
+        if (!res.ok) throw new Error(json.error || `Upload failed for ${file.name}`)
+      }
+
+      setUploadFiles([])
+      setUploadMessage(uploadTarget?.source === 'bank_lines'
+        ? 'Receipt uploaded and linked to the selected bank line.'
+        : 'Receipt uploaded as an unlinked candidate for later matching.')
+      queryClient.invalidateQueries({ queryKey: ['finance', 'workbench'] })
+    } catch (error) {
+      setUploadError((error as Error).message)
+    } finally {
+      setUploadBusy(false)
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[#070b10] text-white">
+      <div className="mx-auto max-w-[1500px] px-6 py-8">
+        <Link href="/finance" className="mb-6 inline-flex items-center gap-2 text-sm text-white/45 transition hover:text-white">
+          <ArrowLeft className="h-4 w-4" />
+          Finance
+        </Link>
+
+        <header className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.28em] text-cyan-300/70">Finance Workbench</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight">Receipts, projects, income, outgoing</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-white/55">
+              Use bank lines for receipt coverage, then switch to Xero transactions or invoices for project realignment.
+              Saves are single-row only: no broad vendor rule updates from this surface.
+            </p>
+          </div>
+          <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+            Source of truth for spend receipt coverage: <span className="font-semibold">bank statement lines</span>.
+          </div>
+        </header>
+
+        {summary && (
+          <section className="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-6">
+            <StatCard
+              title="Receipt gaps"
+              value={summary.receiptGaps.toLocaleString()}
+              detail={`${formatMoney(summary.receiptGapValue)} bank-line spend without final evidence`}
+              icon={Receipt}
+              active={status === 'receipt_gap'}
+              onClick={() => {
+                setSource('bank_lines')
+                setStatus('receipt_gap')
+              }}
+            />
+            <StatCard
+              title="Candidates"
+              value={summary.candidateReceipts.toLocaleString()}
+              detail="Likely files to approve or reject"
+              icon={CheckCircle2}
+              active={status === 'candidate_receipts'}
+              onClick={() => {
+                setSource('bank_lines')
+                setStatus('candidate_receipts')
+              }}
+            />
+            <StatCard
+              title="Draft assist"
+              value={summary.xeroDraftCandidates.toLocaleString()}
+              detail={`${formatMoney(summary.xeroDraftCandidateValue)} missing mirrored Xero target`}
+              icon={FileText}
+              active={status === 'xero_drafts'}
+              onClick={() => {
+                setSource('bank_lines')
+                setDirection('spend')
+                setStatus('xero_drafts')
+              }}
+            />
+            <StatCard
+              title="Unreconciled"
+              value={summary.unreconciledBankLines.toLocaleString()}
+              detail={`${formatMoney(summary.unreconciledValue)} in bank mirror queue`}
+              icon={AlertTriangle}
+              active={status === 'unreconciled'}
+              onClick={() => {
+                setSource('bank_lines')
+                setStatus('unreconciled')
+              }}
+            />
+            <StatCard
+              title="Project gaps"
+              value={(summary.bankProjectGaps + summary.xeroProjectGaps + summary.invoiceProjectGaps).toLocaleString()}
+              detail="Rows without a project code across mirrors"
+              icon={Tags}
+              active={status === 'needs_project'}
+              onClick={() => setStatus('needs_project')}
+            />
+            <StatCard
+              title="R&D review"
+              value={summary.rdReview.toLocaleString()}
+              detail={`${formatMoney(summary.rdEligibleSpend)} currently marked eligible`}
+              icon={FlaskConical}
+              active={status === 'rd_review'}
+              onClick={() => {
+                setSource('xero_transactions')
+                setStatus('rd_review')
+              }}
+            />
+          </section>
+        )}
+
+        <section className="mt-6 rounded-2xl border border-white/10 bg-white/[0.035] p-4">
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-[180px_210px_160px_220px_1fr_auto]">
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Source</span>
+              <select value={source} onChange={(e) => setSource(e.target.value as SourceFilter)} className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white">
+                {sourceOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Queue</span>
+              <select value={status} onChange={(e) => setStatus(e.target.value as StatusFilter)} className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white">
+                {statusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Direction</span>
+              <select value={direction} onChange={(e) => setDirection(e.target.value as DirectionFilter)} className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white">
+                {directionOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Project</span>
+              <select value={project} onChange={(e) => setProject(e.target.value)} className="w-full rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white">
+                <option value="all">All projects</option>
+                <option value="__blank__">No project</option>
+                {projects.map((p) => (
+                  <option key={p.code} value={p.code}>
+                    {p.code} · {p.name || 'Unnamed'}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="space-y-1">
+              <span className="text-xs text-white/40">Search</span>
+              <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-black/30 px-3 py-2">
+                <Search className="h-4 w-4 text-white/30" />
+                <input
+                  value={search}
+                  onChange={(e) => startTransition(() => setSearch(e.target.value))}
+                  placeholder="Vendor, reference, project..."
+                  className="w-full bg-transparent text-sm text-white outline-none placeholder:text-white/25"
+                />
+              </div>
+            </label>
+            <button
+              type="button"
+              onClick={() => query.refetch()}
+              className="mt-5 inline-flex items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70 transition hover:bg-white/10 hover:text-white"
+            >
+              <RefreshCcw className={cn('h-4 w-4', query.isFetching && 'animate-spin')} />
+              Refresh
+            </button>
+          </div>
+        </section>
+
+        {status === 'xero_drafts' && (
+          <section className="mt-6 rounded-2xl border border-cyan-300/20 bg-cyan-300/[0.06] p-4">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-cyan-200/70">Xero draft assist</p>
+                <h2 className="mt-1 text-lg font-semibold text-white">Approve the hidden draft, then reconcile the bank line.</h2>
+                <p className="mt-2 max-w-4xl text-sm leading-6 text-white/55">
+                  These are unreconciled spend lines where our mirror has no Xero accounting target yet. Use the row amount/date/vendor plus project/R&D tag while approving Xero Expenses drafts. This page only updates ACT/Supabase mirror context, not Xero accounting state.
+                </p>
+              </div>
+              <a
+                href="https://go.xero.com/app/expenses"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-xl border border-cyan-300/25 bg-cyan-300/10 px-4 py-2 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-300/20"
+              >
+                Open Xero Expenses
+                <ExternalLink className="h-4 w-4" />
+              </a>
+            </div>
+          </section>
+        )}
+
+        <section className="mt-6 grid grid-cols-1 gap-4 rounded-2xl border border-cyan-400/20 bg-cyan-400/[0.06] p-4 xl:grid-cols-[1fr_420px]">
+          <div
+            onDragOver={(e) => {
+              e.preventDefault()
+              setUploadDragging(true)
+            }}
+            onDragLeave={() => setUploadDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault()
+              setUploadDragging(false)
+              addUploadFiles(e.dataTransfer.files)
+            }}
+            className={cn(
+              'flex min-h-36 flex-col items-center justify-center rounded-2xl border border-dashed border-cyan-300/30 bg-black/25 px-5 py-6 text-center transition',
+              uploadDragging && 'border-cyan-200 bg-cyan-300/10'
+            )}
+          >
+            <Upload className="h-8 w-8 text-cyan-200" />
+            <h2 className="mt-3 text-base font-semibold text-white">Drop receipts here</h2>
+            <p className="mt-1 max-w-xl text-sm text-white/55">
+              Select a bank-line row first to attach directly. If no row is selected, the file is saved as an unlinked receipt candidate.
+            </p>
+            <label className="mt-4 inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/10 bg-white/10 px-4 py-2 text-sm text-white/75 transition hover:bg-white/15 hover:text-white">
+              <FileText className="h-4 w-4" />
+              Choose files
+              <input
+                type="file"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                  if (e.target.files) addUploadFiles(e.target.files)
+                  e.currentTarget.value = ''
+                }}
+              />
+            </label>
+          </div>
+
+          <div className="rounded-2xl border border-white/10 bg-black/25 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-cyan-200/70">Upload target</p>
+                <p className="mt-2 text-sm font-semibold text-white">
+                  {uploadTarget ? uploadTarget.vendor : 'No row selected'}
+                </p>
+                <p className="mt-1 text-xs text-white/40">
+                  {uploadTarget?.source === 'bank_lines'
+                    ? `${dateLabel(uploadTarget.date)} · ${formatMoney(uploadTarget.amount)} · links to bank line`
+                    : 'Upload will be saved as an unlinked candidate.'}
+                </p>
+              </div>
+              {uploadTarget && (
+                <button
+                  type="button"
+                  onClick={clearUploadTarget}
+                  className="rounded-lg border border-white/10 p-2 text-white/45 transition hover:bg-white/10 hover:text-white"
+                  aria-label="Clear upload target"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <input
+                value={uploadVendor}
+                onChange={(e) => setUploadVendor(e.target.value)}
+                placeholder="Vendor"
+                className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-white/25 focus:border-cyan-300/50"
+              />
+              <input
+                value={uploadAmount}
+                onChange={(e) => setUploadAmount(e.target.value)}
+                placeholder="Amount"
+                type="number"
+                step="0.01"
+                className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none placeholder:text-white/25 focus:border-cyan-300/50"
+              />
+              <input
+                value={uploadDate}
+                onChange={(e) => setUploadDate(e.target.value)}
+                type="date"
+                className="rounded-xl border border-white/10 bg-black/30 px-3 py-2 text-sm text-white outline-none focus:border-cyan-300/50"
+              />
+            </div>
+
+            {uploadFiles.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {uploadFiles.map((file, index) => (
+                  <span key={`${file.name}-${index}`} className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/65">
+                    {file.name}
+                    <button
+                      type="button"
+                      onClick={() => setUploadFiles((current) => current.filter((_, i) => i !== index))}
+                      className="text-white/40 hover:text-white"
+                      aria-label={`Remove ${file.name}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-4 flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                disabled={uploadBusy || uploadFiles.length === 0}
+                onClick={uploadReceipts}
+                className="inline-flex items-center gap-2 rounded-xl bg-cyan-400/15 px-4 py-2 text-sm font-semibold text-cyan-100 transition hover:bg-cyan-400/25 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {uploadBusy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                Upload receipt
+              </button>
+              {uploadError && <p className="text-xs text-red-300">{uploadError}</p>}
+              {uploadMessage && <p className="text-xs text-emerald-300">{uploadMessage}</p>}
+            </div>
+          </div>
+        </section>
+
+        {query.error && (
+          <div className="mt-6 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {(query.error as Error).message}
+          </div>
+        )}
+
+        {mutation.error && (
+          <div className="mt-4 rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {(mutation.error as Error).message}
+          </div>
+        )}
+
+        <section className="mt-6 overflow-hidden rounded-2xl border border-white/10 bg-white/[0.025]">
+          <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+            <p className="text-sm text-white/55">
+              Showing <span className="font-semibold text-white">{rows.length.toLocaleString()}</span>
+              {data ? ` of ${data.totalMatching.toLocaleString()} matching rows` : ''}.
+            </p>
+            <p className="text-xs text-white/35">Project changes save to Supabase mirrors only. Xero accounting state is not changed here.</p>
+          </div>
+
+          <div className="max-h-[760px] overflow-auto">
+            <table className="w-full min-w-[1180px] border-collapse text-sm">
+              <thead className="sticky top-0 z-10 bg-[#101722] text-left text-xs uppercase tracking-[0.18em] text-white/35">
+                <tr>
+                  <th className="px-4 py-3">Money line</th>
+                  <th className="px-4 py-3">Amount</th>
+                  <th className="px-4 py-3">Receipt</th>
+                  <th className="px-4 py-3">Xero</th>
+                  <th className="px-4 py-3">Project</th>
+                  <th className="px-4 py-3">R&D</th>
+                  <th className="px-4 py-3">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {query.isLoading && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-10 text-center text-white/45">Loading finance workbench...</td>
+                  </tr>
+                )}
+
+                {!query.isLoading && rows.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-10 text-center text-white/45">No rows match these filters.</td>
+                  </tr>
+                )}
+
+                {rows.map((item) => {
+                  const key = `${item.source}:${item.id}`
+                  const selectedProject = pendingProjects[key] ?? item.projectCode ?? ''
+                  const selectedRd = pendingRd[key] ?? rdValue(item)
+                  const projectChanged = selectedProject !== (item.projectCode ?? '')
+                  const rdChanged = selectedRd !== rdValue(item)
+                  const canEditRd = item.source !== 'xero_invoices'
+                  const canSave = projectChanged || (canEditRd && rdChanged)
+
+                  return (
+                    <tr key={key} className="border-b border-white/5 align-top transition hover:bg-white/[0.035]">
+                      <td className="max-w-[360px] px-4 py-4">
+                        <div className="flex items-start gap-3">
+                          <span
+                            className={cn(
+                              'mt-1 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+                              item.direction === 'income' ? 'bg-emerald-400/15 text-emerald-200' : 'bg-orange-400/15 text-orange-200'
+                            )}
+                          >
+                            {item.direction}
+                          </span>
+                          <div>
+                            <p className="font-medium text-white">{item.vendor}</p>
+                            <p className="mt-1 text-xs text-white/45">{dateLabel(item.date)} · {sourceLabel(item.source)}</p>
+                            {item.description && <p className="mt-1 line-clamp-2 text-xs text-white/40">{item.description}</p>}
+                            {item.xeroReference && <p className="mt-1 text-[11px] text-white/30">Ref {item.xeroReference}</p>}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-4">
+                        <p className="font-semibold text-white">{formatMoney(item.amount)}</p>
+                      </td>
+                      <td className="px-4 py-4">
+                        <span
+                          className={cn(
+                            'inline-flex rounded-full px-2 py-1 text-xs',
+                            item.hasReceipt && 'bg-emerald-400/15 text-emerald-200',
+                            !item.hasReceipt && item.needsReceipt && 'bg-red-400/15 text-red-200',
+                            !item.hasReceipt && !item.needsReceipt && 'bg-white/10 text-white/50'
+                          )}
+                        >
+                          {receiptLabel(item)}
+                        </span>
+                        {(item.candidateCount > 0 || item.confidence != null) && (
+                          <p className="mt-1 text-[11px] text-white/35">
+                            {item.candidateCount > 0 ? `${item.candidateCount} candidate${item.candidateCount === 1 ? '' : 's'}` : ''}
+                            {item.confidence != null ? ` · ${Math.round(item.confidence)}%` : ''}
+                          </p>
+                        )}
+                        {item.receiptSignal && <p className="mt-1 text-[11px] text-white/30">{item.receiptSignal}</p>}
+                      </td>
+                      <td className="px-4 py-4">
+                        <span
+                          className={cn(
+                            'inline-flex rounded-full px-2 py-1 text-xs',
+                            item.isReconciled === true && 'bg-emerald-400/15 text-emerald-200',
+                            item.isReconciled === false && 'bg-amber-400/15 text-amber-100',
+                            item.isReconciled == null && 'bg-white/10 text-white/45'
+                          )}
+                        >
+                          {item.isReconciled === true ? 'Reconciled' : item.isReconciled === false ? 'Unreconciled' : item.xeroStatus || 'Unknown'}
+                        </span>
+                        {item.xeroStatus && <p className="mt-1 text-[11px] text-white/35">{item.xeroStatus}</p>}
+                        {item.needsXeroDraft && (
+                          <p className="mt-2 max-w-[220px] rounded-lg border border-cyan-300/20 bg-cyan-300/10 px-2 py-1 text-[11px] leading-4 text-cyan-100/75">
+                            {item.xeroDraftHint || 'Missing mirrored Xero target'}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-4 py-4">
+                        <select
+                          value={selectedProject}
+                          onChange={(e) => setPendingProjects((current) => ({ ...current, [key]: e.target.value }))}
+                          className={cn(
+                            'w-56 rounded-lg border bg-black/30 px-2 py-2 text-xs text-white outline-none',
+                            item.needsProject ? 'border-red-400/40' : item.needsProjectReview ? 'border-amber-400/40' : 'border-white/10'
+                          )}
+                        >
+                          <option value="">No project</option>
+                          {projects.map((p) => (
+                            <option key={p.code} value={p.code}>
+                              {p.code} · {p.name || 'Unnamed'}
+                            </option>
+                          ))}
+                        </select>
+                        <p className="mt-1 text-[11px] text-white/35">
+                          {item.projectSource || 'no source'}
+                          {item.needsProjectReview ? ' · review broad tag' : ''}
+                        </p>
+                      </td>
+                      <td className="px-4 py-4">
+                        {canEditRd ? (
+                          <select
+                            value={selectedRd}
+                            onChange={(e) => setPendingRd((current) => ({ ...current, [key]: e.target.value }))}
+                            className={cn(
+                              'w-36 rounded-lg border bg-black/30 px-2 py-2 text-xs text-white outline-none',
+                              item.needsRdReview ? 'border-amber-400/40' : 'border-white/10'
+                            )}
+                          >
+                            {rdOptions.map((option) => (
+                              <option key={option.value} value={option.value}>{option.label}</option>
+                            ))}
+                          </select>
+                        ) : (
+                          <span className="text-xs text-white/35">Invoice</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-4">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            disabled={!canSave || mutation.isPending}
+                            onClick={() => {
+                              const payload: { id: string; source: WorkbenchItem['source']; projectCode?: string; rdCategory?: string } = {
+                                id: item.id,
+                                source: item.source,
+                              }
+                              if (projectChanged) payload.projectCode = selectedProject
+                              if (canEditRd && rdChanged) payload.rdCategory = selectedRd
+                              mutation.mutate(payload)
+                            }}
+                            className="rounded-lg bg-cyan-400/15 px-3 py-2 text-xs font-medium text-cyan-100 transition hover:bg-cyan-400/25 disabled:cursor-not-allowed disabled:opacity-35"
+                          >
+                            Save row
+                          </button>
+                          <Link
+                            href={item.receiptEvidenceUrl}
+                            className="inline-flex items-center gap-1 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/55 transition hover:bg-white/10 hover:text-white"
+                          >
+                            Receipt
+                            <ExternalLink className="h-3 w-3" />
+                          </Link>
+                          {item.needsXeroDraft && (
+                            <a
+                              href="https://go.xero.com/app/expenses"
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex items-center gap-1 rounded-lg border border-cyan-300/20 px-3 py-2 text-xs text-cyan-100/75 transition hover:bg-cyan-300/10 hover:text-cyan-50"
+                            >
+                              Xero drafts
+                              <ExternalLink className="h-3 w-3" />
+                            </a>
+                          )}
+                          {item.source === 'bank_lines' && (
+                            <button
+                              type="button"
+                              onClick={() => selectUploadTarget(item)}
+                              className="inline-flex items-center gap-1 rounded-lg border border-cyan-300/20 px-3 py-2 text-xs text-cyan-100/75 transition hover:bg-cyan-300/10 hover:text-cyan-50"
+                            >
+                              Upload
+                              <Upload className="h-3 w-3" />
+                            </button>
+                          )}
+                          {item.projectCode && (
+                            <Link
+                              href={`/finance/projects/${item.projectCode}`}
+                              className="inline-flex items-center gap-1 rounded-lg border border-white/10 px-3 py-2 text-xs text-white/55 transition hover:bg-white/10 hover:text-white"
+                            >
+                              Project
+                              <ExternalLink className="h-3 w-3" />
+                            </Link>
+                          )}
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/command-center/src/app/finance/xero-page-copilot/page.tsx
+++ b/apps/command-center/src/app/finance/xero-page-copilot/page.tsx
@@ -1,0 +1,564 @@
+'use client'
+
+import { useMemo, useState, startTransition } from 'react'
+import Link from 'next/link'
+import { useMutation } from '@tanstack/react-query'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Bot,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  FileSearch,
+  GitCompareArrows,
+  Loader2,
+  ReceiptText,
+  RefreshCcw,
+  ShieldCheck,
+  Sparkles,
+} from 'lucide-react'
+import { formatMoney } from '@/lib/finance/format'
+import { cn } from '@/lib/utils'
+
+type SuggestedAction =
+  | 'click_ok_existing_match'
+  | 'wrong_xero_suggestion'
+  | 'transfer'
+  | 'find_match_bill'
+  | 'create_with_evidence'
+  | 'create_low_value'
+  | 'refund_review'
+  | 'skip_done'
+  | 'bookkeeper_review'
+  | 'unsafe_create'
+
+interface CopilotRow {
+  rowNumber: number
+  date: string
+  description: string
+  transactionType: string
+  amount: number
+  hasOkButton: boolean
+  suggestedWho: string | null
+  suggestedAccount: string | null
+  suggestedWhy: string | null
+  suggestedTaxRate: string | null
+  existingMatchLabel: string | null
+  recommendedFields: {
+    who: string
+    account: string
+    why: string
+    taxRate: string
+  }
+  suggestedAction: SuggestedAction
+  actionLabel: string
+  risk: 'low' | 'medium' | 'high'
+  nextStep: string
+  receiptEvidenceUrl: string
+  bestXeroBillUrl: string | null
+  bankLine: {
+    id: string
+    date: string | null
+    payee: string | null
+    amount: number
+    status: string | null
+    bankAccount: string | null
+    projectCode: string | null
+    projectSource: string | null
+    dateDeltaDays: number | null
+    vendorScore: number
+  } | null
+  evidence: {
+    id: string
+    status: string
+    bestConfidence: number
+    bestSource: string | null
+    bestVendorName: string | null
+    candidateCount: number
+    hasApprovedLink: boolean
+  } | null
+  billCandidates: Array<{
+    id: string
+    xeroId: string | null
+    invoiceNumber: string | null
+    contactName: string | null
+    date: string | null
+    total: number
+    status: string | null
+    amountPaid: number
+    amountDue: number
+    hasAttachments: boolean
+    reference: string | null
+    projectCode: string | null
+    dateDeltaDays: number | null
+    vendorScore: number
+    xeroUrl: string
+  }>
+}
+
+interface CopilotResponse {
+  parsedCount: number
+  dateRange?: { start: string; end: string }
+  sourceCounts?: {
+    bankLines: number
+    evidenceRows: number
+    xeroBills: number
+  }
+  summary: Record<string, number>
+  rows: CopilotRow[]
+  warnings: string[]
+}
+
+const actionLabels: Record<SuggestedAction, string> = {
+  click_ok_existing_match: 'OK existing match',
+  wrong_xero_suggestion: 'Wrong Xero match',
+  transfer: 'Transfer',
+  find_match_bill: 'Find & Match bill',
+  create_with_evidence: 'Create with receipt',
+  create_low_value: 'Low-value create',
+  refund_review: 'Refund review',
+  skip_done: 'Skip done',
+  bookkeeper_review: 'Human review',
+  unsafe_create: 'Check before create',
+}
+
+const actionOrder: SuggestedAction[] = [
+  'wrong_xero_suggestion',
+  'click_ok_existing_match',
+  'transfer',
+  'find_match_bill',
+  'create_with_evidence',
+  'create_low_value',
+  'refund_review',
+  'unsafe_create',
+  'bookkeeper_review',
+  'skip_done',
+]
+
+const sampleText = `1 Oct 2025
+LINKTREE COLLINGWOOD
+XXXXXXXXXXXXXXX1656
+Credit Card Purchase
+More details
+8.20
+OK
+MatchCreateTransferDiscussFind & Match
+Who
+Linktree
+What
+485 - Subscriptions
+Why
+No Invoice - Under $82.50
+GST on Expenses`
+
+function dateLabel(date: string | null): string {
+  if (!date) return 'No date'
+  return new Intl.DateTimeFormat('en-AU', { day: '2-digit', month: 'short', year: 'numeric' }).format(new Date(`${date}T00:00:00`))
+}
+
+function riskClass(risk: CopilotRow['risk']) {
+  if (risk === 'high') return 'border-red-400/35 bg-red-500/10 text-red-100'
+  if (risk === 'medium') return 'border-amber-400/35 bg-amber-500/10 text-amber-100'
+  return 'border-emerald-400/35 bg-emerald-500/10 text-emerald-100'
+}
+
+function actionClass(action: SuggestedAction) {
+  if (action === 'wrong_xero_suggestion') return 'bg-red-500/20 text-red-100'
+  if (action === 'bookkeeper_review' || action === 'unsafe_create') return 'bg-red-400/15 text-red-100'
+  if (action === 'refund_review') return 'bg-amber-400/15 text-amber-100'
+  if (action === 'transfer') return 'bg-blue-400/15 text-blue-100'
+  if (action === 'find_match_bill' || action === 'create_with_evidence') return 'bg-cyan-400/15 text-cyan-100'
+  if (action === 'click_ok_existing_match' || action === 'create_low_value' || action === 'skip_done') return 'bg-emerald-400/15 text-emerald-100'
+  return 'bg-white/10 text-white/65'
+}
+
+async function analyzePage(text: string): Promise<CopilotResponse> {
+  const res = await fetch('/api/finance/xero-page-copilot', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text }),
+  })
+  const data = await res.json()
+  if (!res.ok) throw new Error(data.error || 'Failed to analyse Xero page')
+  return data
+}
+
+function buildCopyText(rows: CopilotRow[]) {
+  return rows.map((row) => {
+    const bits = [
+      `${row.rowNumber}. ${dateLabel(row.date)} ${row.description} ${formatMoney(row.amount)}`,
+      `Action: ${row.actionLabel}`,
+      `Next: ${row.nextStep}`,
+      `Use: Who=${row.recommendedFields.who || row.suggestedWho || ''}; What=${row.recommendedFields.account}; Why=${row.recommendedFields.why}; Tax=${row.recommendedFields.taxRate}`,
+    ]
+    if (row.billCandidates[0]) {
+      bits.push(`Bill: ${row.billCandidates[0].contactName || 'unknown'} ${formatMoney(row.billCandidates[0].total)} ${row.billCandidates[0].status || ''}`)
+    }
+    if (row.evidence) {
+      bits.push(`Evidence: ${row.evidence.status} ${Math.round(row.evidence.bestConfidence * 100)}% ${row.evidence.bestSource || ''}`)
+    }
+    return bits.join(' | ')
+  }).join('\n')
+}
+
+function StatCard({
+  label,
+  value,
+  active,
+  onClick,
+}: {
+  label: string
+  value: number
+  active?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-3xl border border-white/10 bg-white/[0.04] p-4 text-left transition hover:border-cyan-300/40 hover:bg-cyan-300/10',
+        active && 'border-cyan-300/50 bg-cyan-300/10'
+      )}
+    >
+      <p className="text-[10px] uppercase tracking-[0.26em] text-white/40">{label}</p>
+      <p className="mt-2 text-3xl font-semibold text-white">{value}</p>
+    </button>
+  )
+}
+
+export default function XeroPageCopilotPage() {
+  const [text, setText] = useState('')
+  const [filter, setFilter] = useState<SuggestedAction | 'all'>('all')
+  const [copied, setCopied] = useState(false)
+
+  const mutation = useMutation({
+    mutationFn: analyzePage,
+  })
+
+  const rows = mutation.data?.rows || []
+  const filteredRows = useMemo(() => {
+    if (filter === 'all') return rows
+    return rows.filter((row) => row.suggestedAction === filter)
+  }, [filter, rows])
+
+  const summary = mutation.data?.summary || {}
+
+  const copyPlan = async () => {
+    if (!rows.length) return
+    await navigator.clipboard.writeText(buildCopyText(filteredRows))
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1600)
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.18),transparent_30%),radial-gradient(circle_at_80%_0%,rgba(245,158,11,0.14),transparent_26%),#05070d] px-6 py-8 text-white">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8 flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <Link href="/finance" className="mb-5 inline-flex items-center gap-2 text-sm text-white/55 transition hover:text-white">
+              <ArrowLeft className="h-4 w-4" />
+              Finance
+            </Link>
+            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/25 bg-cyan-300/10 px-3 py-1 text-xs uppercase tracking-[0.28em] text-cyan-100">
+              <Bot className="h-3.5 w-3.5" />
+              Xero Page Copilot
+            </div>
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl">
+              Paste one Xero reconcile page. Get the next safe click.
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-white/58">
+              This is deliberately no-write. It parses what Xero is showing, checks ACT mirror evidence,
+              Dext-created bills, receipt status, transfers, refunds, and gives a per-row action queue.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-amber-300/20 bg-amber-300/10 p-4 text-sm text-amber-50 lg:max-w-sm">
+            <div className="flex items-center gap-2 font-semibold">
+              <ShieldCheck className="h-4 w-4" />
+              Hard rule
+            </div>
+            <p className="mt-2 text-amber-100/75">
+              If this page says a Dext/Xero bill already exists, use Find & Match. Do not Create duplicate spend.
+            </p>
+          </div>
+        </header>
+
+        <section className="grid gap-5 lg:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+          <div className="rounded-[2rem] border border-white/10 bg-white/[0.045] p-5 shadow-[0_30px_100px_rgba(0,0,0,0.28)]">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold">Paste copied Xero page text</h2>
+                <p className="mt-1 text-sm text-white/48">Copy from the visible Reconcile page. One page at a time is best.</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setText(sampleText)}
+                className="rounded-full border border-white/10 px-3 py-2 text-xs text-white/65 transition hover:border-white/30 hover:text-white"
+              >
+                Sample
+              </button>
+            </div>
+            <textarea
+              value={text}
+              onChange={(event) => setText(event.target.value)}
+              placeholder="Paste the Xero reconcile page text here..."
+              className="mt-4 min-h-[360px] w-full resize-y rounded-3xl border border-white/10 bg-black/35 p-4 font-mono text-xs leading-5 text-white/80 outline-none transition placeholder:text-white/25 focus:border-cyan-300/45"
+            />
+            <div className="mt-4 flex flex-wrap gap-3">
+              <button
+                type="button"
+                disabled={!text.trim() || mutation.isPending}
+                onClick={() => {
+                  startTransition(() => {
+                    setFilter('all')
+                    mutation.mutate(text)
+                  })
+                }}
+                className="inline-flex items-center gap-2 rounded-full bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-white/15 disabled:text-white/35"
+              >
+                {mutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
+                Analyse page
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setText('')
+                  mutation.reset()
+                  setFilter('all')
+                }}
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 px-5 py-3 text-sm text-white/65 transition hover:border-white/30 hover:text-white"
+              >
+                <RefreshCcw className="h-4 w-4" />
+                Reset
+              </button>
+              <button
+                type="button"
+                disabled={!rows.length}
+                onClick={copyPlan}
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 px-5 py-3 text-sm text-white/65 transition hover:border-white/30 hover:text-white disabled:cursor-not-allowed disabled:text-white/25"
+              >
+                <Copy className="h-4 w-4" />
+                {copied ? 'Copied' : 'Copy plan'}
+              </button>
+            </div>
+            {mutation.error && (
+              <div className="mt-4 rounded-2xl border border-red-400/30 bg-red-500/10 p-4 text-sm text-red-100">
+                {(mutation.error as Error).message}
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-5">
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              <StatCard label="Rows parsed" value={mutation.data?.parsedCount || 0} active={filter === 'all'} onClick={() => setFilter('all')} />
+              {actionOrder.slice(0, 5).map((action) => (
+                <StatCard
+                  key={action}
+                  label={actionLabels[action]}
+                  value={summary[action] || 0}
+                  active={filter === action}
+                  onClick={() => setFilter(action)}
+                />
+              ))}
+            </div>
+
+            {mutation.data?.warnings?.length ? (
+              <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-4 text-sm text-white/55">
+                {mutation.data.warnings.map((warning) => (
+                  <p key={warning} className="flex gap-2">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-200" />
+                    <span>{warning}</span>
+                  </p>
+                ))}
+              </div>
+            ) : null}
+
+            {mutation.data?.sourceCounts ? (
+              <div className="grid grid-cols-3 gap-3 rounded-3xl border border-white/10 bg-black/20 p-4 text-sm">
+                <div>
+                  <p className="text-white/35">Bank mirror</p>
+                  <p className="mt-1 text-lg font-semibold">{mutation.data.sourceCounts.bankLines}</p>
+                </div>
+                <div>
+                  <p className="text-white/35">Evidence rows</p>
+                  <p className="mt-1 text-lg font-semibold">{mutation.data.sourceCounts.evidenceRows}</p>
+                </div>
+                <div>
+                  <p className="text-white/35">Xero bills</p>
+                  <p className="mt-1 text-lg font-semibold">{mutation.data.sourceCounts.xeroBills}</p>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <section className="mt-8 overflow-hidden rounded-[2rem] border border-white/10 bg-white/[0.04]">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 px-5 py-4">
+            <div>
+              <h2 className="font-semibold">Action queue</h2>
+              <p className="text-sm text-white/45">Showing {filteredRows.length} of {rows.length} parsed rows.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => setFilter('all')}
+                className={cn('rounded-full px-3 py-1.5 text-xs transition', filter === 'all' ? 'bg-white text-slate-950' : 'bg-white/10 text-white/55 hover:text-white')}
+              >
+                All
+              </button>
+              {actionOrder.map((action) => (
+                <button
+                  type="button"
+                  key={action}
+                  onClick={() => setFilter(action)}
+                  className={cn('rounded-full px-3 py-1.5 text-xs transition', filter === action ? 'bg-white text-slate-950' : 'bg-white/10 text-white/55 hover:text-white')}
+                >
+                  {actionLabels[action]} {summary[action] ? `(${summary[action]})` : ''}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="divide-y divide-white/10">
+            {!mutation.data && (
+              <div className="p-10 text-center text-white/45">
+                <FileSearch className="mx-auto mb-3 h-8 w-8" />
+                Paste a Xero page and analyse it.
+              </div>
+            )}
+
+            {mutation.data && !filteredRows.length && (
+              <div className="p-10 text-center text-white/45">
+                No rows in this filter.
+              </div>
+            )}
+
+            {filteredRows.map((row) => (
+              <article key={`${row.rowNumber}-${row.date}-${row.description}`} className="grid gap-5 p-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,1fr)]">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs text-white/55">#{row.rowNumber}</span>
+                    <span className={cn('rounded-full px-2.5 py-1 text-xs font-medium', actionClass(row.suggestedAction))}>{row.actionLabel}</span>
+                    <span className={cn('rounded-full border px-2.5 py-1 text-xs font-medium', riskClass(row.risk))}>{row.risk} risk</span>
+                    {row.hasOkButton && <span className="rounded-full bg-emerald-400/15 px-2.5 py-1 text-xs text-emerald-100">Xero OK visible</span>}
+                  </div>
+                  <h3 className="mt-3 text-xl font-semibold text-white">{row.description}</h3>
+                  <p className="mt-1 text-sm text-white/45">{dateLabel(row.date)} · {row.transactionType || 'Unknown type'}</p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight">{formatMoney(row.amount)}</p>
+                  <p className="mt-3 rounded-2xl border border-white/10 bg-black/25 p-3 text-sm leading-6 text-white/70">{row.nextStep}</p>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-black/20 p-4">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
+                    <GitCompareArrows className="h-4 w-4 text-cyan-200" />
+                    What Xero is suggesting
+                  </div>
+                  <dl className="mt-3 space-y-2 text-sm">
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-white/35">Who</dt>
+                      <dd className="text-right text-white/75">{row.suggestedWho || 'not set'}</dd>
+                    </div>
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-white/35">Account</dt>
+                      <dd className="text-right text-white/75">{row.suggestedAccount || 'not set'}</dd>
+                    </div>
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-white/35">Tax</dt>
+                      <dd className="text-right text-white/75">{row.suggestedTaxRate || 'not set'}</dd>
+                    </div>
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-white/35">Why</dt>
+                      <dd className="text-right text-white/75">{row.suggestedWhy || 'not set'}</dd>
+                    </div>
+                  </dl>
+                  {row.existingMatchLabel && (
+                    <p className="mt-4 rounded-2xl bg-emerald-400/10 p-3 text-sm text-emerald-100">
+                      Existing right-hand match: {row.existingMatchLabel}
+                    </p>
+                  )}
+                  <div className="mt-4 rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-sm">
+                    <p className="font-semibold text-cyan-50">ACT recommended fields</p>
+                    <dl className="mt-2 space-y-1 text-cyan-100/80">
+                      <div className="flex justify-between gap-3">
+                        <dt className="text-cyan-100/50">Who</dt>
+                        <dd className="text-right">{row.recommendedFields.who || row.suggestedWho || 'use transfer account'}</dd>
+                      </div>
+                      <div className="flex justify-between gap-3">
+                        <dt className="text-cyan-100/50">What</dt>
+                        <dd className="text-right">{row.recommendedFields.account}</dd>
+                      </div>
+                      <div className="flex justify-between gap-3">
+                        <dt className="text-cyan-100/50">Tax</dt>
+                        <dd className="text-right">{row.recommendedFields.taxRate}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-cyan-100/50">Why</dt>
+                        <dd className="mt-1 leading-5">{row.recommendedFields.why}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </div>
+
+                <div className="rounded-3xl border border-white/10 bg-black/20 p-4">
+                  <div className="flex items-center gap-2 text-sm font-semibold text-white/80">
+                    <ReceiptText className="h-4 w-4 text-cyan-200" />
+                    ACT evidence
+                  </div>
+                  <div className="mt-3 space-y-3 text-sm">
+                    {row.billCandidates[0] ? (
+                      <div className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-3">
+                        <p className="font-medium text-cyan-50">Xero bill candidate</p>
+                        <p className="mt-1 text-cyan-100/75">
+                          {row.billCandidates[0].contactName || 'Unknown'} · {dateLabel(row.billCandidates[0].date)} · {formatMoney(row.billCandidates[0].total)}
+                        </p>
+                        <p className="mt-1 text-cyan-100/60">
+                          {row.billCandidates[0].status || 'no status'} · {row.billCandidates[0].hasAttachments ? 'attachment' : 'no attachment'} · {row.billCandidates[0].reference || 'no reference'}
+                        </p>
+                        <a href={row.billCandidates[0].xeroUrl} target="_blank" rel="noreferrer" className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-cyan-100 hover:text-white">
+                          Open Xero bill <ExternalLink className="h-3 w-3" />
+                        </a>
+                      </div>
+                    ) : (
+                      <p className="rounded-2xl border border-white/10 bg-white/[0.035] p-3 text-white/45">No exact Xero bill candidate found.</p>
+                    )}
+
+                    {row.evidence ? (
+                      <div className="rounded-2xl border border-emerald-300/20 bg-emerald-300/10 p-3">
+                        <p className="font-medium text-emerald-50">
+                          Receipt evidence: {row.evidence.status}
+                        </p>
+                        <p className="mt-1 text-emerald-100/70">
+                          {Math.round(row.evidence.bestConfidence * 100)}% · {row.evidence.bestSource || 'unknown source'} · {row.evidence.candidateCount} candidates
+                        </p>
+                        <Link href={row.receiptEvidenceUrl} className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-emerald-100 hover:text-white">
+                          Open receipt evidence <ExternalLink className="h-3 w-3" />
+                        </Link>
+                      </div>
+                    ) : (
+                      <p className="rounded-2xl border border-white/10 bg-white/[0.035] p-3 text-white/45">No receipt evidence match found in the mirror.</p>
+                    )}
+
+                    {row.bankLine && (
+                      <div className="rounded-2xl border border-white/10 bg-white/[0.035] p-3 text-white/55">
+                        <div className="flex items-center gap-2">
+                          {String(row.bankLine.status || '').toLowerCase() === 'reconciled'
+                            ? <CheckCircle2 className="h-4 w-4 text-emerald-200" />
+                            : <AlertTriangle className="h-4 w-4 text-amber-200" />}
+                          <span>Mirror: {row.bankLine.status || 'unknown'}</span>
+                        </div>
+                        <p className="mt-1">
+                          Project {row.bankLine.projectCode || 'unset'} · date delta {row.bankLine.dateDeltaDays ?? '?'}d
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/command-center/src/app/ideas/page.tsx
+++ b/apps/command-center/src/app/ideas/page.tsx
@@ -28,6 +28,12 @@ interface Idea {
   project_code: string | null
   energy: number
   status: string
+  // Pass 2B lifecycle fields
+  lifecycle_stage: 'idea' | 'scope' | 'fundraise' | 'start' | 'killed'
+  owner: string
+  stage_entered_at: string
+  kill_reason: string | null
+  snooze_count?: number
   notes: string | null
   value_estimate: number
   created_at: string
@@ -46,11 +52,11 @@ const CATEGORIES = [
 ] as const
 
 const STAGES = [
-  { id: 'open', label: 'Spark', icon: '💡', color: 'border-yellow-500/30', desc: 'Raw ideas' },
-  { id: 'exploring', label: 'Exploring', icon: '🔍', color: 'border-blue-500/30', desc: 'Researching' },
-  { id: 'doing', label: 'Building', icon: '🔨', color: 'border-green-500/30', desc: 'In progress' },
-  { id: 'parked', label: 'Parked', icon: '⏸️', color: 'border-white/10', desc: 'On hold' },
-  { id: 'done', label: 'Done', icon: '✅', color: 'border-emerald-500/30', desc: 'Completed' },
+  { id: 'idea', label: 'Idea', icon: '💡', color: 'border-yellow-500/30', desc: 'Raw experiment (90d nudge)' },
+  { id: 'scope', label: 'Scope', icon: '🔍', color: 'border-blue-500/30', desc: 'Actively shaping (30d nudge)' },
+  { id: 'fundraise', label: 'Fundraise', icon: '💸', color: 'border-purple-500/30', desc: 'Asking for money (14d nudge)' },
+  { id: 'start', label: 'Start', icon: '🚀', color: 'border-emerald-500/30', desc: 'In flight (look-back)' },
+  { id: 'killed', label: 'Killed', icon: '❌', color: 'border-white/10', desc: 'Terminal' },
 ] as const
 
 const PROJECT_CODES = ['EL', 'JH', 'GOC', 'BCV', 'HARVEST', 'FARM', 'ART', 'ACT-CORE', 'ACT-EL', 'ACT-JH', 'ACT-GD', 'ACT-HV'] as const
@@ -96,6 +102,27 @@ function formatMoney(n: number): string {
 
 export default function IdeasPage() {
   const queryClient = useQueryClient()
+  // Pass 2B — deep-link target: /ideas?focus=<idea_id> highlights + scrolls to that card.
+  const [focusId, setFocusId] = React.useState<string | null>(null)
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+    const id = new URLSearchParams(window.location.search).get('focus')
+    if (id) setFocusId(id)
+  }, [])
+  React.useEffect(() => {
+    if (!focusId) return
+    // Wait for cards to render then scroll
+    const t = setTimeout(() => {
+      const el = document.getElementById(`idea-card-${focusId}`)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        el.classList.add('ring-2', 'ring-yellow-400/70')
+        setTimeout(() => el.classList.remove('ring-2', 'ring-yellow-400/70'), 3000)
+      }
+    }, 250)
+    return () => clearTimeout(t)
+  }, [focusId])
+
   const [newText, setNewText] = React.useState('')
   const [newCategory, setNewCategory] = React.useState('idea')
   const [newProject, setNewProject] = React.useState<string | null>(null)
@@ -225,18 +252,21 @@ export default function IdeasPage() {
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination) return
     const { draggableId, destination } = result
-    const newStatus = destination.droppableId
-    updateMutation.mutate({ id: draggableId, updates: { status: newStatus } })
+    const newStage = destination.droppableId as Idea['lifecycle_stage']
+    updateMutation.mutate({
+      id: draggableId,
+      updates: { lifecycle_stage: newStage, stage_entered_at: new Date().toISOString() },
+    })
   }
 
-  // Board: group by status
+  // Board: group by lifecycle_stage (Pass 2B). Falls back to legacy 'open' → 'idea'.
   const board = React.useMemo(() => {
     const cols: Record<string, Idea[]> = {}
     for (const stage of STAGES) cols[stage.id] = []
     for (const idea of filteredIdeas) {
-      const status = idea.status || 'open'
-      if (cols[status]) cols[status].push(idea)
-      else cols['open'].push(idea)
+      const stage = idea.lifecycle_stage || 'idea'
+      if (cols[stage]) cols[stage].push(idea)
+      else cols['idea'].push(idea)
     }
     return cols
   }, [filteredIdeas])
@@ -577,7 +607,7 @@ export default function IdeasPage() {
             {STAGES.map((stage) => {
               const items = board[stage.id] || []
               const colValue = items.reduce((s, i) => s + (i.value_estimate || 0), 0)
-              const isTerminal = stage.id === 'parked' || stage.id === 'done'
+              const isTerminal = stage.id === 'killed' || stage.id === 'start'
 
               return (
                 <Droppable key={stage.id} droppableId={stage.id}>
@@ -738,6 +768,7 @@ function IdeaCard({
 
   return (
     <div
+      id={`idea-card-${idea.id}`}
       className={cn(
         'rounded-xl border transition-all',
         isEditing ? `${cat.border} bg-white/[0.06]` : 'border-white/[0.06] bg-white/[0.03] hover:bg-white/[0.05] hover:border-white/[0.1]',
@@ -754,6 +785,28 @@ function IdeaCard({
           {idea.project_code && (
             <span className="text-[10px] font-mono px-1.5 py-0.5 bg-white/[0.06] rounded text-white/40">
               {idea.project_code}
+            </span>
+          )}
+          {idea.owner && idea.owner !== 'ben' && (
+            <span className="text-[10px] px-1.5 py-0.5 bg-white/[0.06] rounded text-white/40" title={`Owner: ${idea.owner}`}>
+              @{idea.owner}
+            </span>
+          )}
+          {idea.snooze_count && idea.snooze_count > 0 && (
+            <span
+              className={cn(
+                'text-[10px] px-1.5 py-0.5 rounded',
+                idea.snooze_count >= 3
+                  ? 'bg-red-500/15 text-red-300'
+                  : 'bg-white/[0.06] text-white/50',
+              )}
+              title={
+                idea.snooze_count >= 3
+                  ? 'Snooze cap reached — make a call'
+                  : `${idea.snooze_count} snooze${idea.snooze_count === 1 ? '' : 's'} (cap 3)`
+              }
+            >
+              💤×{idea.snooze_count}
             </span>
           )}
           <span className="flex-1" />
@@ -854,19 +907,22 @@ function IdeaCard({
         {/* Quick action bar (always visible, not just when editing) */}
         {!isEditing && !compact && (
           <div className="flex items-center gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            {/* Status quick-advance button */}
-            {idea.status !== 'done' && (
+            {/* Lifecycle stage quick-advance button */}
+            {idea.lifecycle_stage !== 'start' && idea.lifecycle_stage !== 'killed' && (
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  const statusOrder = ['open', 'exploring', 'doing', 'done']
-                  const idx = statusOrder.indexOf(idea.status)
-                  if (idx < statusOrder.length - 1) {
-                    onUpdate({ status: statusOrder[idx + 1] })
+                  const order: Idea['lifecycle_stage'][] = ['idea', 'scope', 'fundraise', 'start']
+                  const idx = order.indexOf(idea.lifecycle_stage)
+                  if (idx >= 0 && idx < order.length - 1) {
+                    onUpdate({
+                      lifecycle_stage: order[idx + 1],
+                      stage_entered_at: new Date().toISOString(),
+                    })
                   }
                 }}
                 className="flex items-center gap-0.5 text-[10px] text-white/20 hover:text-white/50 px-1 py-0.5 rounded hover:bg-white/[0.04]"
-                title={`Move to next stage`}
+                title="Move to next lifecycle stage"
               >
                 <ChevronRight className="h-3 w-3" />
               </button>
@@ -904,10 +960,13 @@ function IdeaCard({
 
             {/* Controls row */}
             <div className="flex items-center gap-2 flex-wrap">
-              {/* Status */}
+              {/* Lifecycle stage */}
               <select
-                value={idea.status}
-                onChange={(e) => onUpdate({ status: e.target.value })}
+                value={idea.lifecycle_stage}
+                onChange={(e) => onUpdate({
+                  lifecycle_stage: e.target.value as Idea['lifecycle_stage'],
+                  stage_entered_at: new Date().toISOString(),
+                })}
                 className="text-[10px] px-2 py-1 bg-white/[0.06] border border-white/[0.06] rounded text-white/50 focus:outline-none cursor-pointer"
               >
                 {STAGES.map(s => (
@@ -985,18 +1044,18 @@ function IdeaCard({
           </div>
         )}
 
-        {/* Status badge (grid view, not editing) */}
-        {!isEditing && !compact && idea.status !== 'open' && (
+        {/* Lifecycle stage badge (grid view, not editing) */}
+        {!isEditing && !compact && idea.lifecycle_stage !== 'idea' && (
           <div className="mt-1">
             <span className={cn(
               'text-[10px] px-1.5 py-0.5 rounded capitalize',
-              idea.status === 'exploring' ? 'bg-blue-500/15 text-blue-400' :
-              idea.status === 'doing' ? 'bg-green-500/15 text-green-400' :
-              idea.status === 'parked' ? 'bg-white/[0.06] text-white/30' :
-              idea.status === 'done' ? 'bg-emerald-500/15 text-emerald-400' :
+              idea.lifecycle_stage === 'scope' ? 'bg-blue-500/15 text-blue-400' :
+              idea.lifecycle_stage === 'fundraise' ? 'bg-purple-500/15 text-purple-400' :
+              idea.lifecycle_stage === 'start' ? 'bg-emerald-500/15 text-emerald-400' :
+              idea.lifecycle_stage === 'killed' ? 'bg-white/[0.06] text-white/30' :
               'text-white/30'
             )}>
-              {idea.status}
+              {idea.lifecycle_stage}
             </span>
           </div>
         )}

--- a/apps/command-center/src/components/finance/TodayActionsHero.tsx
+++ b/apps/command-center/src/components/finance/TodayActionsHero.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import { AlertTriangle, ArrowRight, CheckCircle2 } from 'lucide-react'
+
+interface Signal {
+  severity: 'high' | 'medium' | 'low'
+  label: string
+  detail: string
+  href: string
+  count?: number
+}
+
+interface TodayActionsResponse {
+  generatedAt: string
+  hasWork: boolean
+  signals: Signal[]
+  counts: {
+    untaggedTxns: number
+    untaggedInvs: number
+    receiptsReady: number
+    aiSuggestions: number
+    overdueAR: number
+    narrativeAgeDays: number | null
+  }
+}
+
+const SEV_TONE: Record<Signal['severity'], { dot: string; chip: string }> = {
+  high: { dot: 'bg-rose-400', chip: 'text-rose-200 border-rose-500/30 bg-rose-500/5' },
+  medium: { dot: 'bg-amber-400', chip: 'text-amber-200 border-amber-500/30 bg-amber-500/5' },
+  low: { dot: 'bg-cyan-400', chip: 'text-cyan-200 border-cyan-500/30 bg-cyan-500/5' },
+}
+
+export function TodayActionsHero() {
+  const { data, isLoading, error } = useQuery<TodayActionsResponse>({
+    queryKey: ['finance', 'today-actions'],
+    queryFn: async () => {
+      const res = await fetch('/api/finance/today-actions', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    staleTime: 60 * 1000,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="mb-6 animate-pulse rounded-2xl border border-border bg-card p-5">
+        <div className="h-4 w-32 rounded bg-muted" />
+        <div className="mt-3 space-y-2">
+          <div className="h-3 w-2/3 rounded bg-muted/60" />
+          <div className="h-3 w-1/2 rounded bg-muted/60" />
+        </div>
+      </div>
+    )
+  }
+
+  if (error || !data) return null
+
+  if (!data.hasWork) {
+    return (
+      <div className="mb-6 flex items-center gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/5 p-5 text-sm text-emerald-100">
+        <CheckCircle2 className="h-5 w-5 shrink-0" />
+        <div>
+          <p className="font-semibold">Nothing waiting on you right now.</p>
+          <p className="mt-0.5 text-emerald-200/70">
+            Workbench is clear, receipts attached, AI suggestions accepted. Explore below or open{' '}
+            <Link href="/finance/command" className="underline">Money Command</Link>.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-6 rounded-2xl border border-amber-500/30 bg-gradient-to-br from-amber-500/[0.06] to-rose-500/[0.04] p-5">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 text-amber-300" />
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-200">
+          {data.signals.length === 1 ? '1 thing waiting' : `${data.signals.length} things waiting`}
+        </p>
+      </div>
+      <ul className="mt-3 grid gap-2 sm:grid-cols-3">
+        {data.signals.map((s, i) => {
+          const tone = SEV_TONE[s.severity]
+          return (
+            <li key={i}>
+              <Link
+                href={s.href}
+                className={`group flex h-full flex-col justify-between gap-2 rounded-xl border px-4 py-3 transition hover:border-foreground/40 ${tone.chip}`}
+              >
+                <div className="flex items-start gap-2">
+                  <span className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${tone.dot}`} />
+                  <p className="text-sm font-semibold leading-snug">{s.label}</p>
+                </div>
+                <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+                  <span className="truncate">{s.detail}</span>
+                  <ArrowRight className="h-3 w-3 shrink-0 transition group-hover:translate-x-0.5" />
+                </div>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/command-center/src/components/sidebar/sidebar-item.tsx
+++ b/apps/command-center/src/components/sidebar/sidebar-item.tsx
@@ -15,22 +15,6 @@ export function SidebarItem({
   depth?: number
 }) {
   const pathname = usePathname()
-
-  // Divider items render as non-clickable section headers inside a children list.
-  if (item.divider) {
-    const dividerPad = depth === 0 ? 'pl-3' : depth === 1 ? 'pl-9' : 'pl-14'
-    return (
-      <div
-        className={cn(
-          'mt-3 mb-1 pr-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/30',
-          dividerPad,
-        )}
-      >
-        {item.label}
-      </div>
-    )
-  }
-
   const isExactActive = pathname === item.href
   const isActive = isExactActive || pathname.startsWith(`${item.href}/`)
   const hasChildren = item.children && item.children.length > 0
@@ -50,6 +34,22 @@ export function SidebarItem({
       setExpanded(true)
     }
   }, [childActive, isActive])
+
+  // Divider items render as non-clickable section headers. Placed AFTER all
+  // hooks so the rules-of-hooks order stays consistent across both render paths.
+  if (item.divider) {
+    const dividerPad = depth === 0 ? 'pl-3' : depth === 1 ? 'pl-9' : 'pl-14'
+    return (
+      <div
+        className={cn(
+          'mt-3 mb-1 pr-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/30',
+          dividerPad,
+        )}
+      >
+        {item.label}
+      </div>
+    )
+  }
 
   const Icon = item.icon
   const hasColorIcon = item.color && item.bg

--- a/apps/command-center/src/components/sidebar/sidebar-item.tsx
+++ b/apps/command-center/src/components/sidebar/sidebar-item.tsx
@@ -15,6 +15,22 @@ export function SidebarItem({
   depth?: number
 }) {
   const pathname = usePathname()
+
+  // Divider items render as non-clickable section headers inside a children list.
+  if (item.divider) {
+    const dividerPad = depth === 0 ? 'pl-3' : depth === 1 ? 'pl-9' : 'pl-14'
+    return (
+      <div
+        className={cn(
+          'mt-3 mb-1 pr-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-white/30',
+          dividerPad,
+        )}
+      >
+        {item.label}
+      </div>
+    )
+  }
+
   const isExactActive = pathname === item.href
   const isActive = isExactActive || pathname.startsWith(`${item.href}/`)
   const hasChildren = item.children && item.children.length > 0

--- a/apps/command-center/src/lib/agent-tools.ts
+++ b/apps/command-center/src/lib/agent-tools.ts
@@ -41,6 +41,12 @@ import {
 } from './tools/projects'
 
 import {
+  executeAddIdea,
+  executeTransitionIdeaStage,
+  executeSnoozeIdea,
+} from './tools/ideas'
+
+import {
   executeSaveDailyReflection,
   executeSearchPastReflections,
   executeSaveWritingDraft,
@@ -227,6 +233,17 @@ export async function executeTool(
       )
     case 'get_revenue_scoreboard':
       return await executeGetRevenueScoreboard()
+    // Pilot lifecycle tools (Pass 2B)
+    case 'add_idea':
+      return await executeAddIdea(
+        input as { text: string; category?: string; energy?: number; value_estimate?: number; owner?: string }
+      )
+    case 'transition_idea_stage':
+      return await executeTransitionIdeaStage(
+        input as { id: string; stage: 'idea' | 'scope' | 'fundraise' | 'start' | 'killed'; kill_reason?: string; force?: boolean }
+      )
+    case 'snooze_idea':
+      return await executeSnoozeIdea(input as { id: string; days: number; by_owner?: string })
     default:
       return JSON.stringify({ error: `Unknown tool: ${name}` })
   }

--- a/apps/command-center/src/lib/nav-data.ts
+++ b/apps/command-center/src/lib/nav-data.ts
@@ -43,6 +43,8 @@ export interface SidebarNavItem {
   color?: string
   bg?: string
   children?: SidebarNavItem[]
+  /** Render as a non-clickable section header inside a children list. */
+  divider?: boolean
 }
 
 export interface SidebarNavGroup {
@@ -106,22 +108,34 @@ export const navStructure: SidebarNavGroup[] = [
         children: [
           // 2026-05-08 cleanup — retired: tagger, tagger-bulk, pipeline-viz, pipeline-kanban, project-plan, self-reliance, vendor-rules-suggest.
           // 2026-05-16 cleanup — retired: revenue-planning, review (see thoughts/shared/handoffs/2026-05-16-money-audit/).
+          // 2026-05-16 UX audit — grouped by job-to-do with 5 section dividers (ux-audit.md).
+          { href: '#today', label: 'Today', icon: Sun, divider: true },
           { href: '/finance/command', label: 'Money Command', icon: Compass, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
-          { href: '/finance', label: 'All finance (operate hub)', icon: DollarSign, color: 'text-foreground', bg: 'bg-white/10' },
-          { href: '/finance/workbench', label: 'Finance Workbench', icon: ClipboardList, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
+          { href: '/finance/workbench', label: 'Workbench', icon: ClipboardList, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
           { href: '/finance/xero-page-copilot', label: 'Xero Page Copilot', icon: Bot, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
           { href: '/finance/dext-push-audit', label: 'Dext Push Audit', icon: ShieldAlert, color: 'text-red-400', bg: 'bg-red-500/20' },
-          { href: '/finance/overview', label: 'CEO money cockpit', icon: Layers, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
-          { href: '/finance/money-alignment', label: 'Money Alignment', icon: CircleDollarSign, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
-          { href: '/finance/reconciliation', label: 'Reconciliation (receipts)', icon: ClipboardCheck, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
-          { href: '/finance/tagger-v2', label: 'Rapid Tagger', icon: Tag, color: 'text-amber-400', bg: 'bg-amber-500/20' },
+
+          { href: '#receipts', label: 'Receipts & spending', icon: Receipt, divider: true },
+          { href: '/finance/reconciliation', label: 'Reconciliation', icon: ClipboardCheck, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
           { href: '/finance/receipts-triage', label: 'Receipts Triage', icon: Receipt, color: 'text-rose-400', bg: 'bg-rose-500/20' },
+          { href: '/finance/tagger-v2', label: 'Rapid Tagger', icon: Tag, color: 'text-amber-400', bg: 'bg-amber-500/20' },
+
+          { href: '#money-state', label: 'Money state', icon: BarChart3, divider: true },
+          { href: '/finance/overview', label: 'CEO Cockpit', icon: Layers, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
+          { href: '/finance/money-alignment', label: 'Money Alignment', icon: CircleDollarSign, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
           { href: '/finance/projects', label: 'Projects P&L', icon: BarChart3, color: 'text-green-400', bg: 'bg-green-500/20' },
+
+          { href: '#pipeline', label: 'Pipeline & invoices', icon: Target, divider: true },
           { href: '/finance/pipeline', label: 'Pipeline', icon: Target, color: 'text-indigo-400', bg: 'bg-indigo-500/20' },
+          { href: '/finance/invoices', label: 'Invoice Command', icon: Receipt, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
+
+          { href: '#roles', label: 'Role views', icon: Landmark, divider: true },
           { href: '/finance/board', label: 'Board Report', icon: Landmark, color: 'text-blue-400', bg: 'bg-blue-500/20' },
           { href: '/finance/accountant', label: 'Accountant Pack', icon: Calculator, color: 'text-orange-400', bg: 'bg-orange-500/20' },
           { href: '/finance/revenue', label: 'Revenue Sequencing', icon: TrendingUp, color: 'text-purple-400', bg: 'bg-purple-500/20' },
-          { href: '/finance/invoices', label: 'Invoice Command', icon: Receipt, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
+
+          { href: '#hub', label: 'Hub', icon: DollarSign, divider: true },
+          { href: '/finance', label: 'All finance (operate hub)', icon: DollarSign, color: 'text-foreground', bg: 'bg-white/10' },
         ],
       },
     ],

--- a/apps/command-center/src/lib/nav-data.ts
+++ b/apps/command-center/src/lib/nav-data.ts
@@ -112,6 +112,7 @@ export const navStructure: SidebarNavGroup[] = [
           { href: '#today', label: 'Today', icon: Sun, divider: true },
           { href: '/finance/command', label: 'Money Command', icon: Compass, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
           { href: '/finance/workbench', label: 'Workbench', icon: ClipboardList, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
+          { href: '/finance/ai-suggestions', label: 'AI Suggestions', icon: Sparkles, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
           { href: '/finance/xero-page-copilot', label: 'Xero Page Copilot', icon: Bot, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
           { href: '/finance/dext-push-audit', label: 'Dext Push Audit', icon: ShieldAlert, color: 'text-red-400', bg: 'bg-red-500/20' },
 

--- a/apps/command-center/src/lib/telegram/reactor-callbacks.ts
+++ b/apps/command-center/src/lib/telegram/reactor-callbacks.ts
@@ -50,9 +50,61 @@ export async function handleReactorCallback(
       return handleXeroCallback(action, entityId)
     case 'gmail':
       return handleGmailCallback(action, entityId)
+    case 'idea':
+      return handleIdeaCallback(action, entityId, parts[3])
     default:
       return { toast: `Unknown: ${domain}` }
   }
+}
+
+async function handleIdeaCallback(
+  action: string,
+  entityId: string,
+  extra?: string,
+): Promise<CallbackResult> {
+  const { executeTransitionIdeaStage, executeSnoozeIdea } = await import('@/lib/tools/ideas')
+
+  if (action === 'to_fundraise') {
+    const result = JSON.parse(await executeTransitionIdeaStage({ id: entityId, stage: 'fundraise' }))
+    if (result.error) return { toast: result.error.slice(0, 200) }
+    return {
+      toast: '→ fundraise',
+      editMessage: `→ fundraise · "${result.text}"`,
+    }
+  }
+
+  if (action === 'to_start') {
+    const result = JSON.parse(await executeTransitionIdeaStage({ id: entityId, stage: 'start' }))
+    if (result.error) return { toast: result.error.slice(0, 200) }
+    return {
+      toast: '→ start',
+      editMessage: `→ start · "${result.text}"${result.needs_project_code ? ' (run suggest-code helper next)' : ''}`,
+    }
+  }
+
+  if (action === 'kill') {
+    const result = JSON.parse(await executeTransitionIdeaStage({ id: entityId, stage: 'killed' }))
+    if (result.error) return { toast: result.error.slice(0, 200) }
+    return {
+      toast: '❌ killed',
+      editMessage: `❌ killed · "${result.text}"`,
+    }
+  }
+
+  if (action === 'snooze') {
+    const days = extra ? Number.parseInt(extra, 10) : 14
+    const result = JSON.parse(await executeSnoozeIdea({ id: entityId, days }))
+    if (result.error === 'snooze_limit_reached') {
+      return { toast: result.message.slice(0, 200) }
+    }
+    if (result.error) return { toast: result.error.slice(0, 200) }
+    return {
+      toast: `💤 ${days}d`,
+      editMessage: `💤 snoozed until ${result.snoozed_until} (${result.remaining} snoozes left)`,
+    }
+  }
+
+  return { toast: `Unknown idea action: ${action}` }
 }
 
 async function handleGrantCallback(action: string, entityId: string): Promise<CallbackResult> {

--- a/apps/command-center/src/lib/tool-definitions.ts
+++ b/apps/command-center/src/lib/tool-definitions.ts
@@ -298,6 +298,57 @@ export const AGENT_TOOLS: Anthropic.Tool[] = [
     },
   },
 
+  // ── PILOT LIFECYCLE (Pass 2B) ──────────────────────────────────────
+  {
+    name: 'add_idea',
+    description:
+      'Capture a pre-funding experimental idea (not a funded project, workshop, or buyer deal). Use when the user says "new idea", "log this idea", "/idea X", or describes something they want to remember as an experiment to maybe pursue. Sets stage = "idea"; the system will nudge them in 90 days if it stays idle.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        text: { type: 'string', description: 'Short description of the idea (one-line works fine).' },
+        category: { type: 'string', description: 'Optional category like idea, hunch, pilot, partnership. Default: idea.' },
+        energy: { type: 'number', description: 'Optional 1-5 energy score (how much the user is excited about it).' },
+        value_estimate: { type: 'number', description: 'Optional rough $ value if pursued.' },
+        owner: { type: 'string', description: 'Owner. Default: ben.' },
+      },
+      required: ['text'],
+    },
+  },
+  {
+    name: 'transition_idea_stage',
+    description:
+      'Move an idea forward (or kill it) in the lifecycle: idea → scope → fundraise → start, or → killed at any point. Use when the user says "move idea X to fundraise", "kill idea Y", "this idea is starting", or taps an inline reminder button. On → start, the system will suggest a project_code via a separate flow.',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        id: { type: 'string', description: 'idea_board.id (uuid).' },
+        stage: {
+          type: 'string',
+          enum: ['idea', 'scope', 'fundraise', 'start', 'killed'],
+          description: 'Target stage.',
+        },
+        kill_reason: { type: 'string', description: 'Optional free-text reason if stage = "killed".' },
+        force: { type: 'boolean', description: 'Set true to allow backwards or skip-stage moves (default false).' },
+      },
+      required: ['id', 'stage'],
+    },
+  },
+  {
+    name: 'snooze_idea',
+    description:
+      'Push the next reminder for an idea out by N days (1-90). Capped at 3 snoozes per idea — on the 4th attempt the system refuses and asks for a forced decision (→ fundraise / → start / ❌ kill). Use when user says "snooze idea X" or taps "💤 snooze 14d".',
+    input_schema: {
+      type: 'object' as const,
+      properties: {
+        id: { type: 'string', description: 'idea_board.id (uuid).' },
+        days: { type: 'number', description: 'Number of days to snooze (1-90). Default reminder cadence offers 14.' },
+        by_owner: { type: 'string', description: 'Owner who is snoozing. Default: ben.' },
+      },
+      required: ['id', 'days'],
+    },
+  },
+
   // ── GRANT & PIPELINE TOOLS (read-only) ─────────────────────────────
 
   {
@@ -1155,6 +1206,10 @@ const PROJECT_TOOL_NAMES = new Set([
   'get_contacts_needing_attention',
   'get_deal_risks',
   'get_goods_intelligence',
+  // Pilot lifecycle (Pass 2B)
+  'add_idea',
+  'transition_idea_stage',
+  'snooze_idea',
 ])
 
 /** Writing, reflection, dreams, planning */

--- a/apps/command-center/src/lib/tools/ideas.ts
+++ b/apps/command-center/src/lib/tools/ideas.ts
@@ -1,0 +1,223 @@
+/**
+ * Pilot lifecycle tools — Pass 2B
+ *
+ * Plan: ~/.claude/plans/coo-cio-cfo-money-brain-phase2.md (Q2-Q7)
+ *
+ * Stages: idea → scope → fundraise → start (or killed terminal)
+ * Owner: defaults to 'ben' (Q4)
+ * Snooze cap: 3 before forced decision (Q6)
+ */
+
+import { supabase } from '../supabase'
+
+type LifecycleStage = 'idea' | 'scope' | 'fundraise' | 'start' | 'killed'
+
+const VALID_STAGES: LifecycleStage[] = ['idea', 'scope', 'fundraise', 'start', 'killed']
+
+/** Valid forward transitions. Backwards moves require explicit override. */
+const ALLOWED_FORWARD: Record<LifecycleStage, LifecycleStage[]> = {
+  idea: ['scope', 'killed'],
+  scope: ['fundraise', 'killed'],
+  fundraise: ['start', 'killed'],
+  start: ['killed'],
+  killed: [], // terminal
+}
+
+export async function executeAddIdea(input: {
+  text: string
+  category?: string
+  energy?: number
+  value_estimate?: number
+  owner?: string
+}): Promise<string> {
+  try {
+    if (!input.text || input.text.trim().length === 0) {
+      return JSON.stringify({ error: 'Idea text required' })
+    }
+
+    const { data, error } = await supabase
+      .from('idea_board')
+      .insert({
+        text: input.text.trim(),
+        category: input.category ?? 'idea',
+        energy: input.energy ?? 0,
+        value_estimate: input.value_estimate ?? 0,
+        lifecycle_stage: 'idea',
+        owner: input.owner ?? 'ben',
+        status: 'open',
+      })
+      .select('id, text, lifecycle_stage, owner')
+      .single()
+
+    if (error) return JSON.stringify({ error: error.message })
+
+    return JSON.stringify({
+      action: 'idea_added',
+      id: data.id,
+      text: data.text,
+      stage: data.lifecycle_stage,
+      owner: data.owner,
+      confirmation: `Captured idea (${data.lifecycle_stage}, owner ${data.owner}). I'll nudge you in 90 days if it stays idle.`,
+    })
+  } catch (err) {
+    return JSON.stringify({ error: (err as Error).message })
+  }
+}
+
+export async function executeTransitionIdeaStage(input: {
+  id: string
+  stage: LifecycleStage
+  kill_reason?: string
+  force?: boolean
+}): Promise<string> {
+  try {
+    if (!VALID_STAGES.includes(input.stage)) {
+      return JSON.stringify({ error: `Invalid stage: ${input.stage}. Must be one of: ${VALID_STAGES.join(', ')}` })
+    }
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from('idea_board')
+      .select('id, text, lifecycle_stage, project_code')
+      .eq('id', input.id)
+      .single()
+
+    if (fetchErr || !existing) {
+      return JSON.stringify({ error: fetchErr?.message ?? 'Idea not found' })
+    }
+
+    const current = existing.lifecycle_stage as LifecycleStage
+    const allowed = ALLOWED_FORWARD[current]
+    if (!input.force && !allowed.includes(input.stage)) {
+      return JSON.stringify({
+        error: `Invalid transition ${current} → ${input.stage}. Allowed: ${allowed.join(', ') || '(none — terminal)'}`,
+      })
+    }
+
+    if (input.stage === 'killed' && !input.kill_reason) {
+      // optional but encouraged (plan Q decision: optional)
+    }
+
+    const nowIso = new Date().toISOString()
+    const updatePayload: Record<string, unknown> = {
+      lifecycle_stage: input.stage,
+      stage_entered_at: nowIso,
+      updated_at: nowIso,
+    }
+    if (input.stage === 'killed' && input.kill_reason) {
+      updatePayload.kill_reason = input.kill_reason
+    }
+
+    const { error: updateErr } = await supabase
+      .from('idea_board')
+      .update(updatePayload)
+      .eq('id', input.id)
+
+    if (updateErr) return JSON.stringify({ error: updateErr.message })
+
+    const needsProjectCode = input.stage === 'start' && !existing.project_code
+
+    return JSON.stringify({
+      action: 'idea_transitioned',
+      id: existing.id,
+      from: current,
+      to: input.stage,
+      text: existing.text,
+      needs_project_code: needsProjectCode,
+      confirmation:
+        input.stage === 'start' && needsProjectCode
+          ? `Moved to start. I'll suggest a project_code next — run scripts/lib/projects/suggest-code.mjs to bridge into projects.`
+          : input.stage === 'killed'
+            ? `Killed. ${input.kill_reason ? `Reason captured: "${input.kill_reason}".` : 'No reason given.'}`
+            : `Stage updated to ${input.stage}.`,
+    })
+  } catch (err) {
+    return JSON.stringify({ error: (err as Error).message })
+  }
+}
+
+export async function executeSnoozeIdea(input: {
+  id: string
+  days: number
+  by_owner?: string
+}): Promise<string> {
+  try {
+    if (!input.days || input.days < 1 || input.days > 90) {
+      return JSON.stringify({ error: 'days must be 1-90' })
+    }
+
+    const { data: existing, error: fetchErr } = await supabase
+      .from('idea_board')
+      .select('id, text, lifecycle_stage')
+      .eq('id', input.id)
+      .single()
+
+    if (fetchErr || !existing) {
+      return JSON.stringify({ error: fetchErr?.message ?? 'Idea not found' })
+    }
+
+    // Snooze cap (Q6 — 3 max before forced decision)
+    const { count: snoozeCount } = await supabase
+      .from('idea_snoozes')
+      .select('id', { count: 'exact', head: true })
+      .eq('idea_id', input.id)
+
+    if ((snoozeCount ?? 0) >= 3) {
+      return JSON.stringify({
+        error: 'snooze_limit_reached',
+        snooze_count: snoozeCount,
+        message: `This idea has been snoozed ${snoozeCount} times already. Make a call: → fundraise, → start, or ❌ kill.`,
+      })
+    }
+
+    const until = new Date()
+    until.setUTCDate(until.getUTCDate() + input.days)
+    const snoozedUntil = until.toISOString().slice(0, 10) // YYYY-MM-DD
+
+    const { error: insertErr } = await supabase.from('idea_snoozes').insert({
+      idea_id: input.id,
+      snoozed_until: snoozedUntil,
+      by_owner: input.by_owner ?? 'ben',
+    })
+
+    if (insertErr) return JSON.stringify({ error: insertErr.message })
+
+    return JSON.stringify({
+      action: 'idea_snoozed',
+      id: existing.id,
+      snoozed_until: snoozedUntil,
+      snooze_count: (snoozeCount ?? 0) + 1,
+      remaining: 3 - ((snoozeCount ?? 0) + 1),
+      confirmation: `Snoozed until ${snoozedUntil} (${3 - ((snoozeCount ?? 0) + 1)} snoozes remaining before forced decision).`,
+    })
+  } catch (err) {
+    return JSON.stringify({ error: (err as Error).message })
+  }
+}
+
+/**
+ * Build the standard 4-button inline keyboard for a reminder DM.
+ * Callback format: `idea:<action>:<id>[:<extra>]` — handled in reactor-callbacks.ts.
+ */
+export function buildIdeaReminderKeyboard(ideaId: string, currentStage: LifecycleStage) {
+  const rows: Array<Array<{ text: string; callback_data: string }>> = []
+
+  // Stage-progression row (omit options that aren't valid forward moves)
+  const progressionButtons: Array<{ text: string; callback_data: string }> = []
+  if (ALLOWED_FORWARD[currentStage].includes('fundraise')) {
+    progressionButtons.push({ text: '→ fundraise', callback_data: `idea:to_fundraise:${ideaId}` })
+  }
+  if (ALLOWED_FORWARD[currentStage].includes('start')) {
+    progressionButtons.push({ text: '→ start', callback_data: `idea:to_start:${ideaId}` })
+  }
+  if (progressionButtons.length > 0) rows.push(progressionButtons)
+
+  // Decision row (kill + snooze always available unless terminal)
+  if (currentStage !== 'killed') {
+    rows.push([
+      { text: '❌ kill', callback_data: `idea:kill:${ideaId}` },
+      { text: '💤 snooze 14d', callback_data: `idea:snooze:${ideaId}:14` },
+    ])
+  }
+
+  return { inline_keyboard: rows }
+}

--- a/config/dext-routing-sections.json
+++ b/config/dext-routing-sections.json
@@ -1,0 +1,257 @@
+{
+  "_meta": {
+    "description": "Dext setup sections and routing rules for ACT bookkeeping cleanup and future ACT Pty flow.",
+    "version": "1.0.0",
+    "updated": "2026-05-15",
+    "principle": "Dext captures evidence; Xero remains the accounting system of record; Supabase/workbench is the review layer."
+  },
+  "global_settings": {
+    "legacy_cleanup_mode": {
+      "auto_publish_default": false,
+      "archive_after_export": false,
+      "publish_destination_for_paid_card_spend": "Bank Accounts / Spend Money",
+      "publish_destination_for_unpaid_supplier_invoices": "Purchases / Bills",
+      "hold_if_unsure": true,
+      "notes": [
+        "Do not bulk publish historical items until they are classified against Xero bank lines.",
+        "Do not publish zero-total, refund-only, duplicate, unknown supplier, or already-reconciled documents.",
+        "For NAB Visa ACT #8815 spend, prefer paid spend-money/bank-account destination, not unpaid bills."
+      ]
+    },
+    "new_act_pty_mode": {
+      "auto_publish_default": false,
+      "enable_auto_publish_after_sample_size": 3,
+      "sample_requirement": "At least three clean same-vendor same-destination publishes with no phantom bills.",
+      "notes": [
+        "Start new ACT Pty Dext account/client with auto-publish off.",
+        "Only enable auto-publish for predictable SaaS/card charges after Xero sync proves the mapping is clean.",
+        "Keep travel, contractors, materials, assets, and foreign currency on manual review."
+      ]
+    }
+  },
+  "dext_fields_to_configure": [
+    {
+      "field": "Payment Method",
+      "required": true,
+      "values": [
+        {
+          "name": "NAB Visa ACT #8815",
+          "use_for": "ACT card spend already paid by business card",
+          "xero_destination": "Bank Accounts / Spend Money",
+          "default_publish": "manual_review"
+        },
+        {
+          "name": "Personal paid - Ben",
+          "use_for": "Ben paid personally and needs reimbursement/expense claim review",
+          "xero_destination": "Expense Claim / reimbursement review",
+          "default_publish": "hold"
+        },
+        {
+          "name": "Personal paid - Nic",
+          "use_for": "Nic paid personally and needs reimbursement/expense claim review",
+          "xero_destination": "Expense Claim / reimbursement review",
+          "default_publish": "hold"
+        },
+        {
+          "name": "Bank transfer / invoice",
+          "use_for": "Supplier invoices that are not card-paid",
+          "xero_destination": "Purchases / Bills only if genuinely unpaid or bill workflow is intended",
+          "default_publish": "manual_review"
+        }
+      ]
+    },
+    {
+      "field": "Project Tracking",
+      "required": true,
+      "values": [
+        { "code": "ACT-IN", "name": "ACT Infrastructure", "use_for": "core software, internet, AI tools, systems, general infrastructure" },
+        { "code": "ACT-HV", "name": "The Harvest Witta", "use_for": "Harvest site, Witta/Maleny property improvements, farm build materials" },
+        { "code": "ACT-FM", "name": "The Farm", "use_for": "farm operations, animal welfare, local farm supplies and fuel where not Harvest capital works" },
+        { "code": "ACT-GD", "name": "Goods", "use_for": "Goods build, manufacturing, containers, marketplace, product/asset work" },
+        { "code": "ACT-JH", "name": "JusticeHub", "use_for": "justice travel, research, civic/youth justice work" },
+        { "code": "ACT-CORE", "name": "ACT Regenerative Studio", "use_for": "studio operations, accounting, admin, general ACT work that is not infrastructure SaaS" },
+        { "code": "ACT-EL", "name": "Empathy Ledger", "use_for": "storytelling, media capture, empathy ledger platform and content work" },
+        { "code": "ACT-PS", "name": "PICC On Country Photo Studio", "use_for": "photo studio, camera/print/creative equipment for PICC work" },
+        { "code": "ACT-MY", "name": "Mounty Yarns", "use_for": "Mounty Yarns related materials, events, travel, production" },
+        { "code": "ACT-OO", "name": "Oonchiumpa", "use_for": "Oonchiumpa consultancy/service costs" },
+        { "code": "ASK_USER", "name": "Ask Ben/Nic", "use_for": "travel, meals, hotels, large purchases, ambiguous locations, shared trips" },
+        { "code": "SL_REVIEW", "name": "Standard Ledger Review", "use_for": "BAS/tax treatment, insurance, donations, write-offs, duplicate bills, capitalisation" }
+      ]
+    },
+    {
+      "field": "Business Division",
+      "required": false,
+      "values": [
+        { "name": "ACT Pty", "use_for": "future clean entity flow" },
+        { "name": "Legacy ACT/Nic Dext cleanup", "use_for": "current export and historical Dext cleanup only" },
+        { "name": "Personal/Reimbursement", "use_for": "items paid personally or not clearly company card spend" }
+      ]
+    }
+  ],
+  "category_defaults": [
+    {
+      "dext_category": "485 - Subscriptions",
+      "default_project": "ACT-IN",
+      "tax_rate": "GST on Expenses unless overseas/zero-GST invoice",
+      "rd_default": "R&D supporting",
+      "publish_policy": "auto_publish_after_vendor_proven",
+      "notes": "Good auto-publish candidates after test publishes: OpenAI, Anthropic/Claude, Supabase, Webflow, Vercel, Bitwarden, Railway, HighLevel, Dext, Notion."
+    },
+    {
+      "dext_category": "489 - Telephone & Internet",
+      "default_project": "ACT-IN",
+      "tax_rate": "GST on Expenses if Australian supplier",
+      "rd_default": "R&D supporting",
+      "publish_policy": "manual_review",
+      "notes": "Belong/Starlink may be ACT-IN, ACT-HV, ACT-FM, or A Curious Tractor depending site/use."
+    },
+    {
+      "dext_category": "446 - Materials & Supplies",
+      "default_project": "ASK_USER",
+      "tax_rate": "GST on Expenses",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Usually ACT-HV, ACT-FM, ACT-GD, ACT-PS, or ACT-MY based on supplier/location/job."
+    },
+    {
+      "dext_category": "750 - Plant & Equipment",
+      "default_project": "ASK_USER",
+      "tax_rate": "GST on Expenses",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Likely asset/capital treatment. Do not auto-publish without Standard Ledger review for high-value items."
+    },
+    {
+      "dext_category": "432 - Hire Expenses",
+      "default_project": "ASK_USER",
+      "tax_rate": "GST on Expenses",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Kennards/hire usually project-specific and must match job/trip."
+    },
+    {
+      "dext_category": "486 - Sub-contractors",
+      "default_project": "ASK_USER",
+      "tax_rate": "Check invoice GST registration",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Never auto-publish; project, GST, and payable/payment state need review."
+    },
+    {
+      "dext_category": "493 - Travel - National",
+      "default_project": "ASK_USER",
+      "tax_rate": "GST on Expenses when domestic taxable",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Use calendar/trip context. Qantas/Virgin/Uber/Avis/Budget/Airbnb/Booking stay manual."
+    },
+    {
+      "dext_category": "494 - Travel - International (0%)",
+      "default_project": "ASK_USER",
+      "tax_rate": "No GST / BAS excluded as advised",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Foreign currency and overseas travel need project/business-purpose review."
+    },
+    {
+      "dext_category": "421 - Light meals & refreshments",
+      "default_project": "ASK_USER",
+      "tax_rate": "GST on Expenses if Australian taxable receipt",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Keep receipt evidence even under threshold; classify by trip/event/business purpose."
+    },
+    {
+      "dext_category": "449 - MV - Fuel & Oil",
+      "default_project": "ASK_USER",
+      "tax_rate": "GST on Expenses",
+      "rd_default": "review",
+      "publish_policy": "manual_review",
+      "notes": "Project depends on vehicle/trip/location; Maleny/Witta often ACT-HV or ACT-FM."
+    },
+    {
+      "dext_category": "450 - MV - Registration & Insurance",
+      "default_project": "SL_REVIEW",
+      "tax_rate": "Check GST treatment",
+      "rd_default": "not R&D unless directly justified",
+      "publish_policy": "manual_review",
+      "notes": "Can be large and entity/vehicle-specific."
+    },
+    {
+      "dext_category": "467 - Rates & Water (0%)",
+      "default_project": "ACT-HV",
+      "tax_rate": "No GST / BAS excluded as advised",
+      "rd_default": "not R&D unless directly justified",
+      "publish_policy": "manual_review",
+      "notes": "Likely Harvest/property costs; confirm property and entity."
+    },
+    {
+      "dext_category": "433 - Insurance",
+      "default_project": "SL_REVIEW",
+      "tax_rate": "Check stamp duty/GST split",
+      "rd_default": "not R&D unless directly justified",
+      "publish_policy": "manual_review",
+      "notes": "Insurance often has mixed GST/stamp duty treatment."
+    }
+  ],
+  "supplier_defaults": [
+    {
+      "suppliers": ["OpenAI", "Anthropic", "Claude.AI", "Supabase", "Webflow", "Vercel", "Railway Corporation", "Bitwarden", "HighLevel", "Dext Software", "Notion Labs", "Firecrawl", "Cognition AI", "X Global LLC", "Google Australia", "RealtimeBoard", "Shipstation"],
+      "category": "485 - Subscriptions",
+      "project": "ACT-IN",
+      "payment_method": "NAB Visa ACT #8815",
+      "publish_destination": "Bank Accounts / Spend Money",
+      "auto_publish": "after three clean test publishes",
+      "rd_default": "R&D supporting"
+    },
+    {
+      "suppliers": ["Qantas", "Qantas Group Accommodation", "Virgin Australia", "Uber", "Avis", "Budget", "Budget Car and Truck Rental (NT)", "Thrifty", "Airbnb", "Booking.com", "Greyhound Australia", "Taxi Receipt", "GoGet", "Holafly"],
+      "category": "493 - Travel - National / 494 - Travel - International",
+      "project": "ASK_USER",
+      "payment_method": "NAB Visa ACT #8815",
+      "publish_destination": "Bank Accounts / Spend Money only after matching bank line",
+      "auto_publish": false,
+      "rd_default": "review"
+    },
+    {
+      "suppliers": ["Bunnings Warehouse", "Maleny Hardware And Rural Supplies", "MALENY LANDSCAPING SUPPLIES", "Kennards Hire", "Liberty Maleny", "BP", "Reddy Express", "The Bolt King", "Carbatec Brisbane", "Kennedy's", "Edmonds Landscaping Supplies", "Allclass", "Container Options", "Telford Smith Engineering", "Bionic Self Storage", "Hatch Electrical"],
+      "category": "446 - Materials & Supplies / 432 - Hire / 750 - Plant & Equipment",
+      "project": "ASK_USER, often ACT-HV/ACT-FM/ACT-GD",
+      "payment_method": "NAB Visa ACT #8815 or supplier invoice",
+      "publish_destination": "Manual review",
+      "auto_publish": false,
+      "rd_default": "review"
+    },
+    {
+      "suppliers": ["Defy Manufacturing", "Defy", "BOE Design", "DNP Australia", "Centre Canvas And Upholstery"],
+      "category": "Project Materials / Printing & Stationery / Plant & Equipment",
+      "project": "ACT-GD or ACT-PS depending item",
+      "payment_method": "review",
+      "publish_destination": "Manual review",
+      "auto_publish": false,
+      "rd_default": "review"
+    },
+    {
+      "suppliers": ["Sophie Deirdre Hickey", "Joseph Kirmos", "Oonchiumpa Consultancy and Services", "The Matnic Trust", "Manbarra Operations"],
+      "category": "486 - Sub-contractors",
+      "project": "ASK_USER",
+      "payment_method": "review",
+      "publish_destination": "Purchases/Bills only if genuinely unpaid; otherwise match paid bank line",
+      "auto_publish": false,
+      "rd_default": "review"
+    }
+  ],
+  "never_auto_publish": [
+    "unknown supplier",
+    "blank supplier",
+    "zero total",
+    "refund-only or negative amount",
+    "foreign currency unless exact matched",
+    "personal/reimbursement",
+    "duplicate image or duplicate Dext receipt ID",
+    "already reconciled in Xero",
+    "large asset or capital item",
+    "insurance or rates needing GST split",
+    "anything over $500 unless recurring SaaS"
+  ]
+}

--- a/config/dext-supplier-rules.json
+++ b/config/dext-supplier-rules.json
@@ -326,13 +326,14 @@
     "Bank Fees": "6800"
   },
   "setup_checklist": [
-    "1. Log in to Dext: https://prepare.dext.com",
-    "2. Go to Business Settings → Connections → Manage (Xero)",
-    "3. For each subscription vendor: Create Supplier Rule with auto-publish ON",
-    "4. For each travel vendor: Create Supplier Rule with auto-publish OFF",
-    "5. Set default categories and tax rates as specified",
-    "6. For subscriptions: Set tracking category to ACT-IN",
-    "7. For project vendors: Set tracking to specific project code",
-    "8. Test with one receipt before enabling batch auto-publish"
+    "1. Log in to Dext: https://app.dext.com",
+    "2. Use the generated routing pack first: thoughts/shared/reports/dext-routing-pack-2026-05-15/README.md",
+    "3. Go to Business Settings → Connections → Manage (Xero)",
+    "4. For each subscription vendor: Create Supplier Rule with auto-publish ON only after three clean test publishes",
+    "5. For each travel/material/subcontractor vendor: Create Supplier Rule with auto-publish OFF",
+    "6. Set default categories and tax rates as specified",
+    "7. For subscriptions: Set tracking category to ACT-IN",
+    "8. For project vendors: Set tracking to the specific project code or Ask Ben/Nic",
+    "9. Test with one receipt before enabling batch auto-publish"
   ]
 }

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -241,6 +241,22 @@ const cronScripts = [
     cron_restart: '15 15 * * 5', // Weekly Friday 3:15pm AEST — after weekly-money-digest at 3:00pm
   },
   {
+    // Single-entry replacement for the Mon 5:30-9:10 chain (6 separate PM2
+    // entries). Runs each step in sequence with failure isolation — one
+    // step failing doesn't stop the rest. Single Telegram summary at the
+    // end + wiki/cockpit/monday-chain-YYYY-MM-DD.md log.
+    //
+    // To migrate: enable this entry, then disable the 6 individual entries
+    // (weekly-project-pulse, ghl-cleanup-auto, grant-seed-weekly,
+    // xero-payments-sync, weekly-reconciliation, money-framework-sync).
+    // Until migration: this is OFF by default — uncomment to enable.
+    //
+    // name: 'monday-morning-chain',
+    // script: 'scripts/monday-morning-chain.mjs',
+    // args: '--telegram',
+    // cron_restart: '30 5 * * 1', // Mon 5:30am AEST — orchestrates the full chain
+  },
+  {
     // Polls finance_receipt_documents for newly-OCR'd Dext docs that have no
     // AI suggestion yet, grades them with Sonnet 4.6, writes to
     // finance_ai_routing_suggestions. The workbench surfaces the grades so

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -232,6 +232,25 @@ const cronScripts = [
     cron_restart: '0 15 * * 5', // Weekly Friday 3:00pm AEST — Friday Money Digest (week wins, burns, stale, actions)
   },
   {
+    // Sonnet 4.6 reads the money-command data + week deltas and writes the
+    // "5 things to know this week" narrative in Curtis voice. Writes to
+    // wiki/cockpit/weekly-narrative-YYYY-MM-DD.md and Telegram.
+    name: 'weekly-narrative',
+    script: 'scripts/narrate-weekly-digest.mjs',
+    args: '--telegram',
+    cron_restart: '15 15 * * 5', // Weekly Friday 3:15pm AEST — after weekly-money-digest at 3:00pm
+  },
+  {
+    // Polls finance_receipt_documents for newly-OCR'd Dext docs that have no
+    // AI suggestion yet, grades them with Sonnet 4.6, writes to
+    // finance_ai_routing_suggestions. The workbench surfaces the grades so
+    // you see project_code + risk_flags before you publish to Xero.
+    name: 'pre-publish-dext-grader',
+    script: 'scripts/poll-pre-publish-dext-grader.mjs',
+    args: '--batch 25 --telegram',
+    cron_restart: '*/15 8-18 * * 1-5', // Every 15 min, 8am-6pm AEST, Mon-Fri
+  },
+  {
     name: 'ghl-cleanup-auto',
     script: 'scripts/cleanup-stale-ghl-opps.mjs',
     args: '--apply',

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -222,6 +222,21 @@ const cronScripts = [
     cron_restart: '15 8 * * *', // Daily 8:15am AEST — snapshot /finance/command (coverage, drift, 90d incoming, lifetime) + send to Telegram
   },
   {
+    name: 'compliance-snapshot',
+    script: 'scripts/build-compliance-calendar.mjs',
+    cron_restart: '0 7 * * *', // Daily 7am AEST — rebuild compliance snapshot before alerts cron at 7:30
+  },
+  {
+    name: 'compliance-alerts',
+    script: 'scripts/compliance-alerts.mjs',
+    cron_restart: '30 7 * * *', // Daily 7:30am AEST — fires Telegram only when T-30/T-7/T-1 lead time matches exactly
+  },
+  {
+    name: 'compliance-notion-sync',
+    script: 'scripts/sync-compliance-calendar-to-notion.mjs',
+    cron_restart: '45 7 * * *', // Daily 7:45am AEST — push latest snapshot to Notion mirror page (no-op if NOTION_COMPLIANCE_PAGE_ID unset)
+  },
+  {
     name: 'telegram-money-alerts',
     script: 'scripts/telegram-money-alerts.mjs',
     cron_restart: '0 13 * * *', // Daily 1pm AEST — afternoon alert (silent if nothing actionable)

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -237,6 +237,11 @@ const cronScripts = [
     cron_restart: '45 7 * * *', // Daily 7:45am AEST — push latest snapshot to Notion mirror page (no-op if NOTION_COMPLIANCE_PAGE_ID unset)
   },
   {
+    name: 'idea-board-reminders',
+    script: 'scripts/idea-board-reminders.mjs',
+    cron_restart: '0 8 * * *', // Daily 8am AEST — per-owner DM with stale ideas + inline buttons (idea 90d, scope 30d, fundraise 14d). Cap 5 per DM.
+  },
+  {
     name: 'telegram-money-alerts',
     script: 'scripts/telegram-money-alerts.mjs',
     cron_restart: '0 13 * * *', // Daily 1pm AEST — afternoon alert (silent if nothing actionable)

--- a/scripts/ai-route-dext-doc.mjs
+++ b/scripts/ai-route-dext-doc.mjs
@@ -177,6 +177,41 @@ async function fetchUnroutedReceiptEmails(limit) {
   }));
 }
 
+async function fetchUnroutedReceiptDocuments(limit) {
+  // finance_receipt_documents is the cleaner Dext-OCR pipeline source. We want
+  // docs that have OCR'd vendor + amount but haven't been graded yet (no
+  // suggestion row exists for this doc + prompt_version + model).
+  const { data: alreadyGraded } = await sb
+    .from('finance_ai_routing_suggestions')
+    .select('source_record_id')
+    .eq('source_table', 'finance_receipt_documents')
+    .eq('prompt_version', PROMPT_VERSION)
+    .eq('model', MODEL);
+  const skipIds = new Set((alreadyGraded || []).map((r) => r.source_record_id));
+
+  const { data, error } = await sb
+    .from('finance_receipt_documents')
+    .select('id,document_date,vendor_name,document_number,amount_total,subject,from_email,source')
+    .not('vendor_name', 'is', null)
+    .not('amount_total', 'is', null)
+    .order('document_date', { ascending: false, nullsFirst: false })
+    .limit(limit * 2);
+  if (error) throw new Error(`finance_receipt_documents: ${error.message}`);
+
+  return (data || [])
+    .filter((r) => !skipIds.has(r.id))
+    .slice(0, limit)
+    .map((r) => ({
+      source_table: 'finance_receipt_documents',
+      source_record_id: r.id,
+      txn_date: r.document_date,
+      vendor_name: r.vendor_name,
+      amount: r.amount_total,
+      bank_account: null,
+      description: [r.document_number, r.subject, r.from_email, r.source].filter(Boolean).join(' | '),
+    }));
+}
+
 async function fetchUnroutedXeroTransactions(limit) {
   const { data, error } = await sb
     .from('xero_transactions')
@@ -214,6 +249,7 @@ async function fetchInputs() {
   const fns = [];
   if (want === 'all' || want === 'bank') fns.push(fetchUnroutedBankLines);
   if (want === 'all' || want === 'receipt') fns.push(fetchUnroutedReceiptEmails);
+  if (want === 'all' || want === 'documents') fns.push(fetchUnroutedReceiptDocuments);
   if (want === 'all' || want === 'xero') fns.push(fetchUnroutedXeroTransactions);
 
   const perSource = Math.ceil(LIMIT / Math.max(fns.length, 1));

--- a/scripts/ai-route-dext-doc.mjs
+++ b/scripts/ai-route-dext-doc.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+/**
+ * AI Dext / bank-line / Xero routing grader.
+ *
+ * For every row that has vendor + amount + date but no project_code,
+ * ask Sonnet 4.6 which of the 12 ACT project codes it belongs to,
+ * with confidence + reason + risk flags. Write to
+ * finance_ai_routing_suggestions. With --apply, copy
+ * high-confidence (>= 0.85) suggestions to the source row's
+ * project_code (except ASK_USER and SL_REVIEW — those stay as
+ * suggestions until a human approves).
+ *
+ * Usage:
+ *   node scripts/ai-route-dext-doc.mjs                       # dry run, top 20
+ *   node scripts/ai-route-dext-doc.mjs --limit 50            # bigger batch
+ *   node scripts/ai-route-dext-doc.mjs --apply               # write back to source
+ *   node scripts/ai-route-dext-doc.mjs --source bank         # only bank_statement_lines
+ *   node scripts/ai-route-dext-doc.mjs --source receipt      # only receipt_emails
+ *   node scripts/ai-route-dext-doc.mjs --source xero         # only xero_transactions
+ *   node scripts/ai-route-dext-doc.mjs --model haiku         # faster + cheaper
+ *   node scripts/ai-route-dext-doc.mjs --min-confidence 0.9  # raise the apply bar
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'node:fs';
+import { trackedClaudeCompletion } from './lib/llm-client.mjs';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing Supabase URL / service role env vars.');
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const LIMIT = numberAfter('--limit', 20);
+const MIN_CONFIDENCE = numberAfter('--min-confidence', 0.85);
+const SOURCE = valueAfter('--source') || 'all';
+const MODEL_TAG = valueAfter('--model') || 'sonnet';
+const MODEL =
+  MODEL_TAG === 'haiku' ? 'claude-haiku-4-5'
+  : MODEL_TAG === 'opus' ? 'claude-opus-4-7'
+  : 'claude-sonnet-4-6';
+const PROMPT_VERSION = 'v1';
+const SCRIPT_NAME = 'ai-route-dext-doc';
+
+function valueAfter(flag) {
+  const i = args.indexOf(flag);
+  return i === -1 ? null : args[i + 1];
+}
+function numberAfter(flag, fallback) {
+  const raw = valueAfter(flag);
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const routingConfig = JSON.parse(
+  readFileSync('config/dext-routing-sections.json', 'utf8')
+);
+const PROJECT_CODES = routingConfig.dext_fields_to_configure
+  .find((f) => f.field === 'Project Tracking').values;
+
+const ALLOWED_CODES = PROJECT_CODES.map((p) => p.code);
+const CODE_DESCRIPTIONS = PROJECT_CODES
+  .map((p) => `- ${p.code} (${p.name}): ${p.use_for}`)
+  .join('\n');
+
+const SYSTEM_PROMPT = `You route ACT (A Curious Tractor) bookkeeping rows to project codes.
+
+You return ONE of the 12 codes below, plus a confidence 0-1, plus a one-sentence reason, plus risk flags.
+
+Codes and what they're for:
+${CODE_DESCRIPTIONS}
+
+Rules:
+1. SaaS / software / AI APIs / dev infra → ACT-IN.
+2. Harvest / Witta / Maleny property / farm capital works → ACT-HV.
+3. Farm operations, animals, local fuel where NOT Harvest capital works → ACT-FM.
+4. Goods build, manufacturing, containers, marketplace, product/asset work → ACT-GD.
+5. Justice travel, research, civic / youth justice → ACT-JH.
+6. Studio operations, accounting, admin, general ACT work that is NOT infrastructure SaaS → ACT-CORE.
+7. Storytelling, media capture, Empathy Ledger platform / content → ACT-EL.
+8. Photo studio, camera, print, creative equipment for PICC → ACT-PS.
+9. Mounty Yarns materials, events, travel, production → ACT-MY.
+10. Oonchiumpa consultancy / service costs → ACT-OO.
+11. Travel, meals, hotels, large purchases, ambiguous locations, shared trips → ASK_USER (confidence MUST be < 0.7).
+12. BAS / tax / insurance / donations / write-offs / duplicate bills / capitalisation → SL_REVIEW (confidence MUST be < 0.7).
+
+Risk flags to use when applicable:
+- "duplicate_risk" (same vendor + same amount appears multiple times in nearby dates)
+- "high_value" (amount >= 1000)
+- "ambiguous_vendor" (vendor name is generic like AMEX, PAYPAL, STRIPE — the underlying merchant is unclear)
+- "personal_card_flag" (looks like personal-card spend that needs reimbursement review)
+- "foreign_currency" (non-AUD)
+- "no_gst_inferred" (looks like overseas / GST-free)
+- "needs_receipt" (high value with no receipt attached)
+- "rd_eligible" (AI tools, dev infra, research-y purchase that qualifies for FY26 R&D tax)
+
+Return STRICT JSON only — no prose, no markdown:
+{
+  "project_code": "<one of the 12 codes>",
+  "confidence": <0-1>,
+  "reason": "<one short sentence>",
+  "risk_flags": ["<flag>", ...]
+}`;
+
+function buildUserPrompt(row) {
+  const parts = [];
+  parts.push(`Source: ${row.source_table}`);
+  if (row.txn_date) parts.push(`Date: ${row.txn_date}`);
+  if (row.vendor_name) parts.push(`Vendor / payee: ${row.vendor_name}`);
+  if (row.amount !== null && row.amount !== undefined) {
+    parts.push(`Amount: ${row.amount} AUD`);
+  }
+  if (row.bank_account) parts.push(`Bank account: ${row.bank_account}`);
+  if (row.description) parts.push(`Description / notes: ${row.description}`);
+  return parts.join('\n');
+}
+
+function safeParseJson(text) {
+  if (!text) return null;
+  const cleaned = text.trim().replace(/^```json\s*/i, '').replace(/```$/i, '').trim();
+  const firstBrace = cleaned.indexOf('{');
+  const lastBrace = cleaned.lastIndexOf('}');
+  if (firstBrace === -1 || lastBrace === -1) return null;
+  try {
+    return JSON.parse(cleaned.slice(firstBrace, lastBrace + 1));
+  } catch {
+    return null;
+  }
+}
+
+async function fetchUnroutedBankLines(limit) {
+  const { data, error } = await sb
+    .from('bank_statement_lines')
+    .select('id,date,payee,particulars,reference,analysis_code,amount,direction,bank_account,project_code,notes')
+    .or('project_code.is.null,project_code.eq.UNKNOWN,project_code.eq.')
+    .not('payee', 'is', null)
+    .not('amount', 'is', null)
+    .order('date', { ascending: false })
+    .limit(limit);
+  if (error) throw new Error(`bank_statement_lines: ${error.message}`);
+  return (data || []).map((r) => ({
+    source_table: 'bank_statement_lines',
+    source_record_id: r.id,
+    txn_date: r.date,
+    vendor_name: r.payee,
+    amount: r.amount,
+    bank_account: r.bank_account,
+    description: [r.particulars, r.reference, r.notes].filter(Boolean).join(' | '),
+  }));
+}
+
+async function fetchUnroutedReceiptEmails(limit) {
+  const { data, error } = await sb
+    .from('receipt_emails')
+    .select('id,received_at,vendor_name,subject,amount_detected,currency,project_code,status,from_email')
+    .or('project_code.is.null,project_code.eq.UNKNOWN,project_code.eq.')
+    .not('vendor_name', 'is', null)
+    .order('received_at', { ascending: false })
+    .limit(limit);
+  if (error) throw new Error(`receipt_emails: ${error.message}`);
+  return (data || []).map((r) => ({
+    source_table: 'receipt_emails',
+    source_record_id: r.id,
+    txn_date: r.received_at ? r.received_at.slice(0, 10) : null,
+    vendor_name: r.vendor_name,
+    amount: r.amount_detected,
+    bank_account: null,
+    description: [r.subject, r.from_email].filter(Boolean).join(' | '),
+  }));
+}
+
+async function fetchUnroutedXeroTransactions(limit) {
+  const { data, error } = await sb
+    .from('xero_transactions')
+    .select('id,date,contact_name,total,type,bank_account,project_code,line_items')
+    .or('project_code.is.null,project_code.eq.UNKNOWN,project_code.eq.')
+    .not('contact_name', 'is', null)
+    .gte('date', '2025-07-01')
+    .order('date', { ascending: false })
+    .limit(limit);
+  if (error) throw new Error(`xero_transactions: ${error.message}`);
+  return (data || []).map((r) => {
+    let description = r.type || '';
+    if (Array.isArray(r.line_items)) {
+      const descs = r.line_items
+        .map((li) => li?.description || li?.Description)
+        .filter(Boolean)
+        .slice(0, 3)
+        .join(' | ');
+      if (descs) description = `${description} | ${descs}`;
+    }
+    return {
+      source_table: 'xero_transactions',
+      source_record_id: r.id,
+      txn_date: r.date,
+      vendor_name: r.contact_name,
+      amount: r.total,
+      bank_account: r.bank_account,
+      description,
+    };
+  });
+}
+
+async function fetchInputs() {
+  const want = SOURCE.toLowerCase();
+  const fns = [];
+  if (want === 'all' || want === 'bank') fns.push(fetchUnroutedBankLines);
+  if (want === 'all' || want === 'receipt') fns.push(fetchUnroutedReceiptEmails);
+  if (want === 'all' || want === 'xero') fns.push(fetchUnroutedXeroTransactions);
+
+  const perSource = Math.ceil(LIMIT / Math.max(fns.length, 1));
+  const buckets = await Promise.all(fns.map((fn) => fn(perSource)));
+  return buckets.flat().slice(0, LIMIT);
+}
+
+async function gradeOne(row) {
+  const userPrompt = buildUserPrompt(row);
+  let responseText;
+  try {
+    responseText = await trackedClaudeCompletion(userPrompt, SCRIPT_NAME, {
+      model: MODEL,
+      system: SYSTEM_PROMPT,
+      maxTokens: 300,
+      operation: 'route_dext',
+    });
+  } catch (err) {
+    console.warn(`  grader error: ${err.message?.slice(0, 120)}`);
+    return null;
+  }
+
+  const parsed = safeParseJson(responseText);
+  if (!parsed || !parsed.project_code) {
+    console.warn(`  unparseable response for ${row.source_record_id}: ${responseText?.slice(0, 80)}`);
+    return null;
+  }
+  const code = String(parsed.project_code).toUpperCase().trim();
+  if (!ALLOWED_CODES.includes(code)) {
+    console.warn(`  rejected code "${code}" not in allow-list`);
+    return null;
+  }
+  const confidence = Math.max(0, Math.min(1, Number(parsed.confidence) || 0));
+  const reason = (parsed.reason || '').toString().slice(0, 500);
+  const riskFlags = Array.isArray(parsed.risk_flags)
+    ? parsed.risk_flags.map((f) => String(f).trim()).filter(Boolean).slice(0, 10)
+    : [];
+
+  return {
+    ...row,
+    suggested_project_code: code,
+    confidence,
+    reason,
+    risk_flags: riskFlags,
+  };
+}
+
+async function writeSuggestion(suggestion) {
+  const payload = {
+    source_table: suggestion.source_table,
+    source_record_id: suggestion.source_record_id,
+    vendor_name: suggestion.vendor_name,
+    amount: suggestion.amount,
+    txn_date: suggestion.txn_date,
+    bank_account: suggestion.bank_account,
+    description: suggestion.description,
+    suggested_project_code: suggestion.suggested_project_code,
+    confidence: suggestion.confidence,
+    reason: suggestion.reason,
+    risk_flags: suggestion.risk_flags,
+    model: MODEL,
+    prompt_version: PROMPT_VERSION,
+  };
+
+  const { data, error } = await sb
+    .from('finance_ai_routing_suggestions')
+    .upsert(payload, {
+      onConflict: 'source_table,source_record_id,prompt_version,model',
+      ignoreDuplicates: false,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.warn(`  failed to write suggestion: ${error.message}`);
+    return null;
+  }
+  return data?.id;
+}
+
+async function applyToSource(suggestion) {
+  const code = suggestion.suggested_project_code;
+  if (code === 'ASK_USER' || code === 'SL_REVIEW') return false;
+  if (suggestion.confidence < MIN_CONFIDENCE) return false;
+
+  const table = suggestion.source_table;
+  const updates = { project_code: code };
+  if (table === 'xero_transactions') updates.project_code_source = 'ai_router';
+  if (table === 'bank_statement_lines') updates.notes = (
+    suggestion.description
+      ? `${suggestion.description} | ai-router=${code} (${(suggestion.confidence * 100).toFixed(0)}%)`
+      : `ai-router=${code} (${(suggestion.confidence * 100).toFixed(0)}%)`
+  );
+
+  const { error } = await sb
+    .from(table)
+    .update(updates)
+    .eq('id', suggestion.source_record_id);
+  if (error) {
+    console.warn(`  apply failed (${table} ${suggestion.source_record_id}): ${error.message}`);
+    return false;
+  }
+
+  await sb
+    .from('finance_ai_routing_suggestions')
+    .update({ applied_at: new Date().toISOString(), applied_to_source: true })
+    .eq('source_table', suggestion.source_table)
+    .eq('source_record_id', suggestion.source_record_id)
+    .eq('prompt_version', PROMPT_VERSION)
+    .eq('model', MODEL);
+
+  return true;
+}
+
+async function main() {
+  console.log('━'.repeat(72));
+  console.log('AI Dext routing grader');
+  console.log('━'.repeat(72));
+  console.log(`Model: ${MODEL}  •  Source: ${SOURCE}  •  Limit: ${LIMIT}`);
+  console.log(`Apply mode: ${APPLY ? 'YES (writes back to source)' : 'no (suggestions only)'}`);
+  console.log(`Min confidence to auto-apply: ${MIN_CONFIDENCE}`);
+  console.log(`Allowed codes: ${ALLOWED_CODES.join(', ')}`);
+  console.log();
+
+  const inputs = await fetchInputs();
+  console.log(`Found ${inputs.length} unrouted rows.`);
+  if (!inputs.length) return;
+
+  const tallies = { graded: 0, written: 0, applied: 0, by_code: {}, low_conf: 0 };
+
+  for (let i = 0; i < inputs.length; i += 1) {
+    const row = inputs[i];
+    process.stdout.write(`[${i + 1}/${inputs.length}] ${row.source_table} ${row.vendor_name?.slice(0, 30) || '?'} $${row.amount}…  `);
+
+    const suggestion = await gradeOne(row);
+    if (!suggestion) {
+      console.log('skip');
+      continue;
+    }
+    tallies.graded += 1;
+    tallies.by_code[suggestion.suggested_project_code] =
+      (tallies.by_code[suggestion.suggested_project_code] || 0) + 1;
+    if (suggestion.confidence < MIN_CONFIDENCE) tallies.low_conf += 1;
+
+    const id = await writeSuggestion(suggestion);
+    if (id) tallies.written += 1;
+
+    if (APPLY) {
+      const applied = await applyToSource(suggestion);
+      if (applied) tallies.applied += 1;
+    }
+
+    const flags = suggestion.risk_flags.length ? ` [${suggestion.risk_flags.join(',')}]` : '';
+    console.log(`${suggestion.suggested_project_code} ${(suggestion.confidence * 100).toFixed(0)}%${flags}`);
+
+    // Pace requests gently (Anthropic rate limit + give upstream room)
+    await new Promise((r) => setTimeout(r, 150));
+  }
+
+  console.log();
+  console.log('━'.repeat(72));
+  console.log('Summary');
+  console.log('━'.repeat(72));
+  console.log(`Graded:      ${tallies.graded}`);
+  console.log(`Written:     ${tallies.written}`);
+  console.log(`Applied:     ${APPLY ? tallies.applied : '(dry run)'}`);
+  console.log(`Low-conf:    ${tallies.low_conf} (held back from apply)`);
+  console.log('By code:');
+  Object.entries(tallies.by_code)
+    .sort(([, a], [, b]) => b - a)
+    .forEach(([code, count]) => console.log(`  ${code.padEnd(10)} ${count}`));
+
+  if (!APPLY) {
+    console.log();
+    console.log('Run with --apply to write suggestions back to source rows');
+    console.log(`(applies only when confidence >= ${MIN_CONFIDENCE} and code is not ASK_USER / SL_REVIEW).`);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/analyze-receipt-close-queue.mjs
+++ b/scripts/analyze-receipt-close-queue.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Analyze the Q2/Q3 receipt-backed close queue.
+ *
+ * This is read-only by default. With --apply-mirror-hygiene it updates only
+ * Supabase bank_statement_lines mirror status for rows already reconciled in
+ * the Xero mirrors. It never writes to Xero.
+ *
+ * It separates "has a good receipt" from "safe to reconcile/attach" by checking
+ * the Xero transaction and payment mirrors.
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Missing Supabase URL/service role env vars');
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const APPLY_MIRROR_HYGIENE = args.includes('--apply-mirror-hygiene');
+const QUARTERS = valueAfter('--quarters')
+  ? valueAfter('--quarters').split(',').map((q) => q.trim().toUpperCase()).filter(Boolean)
+  : ['Q2', 'Q3'];
+const DATE = todayInBrisbane();
+const OUT_DIR = join('thoughts', 'shared', 'reports', `receipt-close-queue-${DATE}`);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function todayInBrisbane() {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Australia/Brisbane',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
+
+function quarterDates(quarter) {
+  const quarters = {
+    Q1: { start: '2025-07-01', end: '2025-09-30' },
+    Q2: { start: '2025-10-01', end: '2025-12-31' },
+    Q3: { start: '2026-01-01', end: '2026-03-31' },
+    Q4: { start: '2026-04-01', end: '2026-06-30' },
+  };
+  if (!quarters[quarter]) throw new Error(`Unsupported quarter: ${quarter}`);
+  return quarters[quarter];
+}
+
+function money(value) {
+  return Number(value || 0).toLocaleString('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 2,
+  });
+}
+
+function absAmount(value) {
+  return Math.abs(Number(value || 0));
+}
+
+function hasAttachment(candidate) {
+  return Boolean(
+    candidate.attachment_url
+    || candidate.attachment_storage_path
+    || candidate.attachment_filename,
+  );
+}
+
+function isStrictDextBackedCandidate(candidate) {
+  if (!candidate) return false;
+  if (!['dext_receipt', 'receipt_email'].includes(String(candidate.source || ''))) return false;
+  if (!hasAttachment(candidate)) return false;
+  if (Number(candidate.confidence || 0) < 0.99) return false;
+  if (Math.abs(Number(candidate.amount_delta || 0)) > 0.005) return false;
+  if (Number(candidate.amount_score || 0) !== 1) return false;
+  if (Number(candidate.vendor_score || 0) < 0.85) return false;
+
+  const dateDelta = candidate.date_delta_days;
+  if (dateDelta === null || dateDelta === undefined || dateDelta === '') return false;
+  return Math.abs(Number(dateDelta)) <= 7;
+}
+
+function bestStrictCandidate(row) {
+  const candidates = Array.isArray(row.receipt_candidates) ? row.receipt_candidates : [];
+  return candidates
+    .filter(isStrictDextBackedCandidate)
+    .sort((a, b) => Number(b.confidence || 0) - Number(a.confidence || 0))[0] || null;
+}
+
+function sumRows(items) {
+  return items.reduce((sum, item) => sum + absAmount(item.row.amount), 0);
+}
+
+async function fetchRowsForQuarter(quarter) {
+  const { start, end } = quarterDates(quarter);
+  const { data, error } = await sb
+    .from('v_finance_bank_line_evidence')
+    .select('*')
+    .eq('direction', 'debit')
+    .gte('date', start)
+    .lte('date', end)
+    .order('amount', { ascending: false })
+    .limit(2000);
+
+  if (error) throw error;
+  return (data || []).map((row) => ({ ...row, quarter }));
+}
+
+function csvEscape(value) {
+  const string = value === null || value === undefined ? '' : String(value);
+  if (!/[",\n]/.test(string)) return string;
+  return `"${string.replace(/"/g, '""')}"`;
+}
+
+function writeCsv(path, rows) {
+  const headers = [
+    'category',
+    'quarter',
+    'date',
+    'payee',
+    'particulars',
+    'amount',
+    'candidate_source',
+    'candidate_vendor',
+    'candidate_date',
+    'xero_invoice_id',
+    'xero_bank_transaction_id',
+    'xero_payment_id',
+    'xero_payment_amount',
+    'xero_payment_reconciled',
+    'xero_transaction_reconciled',
+    'note',
+  ];
+
+  const lines = [
+    headers.join(','),
+    ...rows.map((item) => headers.map((header) => csvEscape(item[header])).join(',')),
+  ];
+  writeFileSync(path, `${lines.join('\n')}\n`);
+}
+
+const allRows = [];
+for (const quarter of QUARTERS) {
+  allRows.push(...await fetchRowsForQuarter(quarter));
+}
+
+const strictRows = allRows
+  .filter((row) => String(row.status || '').toLowerCase() === 'unreconciled')
+  .map((row) => ({ row, candidate: bestStrictCandidate(row) }))
+  .filter((item) => item.candidate);
+
+const invoiceIds = [...new Set(strictRows.map((item) => item.candidate.xero_invoice_id).filter(Boolean))];
+const bankTxnIds = [...new Set(strictRows.map((item) => item.candidate.xero_bank_transaction_id).filter(Boolean))];
+
+const { data: payments = [], error: paymentError } = invoiceIds.length
+  ? await sb
+    .from('xero_payments')
+    .select('xero_payment_id, invoice_xero_id, date, amount, is_reconciled, status, account_name')
+    .in('invoice_xero_id', invoiceIds)
+  : { data: [], error: null };
+if (paymentError) throw paymentError;
+
+const { data: xeroTransactions = [], error: transactionError } = bankTxnIds.length
+  ? await sb
+    .from('xero_transactions')
+    .select('xero_transaction_id, date, contact_name, total, is_reconciled, has_attachments, type, status')
+    .in('xero_transaction_id', bankTxnIds)
+  : { data: [], error: null };
+if (transactionError) throw transactionError;
+
+const paymentsByInvoice = new Map();
+for (const payment of payments || []) {
+  const list = paymentsByInvoice.get(payment.invoice_xero_id) || [];
+  list.push(payment);
+  paymentsByInvoice.set(payment.invoice_xero_id, list);
+}
+
+const transactionById = new Map((xeroTransactions || []).map((txn) => [txn.xero_transaction_id, txn]));
+const bankTargetUseCount = new Map();
+for (const item of strictRows) {
+  const id = item.candidate.xero_bank_transaction_id;
+  if (id) bankTargetUseCount.set(id, (bankTargetUseCount.get(id) || 0) + 1);
+}
+
+const categories = {
+  already_reconciled_exact_payment: [],
+  invoice_payment_amount_mismatch: [],
+  invoice_no_reconciled_payment: [],
+  bank_transaction_reconciled_unique: [],
+  bank_transaction_duplicate_target: [],
+  bank_transaction_unreconciled_or_unknown: [],
+  no_xero_target: [],
+};
+
+for (const item of strictRows) {
+  const { row, candidate } = item;
+  const amount = absAmount(row.amount);
+  const invoiceId = candidate.xero_invoice_id;
+  const bankTxnId = candidate.xero_bank_transaction_id;
+
+  if (invoiceId) {
+    const invoicePayments = paymentsByInvoice.get(invoiceId) || [];
+    const reconciledPayments = invoicePayments.filter((payment) => payment.is_reconciled === true);
+    const exactPayment = reconciledPayments.find((payment) => Math.abs(absAmount(payment.amount) - amount) < 0.01);
+
+    if (exactPayment) {
+      categories.already_reconciled_exact_payment.push({ ...item, payment: exactPayment });
+    } else if (reconciledPayments.length > 0) {
+      categories.invoice_payment_amount_mismatch.push({ ...item, payments: reconciledPayments });
+    } else {
+      categories.invoice_no_reconciled_payment.push({ ...item, payments: invoicePayments });
+    }
+    continue;
+  }
+
+  if (bankTxnId) {
+    const txn = transactionById.get(bankTxnId);
+    if ((bankTargetUseCount.get(bankTxnId) || 0) > 1) {
+      categories.bank_transaction_duplicate_target.push({ ...item, transaction: txn });
+    } else if (txn?.is_reconciled === true) {
+      categories.bank_transaction_reconciled_unique.push({ ...item, transaction: txn });
+    } else {
+      categories.bank_transaction_unreconciled_or_unknown.push({ ...item, transaction: txn });
+    }
+    continue;
+  }
+
+  categories.no_xero_target.push(item);
+}
+
+let mirrorHygieneUpdated = 0;
+if (APPLY_MIRROR_HYGIENE) {
+  const exactPaymentRows = categories.already_reconciled_exact_payment;
+  const bankTxnRows = categories.bank_transaction_reconciled_unique;
+
+  for (const item of exactPaymentRows) {
+    const { error } = await sb
+      .from('bank_statement_lines')
+      .update({ status: 'reconciled' })
+      .eq('id', item.row.id);
+    if (error) throw error;
+    mirrorHygieneUpdated += 1;
+  }
+
+  for (const item of bankTxnRows) {
+    const { error } = await sb
+      .from('bank_statement_lines')
+      .update({
+        status: 'reconciled',
+        matched_xero_transaction_id: item.candidate.xero_bank_transaction_id,
+        xero_transaction_id: item.candidate.xero_bank_transaction_id,
+      })
+      .eq('id', item.row.id);
+    if (error) throw error;
+    mirrorHygieneUpdated += 1;
+  }
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+const flatRows = [];
+for (const [category, items] of Object.entries(categories)) {
+  for (const item of items) {
+    const payment = item.payment || item.payments?.[0] || null;
+    flatRows.push({
+      category,
+      quarter: item.row.quarter,
+      date: item.row.date,
+      payee: item.row.payee,
+      particulars: item.row.particulars,
+      amount: absAmount(item.row.amount).toFixed(2),
+      candidate_source: item.candidate.source,
+      candidate_vendor: item.candidate.vendor_name,
+      candidate_date: item.candidate.document_date,
+      xero_invoice_id: item.candidate.xero_invoice_id || '',
+      xero_bank_transaction_id: item.candidate.xero_bank_transaction_id || '',
+      xero_payment_id: payment?.xero_payment_id || '',
+      xero_payment_amount: payment?.amount ?? '',
+      xero_payment_reconciled: payment?.is_reconciled ?? '',
+      xero_transaction_reconciled: item.transaction?.is_reconciled ?? '',
+      note: item.payments?.length > 1 ? `${item.payments.length} reconciled payments found` : '',
+    });
+  }
+}
+
+writeCsv(join(OUT_DIR, 'strict-dext-backed-unreconciled.csv'), flatRows);
+
+const summaryLines = [
+  `# Receipt Close Queue - ${QUARTERS.join(' + ')} FY26`,
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  `Mode: ${APPLY_MIRROR_HYGIENE ? 'APPLY SUPABASE MIRROR HYGIENE' : 'READ ONLY'}`,
+  `Supabase: ${SUPABASE_URL}`,
+  '',
+  '## Strict Dext-Backed Unreconciled Queue',
+  '',
+  `- Rows: ${strictRows.length}`,
+  `- Value: ${money(sumRows(strictRows))}`,
+  '',
+  '## Categories',
+  '',
+  ...Object.entries(categories).map(([category, items]) => (
+    `- ${category}: ${items.length} (${money(sumRows(items))})`
+  )),
+  '',
+  '## Output Files',
+  '',
+  `- ${join(OUT_DIR, 'strict-dext-backed-unreconciled.csv')}`,
+  '',
+  '## Verification Status',
+  '',
+  'verified: Queried live Supabase v_finance_bank_line_evidence, xero_payments, and xero_transactions.',
+  APPLY_MIRROR_HYGIENE
+    ? `verified: This script performed Supabase-only mirror hygiene for ${mirrorHygieneUpdated} rows already reconciled in the Xero mirrors.`
+    : 'verified: This script performed no Xero writes and no Supabase writes.',
+  'inferred: Strict receipt matches are based on deterministic receipt-evidence scores and mirror IDs.',
+  'unverified: Xero UI was not clicked; duplicate bank transaction targets require manual/Xero UI review.',
+  '',
+];
+
+writeFileSync(join(OUT_DIR, 'summary.md'), summaryLines.join('\n'));
+writeFileSync(join(OUT_DIR, 'summary.md.provenance.md'), [
+  `# Provenance - Receipt Close Queue ${QUARTERS.join(' + ')} FY26`,
+  '',
+  `Report: ${join(OUT_DIR, 'summary.md')}`,
+  `Generated: ${new Date().toISOString()}`,
+  `Command: node scripts/analyze-receipt-close-queue.mjs --quarters ${QUARTERS.join(',')}${APPLY_MIRROR_HYGIENE ? ' --apply-mirror-hygiene' : ''}`,
+  '',
+  '## Queried Sources',
+  '',
+  '- public.v_finance_bank_line_evidence: debit bank lines and receipt candidates',
+  '- public.xero_payments: invoice payment mirror',
+  '- public.xero_transactions: bank transaction mirror',
+  '',
+  '## Verified',
+  '',
+  '- Live Supabase data was queried during this run.',
+  APPLY_MIRROR_HYGIENE
+    ? `- Supabase-only mirror status updates were applied to ${mirrorHygieneUpdated} rows already reconciled in the Xero mirrors.`
+    : '- The analysis script was read-only.',
+  '',
+  '## Inferred',
+  '',
+  '- Strict match confidence depends on the receipt evidence scoring model.',
+  '- Xero UI actionability is inferred from mirror IDs and duplicate target checks.',
+  '',
+  '## Unknown / Not Checked',
+  '',
+  '- Whether Xero UI currently shows each row in the bank reconciliation queue.',
+  '- BAS lodgement report figures.',
+  '',
+].join('\n'));
+
+console.log(`Receipt close queue analysis complete`);
+console.log(`  Supabase: ${SUPABASE_URL}`);
+console.log(`  Quarters: ${QUARTERS.join(', ')}`);
+console.log(`  Strict queue: ${strictRows.length} (${money(sumRows(strictRows))})`);
+for (const [category, items] of Object.entries(categories)) {
+  console.log(`  ${category.padEnd(42)} ${String(items.length).padStart(3)}  ${money(sumRows(items)).padStart(14)}`);
+}
+console.log(`  Report: ${join(OUT_DIR, 'summary.md')}`);
+if (APPLY_MIRROR_HYGIENE) console.log(`  Applied Supabase mirror hygiene: ${mirrorHygieneUpdated} rows`);

--- a/scripts/approve-safe-receipt-evidence.mjs
+++ b/scripts/approve-safe-receipt-evidence.mjs
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+/**
+ * Approve only strict-safe receipt evidence links.
+ *
+ * This updates Supabase evidence state only. It does not write to Xero and it
+ * does not reconcile bank-feed lines.
+ *
+ * Strict-safe means:
+ * - bank statement line is unreconciled
+ * - best candidate has an attachment/file
+ * - confidence >= 95%
+ * - amount delta <= $1
+ * - date delta <= 7 days
+ * - candidate vendor has a meaningful token in the bank payee/particulars
+ *
+ * Usage:
+ *   node scripts/approve-safe-receipt-evidence.mjs --quarters Q2,Q3
+ *   node scripts/approve-safe-receipt-evidence.mjs --quarters Q2,Q3 --apply
+ *   node scripts/approve-safe-receipt-evidence.mjs --link-id <uuid> --apply
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Missing Supabase URL/service role env vars');
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const QUARTERS = valueAfter('--quarters')
+  ? valueAfter('--quarters').split(',').map((q) => q.trim().toUpperCase()).filter(Boolean)
+  : ['Q2', 'Q3'];
+const TARGET_LINK_IDS = new Set(
+  (valueAfter('--link-id') || '')
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean),
+);
+const INCLUDE_NON_BEST = args.includes('--include-non-best');
+
+const GENERIC_VENDOR_WORDS = new Set([
+  'australia',
+  'australian',
+  'brisbane',
+  'sydney',
+  'melbourne',
+  'mascot',
+  'maleny',
+  'alice',
+  'springs',
+  'townsville',
+  'witta',
+  'pty',
+  'ltd',
+  'limited',
+  'inc',
+  'llc',
+  'corp',
+  'corporation',
+  'company',
+  'group',
+  'www',
+  'com',
+  'au',
+  'internet',
+  'banking',
+  'transfer',
+  'payment',
+  'service',
+  'station',
+  'the',
+  'and',
+  'for',
+  'with',
+  'mount',
+  'mt',
+  'isa',
+  'air',
+  'airways',
+]);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function quarterDates(quarter) {
+  const quarters = {
+    Q1: { start: '2025-07-01', end: '2025-09-30' },
+    Q2: { start: '2025-10-01', end: '2025-12-31' },
+    Q3: { start: '2026-01-01', end: '2026-03-31' },
+    Q4: { start: '2026-04-01', end: '2026-06-30' },
+  };
+  if (!quarters[quarter]) throw new Error(`Unsupported quarter: ${quarter}`);
+  return quarters[quarter];
+}
+
+function cleanMatchText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function meaningfulTokens(value) {
+  return cleanMatchText(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_VENDOR_WORDS.has(token));
+}
+
+function vendorMatchesPayee(row, candidate) {
+  const payeeTokens = new Set([
+    ...meaningfulTokens(row.payee),
+    ...meaningfulTokens(row.particulars),
+  ]);
+  return meaningfulTokens(candidate.vendor_name).some((token) => payeeTokens.has(token));
+}
+
+function hasAttachment(candidate) {
+  return Boolean(
+    candidate.signed_url
+    || candidate.attachment_url
+    || candidate.attachment_storage_path
+    || candidate.attachment_filename,
+  );
+}
+
+function candidatesFor(row) {
+  const candidates = Array.isArray(row.receipt_candidates) ? row.receipt_candidates : [];
+  return candidates;
+}
+
+function approvalCandidatesFor(row) {
+  const candidates = candidatesFor(row);
+  if (TARGET_LINK_IDS.size > 0) {
+    return candidates.filter((candidate) => TARGET_LINK_IDS.has(String(candidate.link_id || '')));
+  }
+  return INCLUDE_NON_BEST ? candidates : candidates.slice(0, 1);
+}
+
+function isStrictSafe(row, candidate) {
+  if (!candidate) return false;
+  if (String(row.status || '').toLowerCase() !== 'unreconciled') return false;
+  if (!['candidate', 'needs_review'].includes(String(candidate.link_status || 'candidate'))) return false;
+  if (!hasAttachment(candidate)) return false;
+  if (Number(candidate.confidence || row.best_confidence || 0) < 0.95) return false;
+  if (Math.abs(Number(candidate.amount_delta || 0)) > 1) return false;
+
+  const dateDelta = candidate.date_delta_days;
+  if (dateDelta === null || dateDelta === undefined || dateDelta === '') return false;
+  if (Math.abs(Number(dateDelta)) > 7) return false;
+
+  return vendorMatchesPayee(row, candidate);
+}
+
+function money(value) {
+  return Number(value || 0).toLocaleString('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 2,
+  });
+}
+
+async function loadRowsForQuarter(quarter) {
+  const { start, end } = quarterDates(quarter);
+  const { data, error } = await sb
+    .from('v_finance_bank_line_evidence')
+    .select('*')
+    .eq('direction', 'debit')
+    .gte('date', start)
+    .lte('date', end)
+    .order('amount', { ascending: false })
+    .limit(2000);
+
+  if (error) throw error;
+  return (data || []).map((row) => ({ ...row, quarter }));
+}
+
+async function approveLink(row, candidate) {
+  const linkId = candidate.link_id;
+  if (!linkId) throw new Error(`Missing link_id for ${row.id}`);
+
+  const { error: linkError } = await sb
+    .from('finance_receipt_bank_line_links')
+    .update({
+      link_status: 'approved',
+      review_note: 'Auto-approved strict safe receipt evidence: exact amount, <=7d date delta, vendor token match',
+      review_owner: 'codex',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', linkId);
+
+  if (linkError) throw linkError;
+
+  if (candidate.source_table !== 'receipt_emails' || !candidate.source_record_id) return;
+
+  const { error: lineError } = await sb
+    .from('bank_statement_lines')
+    .update({
+      receipt_match_status: 'matched',
+      receipt_match_score: Number(candidate.confidence || row.best_confidence || 1),
+      receipt_match_id: candidate.source_record_id,
+      matched_receipt_email_id: candidate.source_record_id,
+      notes: `Approved strict safe receipt evidence link ${linkId}`,
+    })
+    .eq('id', row.id);
+
+  if (lineError) throw lineError;
+}
+
+const allRows = [];
+for (const quarter of QUARTERS) {
+  allRows.push(...await loadRowsForQuarter(quarter));
+}
+
+const safe = allRows
+  .map((row) => ({
+    row,
+    candidate: approvalCandidatesFor(row).find((candidate) => isStrictSafe(row, candidate)) || null,
+  }))
+  .filter(({ candidate }) => candidate);
+
+const value = safe.reduce((sum, item) => sum + Math.abs(Number(item.row.amount || 0)), 0);
+
+console.log(`Safe evidence approvals: ${safe.length} (${money(value)})`);
+for (const { row, candidate } of safe) {
+  console.log([
+    row.quarter,
+    row.date,
+    money(row.amount).padStart(12),
+    String(row.payee || '').slice(0, 34).padEnd(34),
+    '->',
+    String(candidate.vendor_name || '').slice(0, 30).padEnd(30),
+    `${Math.round(Number(candidate.confidence || 0) * 100)}%`,
+    candidate.link_id,
+  ].join(' '));
+}
+
+if (!APPLY) {
+  console.log('\nDry run only. Re-run with --apply to approve these Supabase evidence links.');
+  process.exit(0);
+}
+
+let applied = 0;
+for (const { row, candidate } of safe) {
+  await approveLink(row, candidate);
+  applied += 1;
+}
+
+console.log(`\nApplied approvals: ${applied}/${safe.length}`);

--- a/scripts/audit-approved-receipt-links.mjs
+++ b/scripts/audit-approved-receipt-links.mjs
@@ -1,0 +1,314 @@
+#!/usr/bin/env node
+/**
+ * Audit approved receipt evidence links that should not be trusted.
+ *
+ * Default mode is read-only. With --apply, this script updates only the
+ * Supabase receipt-evidence mirror, changing unsafe approved links to
+ * needs_review. It never writes to Xero.
+ *
+ * Usage:
+ *   node scripts/audit-approved-receipt-links.mjs --quarters Q2,Q3,Q4
+ *   node scripts/audit-approved-receipt-links.mjs --quarters Q2,Q3,Q4 --apply
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Missing Supabase URL/service role env vars');
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const APPLY_ALL_UNSAFE = args.includes('--apply-all-unsafe');
+const QUARTERS = valueAfter('--quarters')?.split(',').map((q) => q.trim().toUpperCase()).filter(Boolean) || ['Q2', 'Q3'];
+const FY = Number(valueAfter('--fy') || '26');
+const DATE = todayInBrisbane();
+const REPORT_DIR = join('thoughts', 'shared', 'reports', `approved-receipt-link-audit-${DATE}`);
+
+const GENERIC_TOKENS = new Set([
+  'australia',
+  'australian',
+  'brisbane',
+  'sydney',
+  'melbourne',
+  'mascot',
+  'pty',
+  'ltd',
+  'limited',
+  'inc',
+  'llc',
+  'corp',
+  'corporation',
+  'company',
+  'group',
+  'air',
+  'airways',
+  'and',
+  'bar',
+  'cafe',
+  'coffee',
+  'for',
+  'from',
+  'hotel',
+  'motel',
+  'online',
+  'resort',
+  'restaurant',
+  'restaurants',
+  'the',
+  'with',
+  'beach',
+]);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function todayInBrisbane() {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Australia/Brisbane',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
+
+function quarterDates(fy, quarter) {
+  const yr1 = 2000 + fy - 1;
+  const yr2 = 2000 + fy;
+  const quarters = {
+    Q1: { start: `${yr1}-07-01`, end: `${yr1}-09-30` },
+    Q2: { start: `${yr1}-10-01`, end: `${yr1}-12-31` },
+    Q3: { start: `${yr2}-01-01`, end: `${yr2}-03-31` },
+    Q4: { start: `${yr2}-04-01`, end: `${yr2}-06-30` },
+  };
+  if (!quarters[quarter]) throw new Error(`Unsupported quarter: ${quarter}`);
+  return quarters[quarter];
+}
+
+function cleanText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokens(value) {
+  return cleanText(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_TOKENS.has(token));
+}
+
+function vendorLooksRelated(row, candidate) {
+  const vendorTokens = tokens(candidate.vendor_name || candidate.document_vendor || candidate.vendor || '');
+  const lineTokens = new Set(tokens(`${row.payee || ''} ${row.particulars || ''}`));
+  if (!vendorTokens.length || !lineTokens.size) return false;
+  return vendorTokens.some((token) => lineTokens.has(token));
+}
+
+function asNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function auditCandidate(row, candidate) {
+  const reasons = [];
+  const confidence = asNumber(candidate.confidence);
+  const amountDelta = asNumber(candidate.amount_delta);
+  const dateDelta = asNumber(candidate.date_delta_days);
+
+  if (!candidate.link_id) reasons.push('missing link_id');
+  if (confidence === null || confidence < 0.95) reasons.push(`confidence ${confidence ?? 'unknown'} < 0.95`);
+  if (amountDelta === null || Math.abs(amountDelta) > 1) reasons.push(`amount delta ${amountDelta ?? 'unknown'} > $1`);
+  if (dateDelta === null || Math.abs(dateDelta) > 7) reasons.push(`date delta ${dateDelta ?? 'unknown'}d > 7d`);
+  if (!vendorLooksRelated(row, candidate)) reasons.push('vendor tokens do not match bank line');
+
+  return reasons;
+}
+
+function severityFor(row, candidate, reasons) {
+  const hasVendorMismatch = reasons.some((reason) => reason.includes('vendor tokens'));
+  const hasAmountMismatch = reasons.some((reason) => reason.includes('amount delta'));
+  const hasDateMismatch = reasons.some((reason) => reason.includes('date delta'));
+  const vendor = cleanText(candidate.vendor_name || candidate.document_vendor || candidate.vendor || '');
+  const line = cleanText(`${row.payee || ''} ${row.particulars || ''}`);
+
+  if (hasVendorMismatch && (hasAmountMismatch || hasDateMismatch)) return 'definitely_wrong';
+  if (hasAmountMismatch && hasDateMismatch) return 'definitely_wrong';
+  if (hasVendorMismatch && vendor && line && !line.includes(vendor.slice(0, Math.min(vendor.length, 6)))) {
+    return 'needs_human_review';
+  }
+  return 'needs_human_review';
+}
+
+async function fetchRows() {
+  const ranges = QUARTERS.map((quarter) => ({ quarter, ...quarterDates(FY, quarter) }));
+  const rows = [];
+  for (const range of ranges) {
+    const { data, error } = await sb
+      .from('v_finance_bank_line_evidence')
+      .select('id,date,payee,particulars,amount,status,evidence_status,best_confidence,best_vendor_name,best_source,receipt_candidates')
+      .eq('direction', 'debit')
+      .gte('date', range.start)
+      .lte('date', range.end)
+      .order('date');
+    if (error) throw error;
+    rows.push(...(data || []).map((row) => ({ ...row, quarter: range.quarter })));
+  }
+  return rows;
+}
+
+function csvEscape(value) {
+  const string = value === null || value === undefined ? '' : String(value);
+  if (!/[",\n]/.test(string)) return string;
+  return `"${string.replace(/"/g, '""')}"`;
+}
+
+function writeCsv(path, rows, headers) {
+  const lines = [
+    headers.join(','),
+    ...rows.map((row) => headers.map((header) => csvEscape(row[header])).join(',')),
+  ];
+  writeFileSync(path, `${lines.join('\n')}\n`);
+}
+
+const rows = await fetchRows();
+const unsafe = [];
+let approvedCount = 0;
+
+for (const row of rows) {
+  const candidates = Array.isArray(row.receipt_candidates) ? row.receipt_candidates : [];
+  for (const candidate of candidates) {
+    if (candidate.link_status !== 'approved') continue;
+    approvedCount += 1;
+    const reasons = auditCandidate(row, candidate);
+    if (!reasons.length) continue;
+    const severity = severityFor(row, candidate, reasons);
+    unsafe.push({
+      severity,
+      quarter: row.quarter,
+      bank_line_id: row.id,
+      link_id: candidate.link_id || '',
+      date: row.date,
+      payee: row.payee,
+      particulars: row.particulars,
+      amount: row.amount,
+      candidate_vendor: candidate.vendor_name || '',
+      candidate_source: candidate.source || '',
+      confidence: candidate.confidence ?? '',
+      amount_delta: candidate.amount_delta ?? '',
+      date_delta_days: candidate.date_delta_days ?? '',
+      reasons: reasons.join('; '),
+    });
+  }
+}
+
+mkdirSync(REPORT_DIR, { recursive: true });
+writeCsv(join(REPORT_DIR, 'unsafe-approved-links.csv'), unsafe, [
+  'severity',
+  'quarter',
+  'bank_line_id',
+  'link_id',
+  'date',
+  'payee',
+  'particulars',
+  'amount',
+  'candidate_vendor',
+  'candidate_source',
+  'confidence',
+  'amount_delta',
+  'date_delta_days',
+  'reasons',
+]);
+
+const definitelyWrong = unsafe.filter((row) => row.severity === 'definitely_wrong');
+writeCsv(join(REPORT_DIR, 'definitely-wrong-approved-links.csv'), definitelyWrong, [
+  'severity',
+  'quarter',
+  'bank_line_id',
+  'link_id',
+  'date',
+  'payee',
+  'particulars',
+  'amount',
+  'candidate_vendor',
+  'candidate_source',
+  'confidence',
+  'amount_delta',
+  'date_delta_days',
+  'reasons',
+]);
+
+let updated = 0;
+const applyRows = APPLY_ALL_UNSAFE ? unsafe : definitelyWrong;
+if (APPLY && applyRows.length) {
+  for (let i = 0; i < applyRows.length; i += 100) {
+    const batch = applyRows.slice(i, i + 100).map((row) => row.link_id).filter(Boolean);
+    if (!batch.length) continue;
+    const { error, count } = await sb
+      .from('finance_receipt_bank_line_links')
+      .update({
+        link_status: 'needs_review',
+        review_owner: 'codex',
+        review_note: `Demoted by approved receipt audit ${DATE}: strict receipt safety rule failed`,
+        updated_at: new Date().toISOString(),
+      }, { count: 'exact' })
+      .in('id', batch);
+    if (error) throw error;
+    updated += count || 0;
+  }
+}
+
+const md = [
+  `# Approved Receipt Link Audit - ${DATE}`,
+  '',
+  `Mode: ${APPLY ? 'APPLY' : 'READ ONLY'}`,
+  `Quarters: ${QUARTERS.join(', ')}`,
+  `Rows scanned: ${rows.length}`,
+  `Approved links scanned: ${approvedCount}`,
+  `Unsafe approved links: ${unsafe.length}`,
+  `Definitely wrong approved links: ${definitelyWrong.length}`,
+  `Apply target: ${APPLY_ALL_UNSAFE ? 'all unsafe approved links' : 'definitely wrong approved links only'}`,
+  `Links demoted to needs_review: ${updated}`,
+  '',
+  '## Rule',
+  '',
+  'Approved links should have confidence >= 0.95, amount delta <= $1, date delta <= 7 days, and vendor-token overlap with the bank line.',
+  '',
+  '## Output',
+  '',
+  `- ${join(REPORT_DIR, 'unsafe-approved-links.csv')}`,
+  `- ${join(REPORT_DIR, 'definitely-wrong-approved-links.csv')}`,
+  '',
+  '## Verification Status',
+  '',
+  'verified: Queried live Supabase v_finance_bank_line_evidence.',
+  APPLY
+    ? `verified: Applied Supabase-only evidence mirror updates to ${updated} links.`
+    : 'verified: Read-only mode; no Supabase writes were made.',
+  'unverified: No Xero UI reconciliation state was changed or checked by this script.',
+  '',
+].join('\n');
+
+writeFileSync(join(REPORT_DIR, 'summary.md'), md);
+
+console.log(`Approved receipt link audit ${APPLY ? 'apply' : 'dry-run'} complete`);
+console.log(`  Rows scanned:            ${rows.length}`);
+console.log(`  Approved links scanned:  ${approvedCount}`);
+console.log(`  Unsafe approved links:   ${unsafe.length}`);
+console.log(`  Definitely wrong links:  ${definitelyWrong.length}`);
+console.log(`  Apply target:            ${APPLY_ALL_UNSAFE ? 'all unsafe' : 'definitely wrong only'}`);
+console.log(`  Links demoted:           ${updated}`);
+console.log(`  Report:                  ${join(REPORT_DIR, 'summary.md')}`);

--- a/scripts/audit-money-in-alignment.mjs
+++ b/scripts/audit-money-in-alignment.mjs
@@ -33,7 +33,7 @@ const sinceArg = args.find(a => a.startsWith('--since'));
 const SINCE = sinceArg ? sinceArg.split(/[ =]/)[1] : '2025-07-01'; // FY26
 
 const supabase = createClient(
-  process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
 );
 

--- a/scripts/audit-money-out-alignment.mjs
+++ b/scripts/audit-money-out-alignment.mjs
@@ -25,7 +25,7 @@ const sinceArg = args.find(a => a.startsWith('--since'));
 const SINCE = sinceArg ? sinceArg.split(/[ =]/)[1] : '2025-07-01';
 
 const supabase = createClient(
-  process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
 );
 

--- a/scripts/auto-tag-fy26-transactions.mjs
+++ b/scripts/auto-tag-fy26-transactions.mjs
@@ -231,6 +231,26 @@ function checkRdEligible(projectCode, contactName) {
   return false;
 }
 
+async function fetchAllRows(buildQuery, label) {
+  const rows = [];
+  const pageSize = 1000;
+
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await buildQuery()
+      .range(from, from + pageSize - 1);
+
+    if (error) {
+      throw new Error(`${label}: ${error.message}`);
+    }
+    if (!data || data.length === 0) break;
+
+    rows.push(...data);
+    if (data.length < pageSize) break;
+  }
+
+  return rows;
+}
+
 // ============================================================================
 // MAIN
 // ============================================================================
@@ -246,18 +266,16 @@ async function main() {
   // Load vendor rules from DB
   await loadVendorRules();
 
-  // Fetch all FY26 transactions
-  const { data: allTxns, error: allErr } = await supabase
-    .from('xero_transactions')
-    .select('id, xero_transaction_id, contact_name, type, total, date, project_code, project_code_source, line_items')
-    .gte('date', FY26_START)
-    .lte('date', FY26_END)
-    .order('date', { ascending: true });
-
-  if (allErr) {
-    console.error('Failed to fetch transactions:', allErr);
-    process.exit(1);
-  }
+  // Fetch all FY26 transactions. Supabase defaults to 1,000 rows, so paginate.
+  const allTxns = await fetchAllRows(
+    () => supabase
+      .from('xero_transactions')
+      .select('id, xero_transaction_id, contact_name, type, total, date, project_code, project_code_source, line_items')
+      .gte('date', FY26_START)
+      .lte('date', FY26_END)
+      .order('date', { ascending: true }),
+    'xero_transactions FY26',
+  );
 
   const total = allTxns.length;
   const alreadyTagged = allTxns.filter(t => t.project_code && t.project_code !== '');

--- a/scripts/build-bank-line-action-queue.mjs
+++ b/scripts/build-bank-line-action-queue.mjs
@@ -1,0 +1,856 @@
+#!/usr/bin/env node
+/**
+ * Build the canonical bank-line-first close action queue.
+ *
+ * Read-only. This does not write to Xero or Supabase.
+ *
+ * Usage:
+ *   node scripts/build-bank-line-action-queue.mjs --quarters Q2,Q3
+ *   node scripts/build-bank-line-action-queue.mjs --quarters Q2,Q3 --format json
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Missing Supabase URL/service role env vars');
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const FY = numberAfter('--fy', 26);
+const QUARTERS = valueAfter('--quarters')
+  ? valueAfter('--quarters').split(',').map((q) => q.trim().toUpperCase()).filter(Boolean)
+  : args.filter((arg) => /^Q[1-4]$/i.test(arg)).map((arg) => arg.toUpperCase());
+const quarterList = QUARTERS.length ? QUARTERS : ['Q2', 'Q3'];
+const FORMAT = valueAfter('--format') || 'all';
+const DATE = todayInBrisbane();
+const OUT_DIR = join('thoughts', 'shared', 'reports', `bank-line-action-queue-${DATE}`);
+const RECEIPT_THRESHOLD = 82.5;
+
+const ACTIONS = {
+  already_done: 'already_done',
+  attached_in_xero: 'attached_in_xero',
+  upload_attachment: 'upload_attachment',
+  xero_target_missing: 'xero_target_missing',
+  click_ok_existing_match: 'click_ok_existing_match',
+  create_low_value: 'create_low_value',
+  create_with_receipt: 'create_with_receipt',
+  review_receipt_candidate: 'review_receipt_candidate',
+  find_match_bill: 'find_match_bill',
+  transfer: 'transfer',
+  income_review: 'income_review',
+  reject_xero_suggestion: 'reject_xero_suggestion',
+  reject_receipt_candidate: 'reject_receipt_candidate',
+  find_receipt: 'find_receipt',
+  project_rd_review: 'project_rd_review',
+  bookkeeper_review: 'bookkeeper_review',
+};
+
+const LOW_VALUE_NO_RECEIPT_PURPOSE = 'No invoice required under $82.50; keep business purpose clear.';
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function numberAfter(flag, fallback) {
+  const raw = valueAfter(flag);
+  if (!raw) return fallback;
+  const number = Number(raw);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function todayInBrisbane() {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Australia/Brisbane',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
+
+function quarterDates(fy, quarter) {
+  const yr1 = 2000 + fy - 1;
+  const yr2 = 2000 + fy;
+  const ranges = {
+    Q1: { start: `${yr1}-07-01`, end: `${yr1}-09-30` },
+    Q2: { start: `${yr1}-10-01`, end: `${yr1}-12-31` },
+    Q3: { start: `${yr2}-01-01`, end: `${yr2}-03-31` },
+    Q4: { start: `${yr2}-04-01`, end: `${yr2}-06-30` },
+  };
+  if (!ranges[quarter]) throw new Error(`Unsupported quarter: ${quarter}`);
+  return ranges[quarter];
+}
+
+function quarterForDate(date) {
+  const month = Number(String(date || '').slice(5, 7));
+  if (month >= 7 && month <= 9) return 'Q1';
+  if (month >= 10 && month <= 12) return 'Q2';
+  if (month >= 1 && month <= 3) return 'Q3';
+  return 'Q4';
+}
+
+function dateClause(alias = 'bsl') {
+  return quarterList
+    .map((quarter) => {
+      const { start, end } = quarterDates(FY, quarter);
+      return `(${alias}.date >= $$${start}$$::date and ${alias}.date <= $$${end}$$::date)`;
+    })
+    .join(' or ');
+}
+
+function asNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function absAmount(value) {
+  return Math.abs(asNumber(value));
+}
+
+function cents(value) {
+  return Math.round(absAmount(value) * 100);
+}
+
+function isAmountClose(a, b, toleranceCents = 2) {
+  return Math.abs(cents(a) - cents(b)) <= toleranceCents;
+}
+
+function money(value) {
+  return absAmount(value).toLocaleString('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 2,
+  });
+}
+
+function cleanText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const GENERIC_WORDS = new Set([
+  'and',
+  'australia',
+  'australian',
+  'bank',
+  'brisbane',
+  'card',
+  'co',
+  'company',
+  'credit',
+  'group',
+  'internet',
+  'limited',
+  'ltd',
+  'melbourne',
+  'payment',
+  'payments',
+  'purchase',
+  'pty',
+  'sydney',
+  'the',
+  'transfer',
+  'visa',
+]);
+
+function meaningfulTokens(value) {
+  return cleanText(value)
+    .split(' ')
+    .filter((token) => token.length >= 3 && !GENERIC_WORDS.has(token));
+}
+
+function vendorScore(needle, haystack) {
+  const left = cleanText(needle);
+  const right = cleanText(haystack);
+  if (!left || !right) return 0;
+  if (left === right) return 1;
+  if (left.includes(right) || right.includes(left)) return 0.95;
+
+  const leftTokens = meaningfulTokens(left);
+  const rightTokens = new Set(meaningfulTokens(right));
+  if (!leftTokens.length || !rightTokens.size) return 0;
+  return leftTokens.filter((token) => rightTokens.has(token)).length / leftTokens.length;
+}
+
+function dateDeltaDays(a, b) {
+  if (!a || !b) return null;
+  const first = new Date(`${a}T00:00:00`).getTime();
+  const second = new Date(`${b}T00:00:00`).getTime();
+  if (!Number.isFinite(first) || !Number.isFinite(second)) return null;
+  return Math.round((second - first) / 86400000);
+}
+
+function hasFile(docOrCandidate) {
+  return Boolean(
+    docOrCandidate?.attachment_storage_path
+    || docOrCandidate?.attachment_url
+    || docOrCandidate?.attachment_filename,
+  );
+}
+
+function hasXeroTarget(rowOrDoc) {
+  return Boolean(
+    rowOrDoc?.xero_bank_transaction_id
+    || rowOrDoc?.xero_transaction_id
+    || rowOrDoc?.matched_xero_transaction_id,
+  );
+}
+
+function targetId(row, approvedLink) {
+  return (
+    approvedLink?.document_xero_bank_transaction_id
+    || approvedLink?.document_xero_transaction_id
+    || row.xero_transaction_id
+    || row.matched_xero_transaction_id
+    || null
+  );
+}
+
+function rowVendor(row) {
+  return row.payee || row.best_vendor_name || row.particulars || row.reference || 'Bank line';
+}
+
+function rowText(row) {
+  return [
+    row.payee,
+    row.particulars,
+    row.reference,
+    row.best_vendor_name,
+    row.bank_account,
+  ].filter(Boolean).join(' ');
+}
+
+function isTransfer(row) {
+  const text = cleanText(rowText(row));
+  return Boolean(
+    row.direction === 'credit' && /internet payment|linked acc|credit card payment|card repayment/.test(text)
+    || /internet payment|linked acc|linked account|credit card payment|card repayment|bank transfer|transfer/.test(text)
+    || /ato payment/.test(text)
+  );
+}
+
+function isRefund(row) {
+  const text = cleanText(rowText(row));
+  return row.direction === 'credit' || /refund|rebate|reversal|credit/.test(text);
+}
+
+function noReceiptNeeded(row) {
+  const state = String(row.evidence_status || row.receipt_match_status || '').toLowerCase();
+  return state === 'no_receipt_needed'
+    || String(row.receipt_match_status || '').toLowerCase() === 'no_receipt_needed'
+    || isTransfer(row);
+}
+
+function bestApprovedLink(links) {
+  return (links || [])
+    .filter((link) => link.link_status === 'approved' && link.has_file)
+    .sort((a, b) => asNumber(b.confidence) - asNumber(a.confidence))[0] || null;
+}
+
+function rejectedLinkCount(links) {
+  return (links || []).filter((link) => link.link_status === 'rejected').length;
+}
+
+function bestReviewableCandidate(row, rejectedDocumentIds) {
+  const candidates = Array.isArray(row.receipt_candidates) ? row.receipt_candidates : [];
+  return candidates
+    .filter((candidate) => {
+      if (!candidate || rejectedDocumentIds.has(String(candidate.receipt_document_id || candidate.id || ''))) return false;
+      const source = String(candidate.source || candidate.source_table || '').toLowerCase();
+      const action = String(candidate.xero_action || '').toLowerCase();
+      const confidence = asNumber(candidate.confidence);
+      const amountDelta = Math.abs(asNumber(candidate.amount_delta));
+      const dateDelta = candidate.date_delta_days === null || candidate.date_delta_days === undefined
+        ? null
+        : Math.abs(asNumber(candidate.date_delta_days));
+      const vendor = asNumber(candidate.vendor_score) || vendorScore(rowText(row), candidate.vendor_name);
+      const receiptish = /(dext|receipt|xero_me|manual|gmail)/.test(source) || action === 'attach_file';
+      if (!receiptish || !hasFile(candidate)) return false;
+      if (confidence < 0.70) return false;
+      if (vendor < 0.45) return false;
+      if (dateDelta !== null && dateDelta > 21) return false;
+      if (amountDelta > Math.max(2, absAmount(row.amount) * 0.10)) return false;
+      return true;
+    })
+    .sort((a, b) => asNumber(b.confidence) - asNumber(a.confidence))[0] || null;
+}
+
+function bestBillCandidate(row, invoices) {
+  const candidates = invoices
+    .map((invoice) => ({
+      invoice,
+      score: vendorScore(rowText(row), invoice.contact_name),
+      delta: dateDeltaDays(row.date, invoice.date),
+    }))
+    .filter(({ invoice, score, delta }) => (
+      invoice.type === 'ACCPAY'
+      && ['AUTHORISED', 'PAID'].includes(String(invoice.status || '').toUpperCase())
+      && isAmountClose(row.amount, invoice.total)
+      && delta !== null
+      && Math.abs(delta) <= 14
+      && score >= 0.45
+    ))
+    .sort((a, b) => {
+      const attachedDiff = Number(Boolean(b.invoice.has_attachments)) - Number(Boolean(a.invoice.has_attachments));
+      if (attachedDiff !== 0) return attachedDiff;
+      const scoreDiff = b.score - a.score;
+      if (Math.abs(scoreDiff) > 0.001) return scoreDiff;
+      return Math.abs(a.delta || 0) - Math.abs(b.delta || 0);
+    });
+
+  return candidates.length === 1 ? candidates[0] : null;
+}
+
+function codingSuggestion(row) {
+  const text = cleanText(rowText(row));
+  const amount = absAmount(row.amount);
+
+  if (isTransfer(row)) {
+    return {
+      who: '',
+      account: 'Transfer',
+      why: `NAB Visa card repayment/internal transfer - ${row.reference || row.card_last4 || 'bank line'}`,
+      taxRate: 'BAS Excluded',
+    };
+  }
+
+  if (/belong|telstra|dialpad|starlink/.test(text)) {
+    return { who: rowVendor(row), account: '489 - Telephone & Internet', why: `${rowVendor(row)} phone/internet service`, taxRate: 'GST on Expenses' };
+  }
+
+  if (/linktree|linkedin|squarespace|webflow|openai|anthropic|claude|notion|figma|vercel|railway|supabase|zapier|bitwarden|codeguide|descript|mighty|warp|cognition/.test(text)) {
+    const taxRate = /linkedin|openai|anthropic|claude|notion|figma|vercel|railway|supabase|zapier|bitwarden|codeguide|descript|mighty|warp|cognition|webflow/.test(text)
+      ? 'GST Free Expenses'
+      : 'GST on Expenses';
+    return { who: rowVendor(row), account: '485 - Subscriptions', why: `${rowVendor(row)} subscription${amount <= RECEIPT_THRESHOLD ? ` - ${LOW_VALUE_NO_RECEIPT_PURPOSE}` : ''}`, taxRate };
+  }
+
+  if (/qantas|virgin|avis|budget|booking|airbnb|hotel|novotel|dayuse|cabfare|taxi|uber/.test(text)) {
+    const account = /cabfare|taxi|uber/.test(text) ? '452 - Parking, Tolls & Taxis' : '493 - Travel - National';
+    return { who: rowVendor(row), account, why: `${rowVendor(row)} travel-related spend`, taxRate: 'GST on Expenses' };
+  }
+
+  if (/fuel|ampol|bp |liberty|shell|caltex|eg group|reddy express/.test(text)) {
+    return { who: rowVendor(row), account: '449 - MV - Fuel & Oil', why: `${rowVendor(row)} fuel/motor vehicle spend`, taxRate: 'GST on Expenses' };
+  }
+
+  if (/bunnings|stratco|electrical|hardware|kennards|trailer|tools|sydney tools/.test(text)) {
+    return { who: rowVendor(row), account: '409 - Client to Advise', why: `${rowVendor(row)} supplies/equipment - confirm project and account`, taxRate: 'GST on Expenses' };
+  }
+
+  if (amount <= RECEIPT_THRESHOLD) {
+    return { who: rowVendor(row), account: '429 - General Expenses', why: `${rowVendor(row)} - ${LOW_VALUE_NO_RECEIPT_PURPOSE}`, taxRate: 'GST on Expenses' };
+  }
+
+  return { who: rowVendor(row), account: '409 - Client to Advise', why: `${rowVendor(row)} - confirm receipt, project, and account before reconciling`, taxRate: 'GST on Expenses' };
+}
+
+function actionRecord(row, action, risk, owner, reason, extra = {}) {
+  const coding = codingSuggestion(row);
+  return {
+    bank_line_id: row.id,
+    quarter: quarterForDate(row.date),
+    date: row.date,
+    direction: row.direction,
+    vendor: rowVendor(row),
+    description: [row.particulars, row.reference, row.bank_account].filter(Boolean).join(' · '),
+    amount: absAmount(row.amount),
+    bank_status: row.status,
+    xero_state: extra.xero_state || xeroState(row, extra),
+    evidence_state: extra.evidence_state || evidenceState(row, extra),
+    next_action: action,
+    risk,
+    owner,
+    reason,
+    safe_to_click: ['transfer', 'create_low_value', 'click_ok_existing_match'].includes(action) && risk === 'low',
+    project_code: row.project_code || '',
+    project_source: row.project_source || '',
+    rd_eligible: row.rd_eligible === true,
+    rd_category: row.rd_category || '',
+    xero_target_id: extra.target_id || '',
+    receipt_document_id: extra.receipt_document_id || '',
+    receipt_source: extra.receipt_source || row.best_source || '',
+    receipt_confidence: extra.receipt_confidence ?? row.best_confidence ?? '',
+    candidate_count: asNumber(row.candidate_count),
+    rejected_candidate_count: extra.rejected_candidate_count || 0,
+    who: coding.who,
+    what: coding.account,
+    why: coding.why,
+    tax_rate: coding.taxRate,
+  };
+}
+
+function xeroState(row, extra) {
+  if (extra.target_id && extra.target_has_attachment) return 'reconciled_target_attached';
+  if (extra.target_id) return 'target_known';
+  if (String(row.status || '').toLowerCase() === 'unreconciled') return 'unreconciled_target_missing';
+  if (String(row.status || '').toLowerCase() === 'reconciled') return 'reconciled_target_missing';
+  return 'unknown';
+}
+
+function evidenceState(row, extra) {
+  if (extra.target_has_attachment) return 'attached_in_xero';
+  if (extra.approved_link) return 'approved_file';
+  if (noReceiptNeeded(row)) return 'no_receipt_needed';
+  if (extra.candidate) return 'candidate';
+  return row.evidence_status || row.receipt_match_status || 'none';
+}
+
+function classifyRow(row, context) {
+  const links = context.linksByBankLine.get(row.id) || [];
+  const rejectedIds = new Set(links.filter((link) => link.link_status === 'rejected').map((link) => String(link.receipt_document_id)));
+  const approved = bestApprovedLink(links);
+  const rejectedCount = rejectedLinkCount(links);
+  const target = targetId(row, approved);
+  const targetTxn = target ? context.transactionsById.get(target) : null;
+  const targetHasAttachment = targetTxn?.has_attachments === true || approved?.document_xero_attachment_id;
+  const candidate = bestReviewableCandidate(row, rejectedIds);
+  const bankStatus = String(row.status || '').toLowerCase();
+  const isReconciled = bankStatus === 'reconciled';
+  const billCandidate = isReconciled ? null : bestBillCandidate(row, context.invoices);
+  const amount = absAmount(row.amount);
+  const baseExtra = {
+    target_id: target || '',
+    target_has_attachment: Boolean(targetHasAttachment),
+    approved_link: approved || null,
+    candidate,
+    rejected_candidate_count: rejectedCount,
+    receipt_document_id: approved?.receipt_document_id || candidate?.receipt_document_id || candidate?.id || '',
+    receipt_source: approved?.document_source || candidate?.source || row.best_source || '',
+    receipt_confidence: approved?.confidence ?? candidate?.confidence ?? row.best_confidence ?? '',
+  };
+
+  if (row.direction === 'credit' && !isTransfer(row)) {
+    return actionRecord(row, ACTIONS.income_review, 'medium', 'ben', 'Incoming/refund line. Review against invoice, refund, or transfer before coding.', baseExtra);
+  }
+
+  if (isTransfer(row)) {
+    return actionRecord(row, ACTIONS.transfer, 'low', 'ben', 'Internal transfer/card repayment. Use Xero Transfer, not a new spend item.', {
+      ...baseExtra,
+      evidence_state: 'no_receipt_needed',
+    });
+  }
+
+  if (approved && target && targetHasAttachment) {
+    return actionRecord(row, ACTIONS.attached_in_xero, 'low', 'codex', 'Approved receipt is already attached to the known Xero target.', baseExtra);
+  }
+
+  if (approved && target && !targetHasAttachment) {
+    return actionRecord(row, ACTIONS.upload_attachment, 'low', 'codex', 'Approved receipt has an exact Xero target and can be uploaded as an attachment.', baseExtra);
+  }
+
+  if (approved && !target) {
+    const owner = bankStatus === 'unreconciled' ? 'ben' : 'codex';
+    const reason = bankStatus === 'unreconciled'
+      ? 'Receipt is approved, but the bank line still needs the Xero UI reconciliation/create step before attachment.'
+      : 'Receipt is approved, but the mirror lacks an exact Xero target. Run deterministic target linker or inspect Xero.';
+    return actionRecord(row, ACTIONS.xero_target_missing, 'medium', owner, reason, baseExtra);
+  }
+
+  if (isReconciled) {
+    const status = String(row.evidence_status || row.receipt_match_status || '').toLowerCase();
+    if (candidate || ['covered_legacy', 'covered_evidence', 'candidate', 'high_confidence_candidate'].includes(status)) {
+      return actionRecord(row, ACTIONS.review_receipt_candidate, 'medium', 'ben', 'Bank line is already reconciled, but receipt evidence still needs human approval/rejection for the close pack.', baseExtra);
+    }
+
+    if (noReceiptNeeded(row) || amount <= RECEIPT_THRESHOLD) {
+      return actionRecord(row, ACTIONS.already_done, 'low', 'codex', 'Bank line is already reconciled and does not need more receipt work.', {
+        ...baseExtra,
+        evidence_state: noReceiptNeeded(row) ? 'no_receipt_needed' : 'low_value_no_file',
+      });
+    }
+
+    if (!row.project_code || row.project_code === 'ACT-IN' || row.rd_eligible === null) {
+      return actionRecord(row, ACTIONS.project_rd_review, 'medium', 'ben', 'Bank line is already reconciled but needs project/R&D review before bookkeeper pack.', baseExtra);
+    }
+
+    return actionRecord(row, ACTIONS.find_receipt, 'high', 'ben', 'Bank line is already reconciled, but receipt evidence is still missing for the close pack.', baseExtra);
+  }
+
+  if (billCandidate) {
+    return actionRecord(row, ACTIONS.find_match_bill, 'low', 'ben', `Exact Xero bill candidate exists: ${billCandidate.invoice.contact_name || 'bill'} ${money(billCandidate.invoice.total)}. Use Find & Match, not Create.`, {
+      ...baseExtra,
+      target_id: billCandidate.invoice.xero_id || '',
+      xero_state: 'bill_candidate',
+    });
+  }
+
+  if (candidate) {
+    return actionRecord(row, ACTIONS.review_receipt_candidate, 'medium', 'ben', 'Receipt candidate exists. Preview the file; approve if vendor/date/amount are correct, otherwise reject it.', baseExtra);
+  }
+
+  if (
+    ['covered_legacy', 'covered_evidence', 'candidate', 'high_confidence_candidate'].includes(String(row.evidence_status || '').toLowerCase())
+    || (asNumber(row.candidate_count) > 0 && row.best_source)
+  ) {
+    return actionRecord(row, ACTIONS.review_receipt_candidate, 'medium', 'ben', 'Evidence/candidates exist, but none are approved yet. Open the receipt preview and approve the correct file or reject bad candidates.', baseExtra);
+  }
+
+  if (noReceiptNeeded(row)) {
+    if (bankStatus === 'unreconciled') {
+      return actionRecord(row, ACTIONS.create_low_value, 'low', 'ben', 'No receipt needed path. Create/reconcile only if account, tax, project, and business purpose are correct.', {
+        ...baseExtra,
+        evidence_state: 'no_receipt_needed',
+      });
+    }
+    return actionRecord(row, ACTIONS.already_done, 'low', 'codex', 'Bank line is already reconciled and marked no receipt needed.', {
+      ...baseExtra,
+      evidence_state: 'no_receipt_needed',
+    });
+  }
+
+  if (amount <= RECEIPT_THRESHOLD && bankStatus === 'unreconciled') {
+    return actionRecord(row, ACTIONS.create_low_value, 'low', 'ben', LOW_VALUE_NO_RECEIPT_PURPOSE, {
+      ...baseExtra,
+      evidence_state: 'low_value_no_file',
+    });
+  }
+
+  if (bankStatus === 'unreconciled') {
+    return actionRecord(row, ACTIONS.find_receipt, 'high', 'ben', 'Unreconciled spend over threshold with no approved receipt or exact bill target. Find receipt or code BAS excluded with explicit review.', baseExtra);
+  }
+
+  if (!row.project_code || row.project_code === 'ACT-IN' || row.rd_eligible === null) {
+    return actionRecord(row, ACTIONS.project_rd_review, 'medium', 'ben', 'Bank line appears reconciled but needs project/R&D review before bookkeeper pack.', baseExtra);
+  }
+
+  return actionRecord(row, ACTIONS.bookkeeper_review, 'medium', 'standard_ledger', 'Reconciled or historical row still has unresolved evidence/target ambiguity. Include in bookkeeper exception pack.', baseExtra);
+}
+
+async function execSql(query) {
+  const { data, error } = await sb.rpc('exec_sql', { query });
+  if (error) throw error;
+  return data || [];
+}
+
+async function fetchPaged(label, queryFactory, pageSize = 1000) {
+  const rows = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await queryFactory(from, from + pageSize - 1);
+    if (error) throw new Error(`${label}: ${error.message}`);
+    rows.push(...(data || []));
+    if (!data || data.length < pageSize) break;
+  }
+  return rows;
+}
+
+async function loadBankRows() {
+  const rows = [];
+  for (const quarter of quarterList) {
+    const { start, end } = quarterDates(FY, quarter);
+    rows.push(...await fetchPaged(`bank evidence ${quarter}`, (from, to) =>
+      sb
+        .from('v_finance_bank_line_evidence')
+        .select('*')
+        .gte('date', start)
+        .lte('date', end)
+        .order('date', { ascending: true })
+        .range(from, to)
+    ));
+  }
+  return rows;
+}
+
+async function loadLinks() {
+  const query = `
+    select
+      l.id,
+      l.bank_line_id,
+      l.receipt_document_id,
+      l.link_status,
+      l.match_method,
+      l.confidence,
+      l.rank,
+      l.is_best_candidate,
+      l.vendor_score,
+      l.amount_score,
+      l.date_score,
+      l.amount_delta,
+      l.date_delta_days,
+      l.review_owner,
+      l.review_note,
+      l.xero_action,
+      d.source as document_source,
+      d.source_table as document_source_table,
+      d.vendor_name as document_vendor,
+      d.document_date as document_date,
+      d.amount_total as document_amount,
+      d.attachment_url as document_attachment_url,
+      d.attachment_storage_path as document_attachment_storage_path,
+      d.attachment_filename as document_attachment_filename,
+      d.xero_transaction_id as document_xero_transaction_id,
+      d.xero_bank_transaction_id as document_xero_bank_transaction_id,
+      d.xero_invoice_id as document_xero_invoice_id,
+      d.xero_attachment_id as document_xero_attachment_id,
+      d.status as document_status,
+      (
+        d.attachment_url is not null
+        or d.attachment_storage_path is not null
+        or d.attachment_filename is not null
+      ) as has_file
+    from finance_receipt_bank_line_links l
+    join finance_receipt_documents d on d.id = l.receipt_document_id
+    join bank_statement_lines bsl on bsl.id = l.bank_line_id
+    where ${dateClause('bsl')}
+    order by l.bank_line_id, l.link_status, l.confidence desc nulls last
+  `;
+  const rows = await execSql(query);
+  const map = new Map();
+  for (const row of rows) {
+    const list = map.get(row.bank_line_id) || [];
+    list.push(row);
+    map.set(row.bank_line_id, list);
+  }
+  return map;
+}
+
+async function loadXeroTransactions() {
+  const ranges = quarterList.map((q) => quarterDates(FY, q));
+  const start = ranges.map((r) => r.start).sort()[0];
+  const end = ranges.map((r) => r.end).sort().at(-1);
+  const rows = await fetchPaged('xero transactions', (from, to) =>
+    sb
+      .from('xero_transactions')
+      .select('xero_transaction_id,type,contact_name,total,status,date,has_attachments,is_reconciled,project_code,rd_category')
+      .gte('date', start)
+      .lte('date', end)
+      .range(from, to)
+  );
+  return new Map(rows.filter((row) => row.xero_transaction_id).map((row) => [row.xero_transaction_id, row]));
+}
+
+async function loadXeroInvoices() {
+  const ranges = quarterList.map((q) => quarterDates(FY, q));
+  const start = ranges.map((r) => r.start).sort()[0];
+  const end = ranges.map((r) => r.end).sort().at(-1);
+  return fetchPaged('xero invoices', (from, to) =>
+    sb
+      .from('xero_invoices')
+      .select('id,xero_id,invoice_number,type,status,contact_name,date,total,amount_due,amount_paid,has_attachments,reference,project_code,project_code_source')
+      .eq('type', 'ACCPAY')
+      .gte('date', start)
+      .lte('date', end)
+      .range(from, to)
+  );
+}
+
+function csvEscape(value) {
+  const string = value === null || value === undefined ? '' : String(value);
+  if (!/[",\n]/.test(string)) return string;
+  return `"${string.replace(/"/g, '""')}"`;
+}
+
+function writeCsv(path, rows, headers) {
+  const lines = [
+    headers.join(','),
+    ...rows.map((row) => headers.map((header) => csvEscape(row[header])).join(',')),
+  ];
+  writeFileSync(path, `${lines.join('\n')}\n`);
+}
+
+function summarize(rows, key) {
+  return [...rows.reduce((map, row) => {
+    const value = row[key] || 'unknown';
+    const item = map.get(value) || { key: value, count: 0, value: 0 };
+    item.count += 1;
+    item.value += row.amount;
+    map.set(value, item);
+    return map;
+  }, new Map()).values()].sort((a, b) => b.value - a.value);
+}
+
+function markdownTable(rows, headers) {
+  const head = `| ${headers.join(' | ')} |`;
+  const sep = `| ${headers.map(() => '---').join(' | ')} |`;
+  const body = rows.map((row) => `| ${headers.map((header) => row[header]).join(' | ')} |`);
+  return [head, sep, ...body].join('\n');
+}
+
+function writeReports(rows) {
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const headers = [
+    'quarter',
+    'date',
+    'direction',
+    'vendor',
+    'amount',
+    'bank_status',
+    'xero_state',
+    'evidence_state',
+    'next_action',
+    'risk',
+    'owner',
+    'safe_to_click',
+    'project_code',
+    'rd_eligible',
+    'xero_target_id',
+    'receipt_document_id',
+    'receipt_source',
+    'receipt_confidence',
+    'candidate_count',
+    'rejected_candidate_count',
+    'who',
+    'what',
+    'why',
+    'tax_rate',
+    'reason',
+    'description',
+    'bank_line_id',
+  ];
+
+  const csvRows = rows.map((row) => ({
+    ...row,
+    amount: row.amount.toFixed(2),
+  }));
+
+  writeCsv(join(OUT_DIR, 'queue.csv'), csvRows, headers);
+  writeFileSync(join(OUT_DIR, 'queue.json'), `${JSON.stringify(rows, null, 2)}\n`);
+
+  const byAction = summarize(rows, 'next_action').map((row) => ({
+    Action: row.key,
+    Count: row.count,
+    Value: money(row.value),
+  }));
+  const byOwner = summarize(rows, 'owner').map((row) => ({
+    Owner: row.key,
+    Count: row.count,
+    Value: money(row.value),
+  }));
+  const byRisk = summarize(rows, 'risk').map((row) => ({
+    Risk: row.key,
+    Count: row.count,
+    Value: money(row.value),
+  }));
+
+  const topBenRows = rows
+    .filter((row) => row.owner === 'ben' && row.next_action !== ACTIONS.transfer)
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, 50)
+    .map((row) => ({
+      Date: row.date,
+      Vendor: row.vendor.replaceAll('|', '/'),
+      Amount: money(row.amount),
+      Action: row.next_action,
+      Risk: row.risk,
+      Reason: row.reason.replaceAll('|', '/'),
+    }));
+
+  const md = `# Bank-Line Action Queue ${DATE}
+
+Read-only queue for ${quarterList.join(', ')} FY${FY}.
+
+## Summary
+
+- Total rows: ${rows.length}
+- Total absolute value: ${money(rows.reduce((sum, row) => sum + row.amount, 0))}
+- Safe-to-click rows: ${rows.filter((row) => row.safe_to_click).length}
+- Ben-owned rows: ${rows.filter((row) => row.owner === 'ben').length}
+- Codex-owned rows: ${rows.filter((row) => row.owner === 'codex').length}
+- Standard Ledger rows: ${rows.filter((row) => row.owner === 'standard_ledger').length}
+
+## By Action
+
+${markdownTable(byAction, ['Action', 'Count', 'Value'])}
+
+## By Owner
+
+${markdownTable(byOwner, ['Owner', 'Count', 'Value'])}
+
+## By Risk
+
+${markdownTable(byRisk, ['Risk', 'Count', 'Value'])}
+
+## Top Ben Review Rows
+
+${markdownTable(topBenRows, ['Date', 'Vendor', 'Amount', 'Action', 'Risk', 'Reason'])}
+
+## Files
+
+- \`queue.csv\`
+- \`queue.json\`
+
+## Verification Status
+
+- verified: Generated from live Supabase bank-line, receipt-link, Xero transaction, and Xero invoice mirrors.
+- unverified: No Xero UI action, Xero write, attachment upload, or Dext publish was performed by this script.
+`;
+
+  writeFileSync(join(OUT_DIR, 'action-queue.md'), md);
+
+  const provenance = `# Bank-Line Action Queue ${DATE} Provenance
+
+## Purpose
+
+- Output: Q2/Q3 bank-line close action queue.
+- Intended destination: ACT finance close workflow and Xero Page Copilot validation.
+- Why it was generated: Convert receipt/Xero/Dext/project state into one next action per bank line.
+
+## Data Sources Queried
+
+| Source | Type | Range / Snapshot | How it was used |
+|---|---|---|---|
+| \`v_finance_bank_line_evidence\` | Supabase view | ${quarterList.join(', ')} FY${FY} | Base bank-line and evidence status queue. |
+| \`finance_receipt_bank_line_links\` | Supabase table | ${quarterList.join(', ')} FY${FY} | Approved/rejected receipt evidence state. |
+| \`finance_receipt_documents\` | Supabase table | ${quarterList.join(', ')} FY${FY} linked rows | Receipt file/source/Xero target metadata. |
+| \`xero_transactions\` | Supabase mirror | ${quarterList.join(', ')} FY${FY} | Xero target attachment/reconciliation state. |
+| \`xero_invoices\` | Supabase mirror | ${quarterList.join(', ')} FY${FY} | Exact bill candidates for Find & Match. |
+
+## Verification Status
+
+- verified: Report was generated from live Supabase mirrors.
+- inferred: Next action, risk, owner, and Xero coding suggestions are rule-based classifications.
+- unverified: No Xero UI action, Xero write, attachment upload, Dext publish, or BAS lodgement check was performed.
+
+## Reproduction Steps
+
+1. Run \`node scripts/build-bank-line-action-queue.mjs --quarters ${quarterList.join(',')}\`.
+2. Review \`${OUT_DIR}/action-queue.md\`.
+3. Use \`${OUT_DIR}/queue.csv\` for filtered close work.
+`;
+
+  writeFileSync(join(OUT_DIR, 'action-queue.provenance.md'), provenance);
+}
+
+const bankRows = await loadBankRows();
+const [linksByBankLine, transactionsById, invoices] = await Promise.all([
+  loadLinks(),
+  loadXeroTransactions(),
+  loadXeroInvoices(),
+]);
+
+const context = { linksByBankLine, transactionsById, invoices };
+const actionRows = bankRows
+  .map((row) => classifyRow(row, context))
+  .sort((a, b) => {
+    if (a.quarter !== b.quarter) return a.quarter.localeCompare(b.quarter);
+    if (a.risk !== b.risk) return ['high', 'medium', 'low'].indexOf(a.risk) - ['high', 'medium', 'low'].indexOf(b.risk);
+    return b.amount - a.amount;
+  });
+
+writeReports(actionRows);
+
+if (FORMAT === 'json') {
+  console.log(JSON.stringify(actionRows, null, 2));
+} else {
+  const byAction = summarize(actionRows, 'next_action');
+  console.log(`Bank-line action queue generated: ${OUT_DIR}`);
+  console.log(`Rows: ${actionRows.length}`);
+  for (const row of byAction) {
+    console.log(`${row.key}: ${row.count} (${money(row.value)})`);
+  }
+}

--- a/scripts/build-compliance-calendar.mjs
+++ b/scripts/build-compliance-calendar.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Build the unified compliance calendar by merging:
+ *   - Fixed obligations from wiki/finance/compliance-calendar.md (frontmatter)
+ *   - Dynamic grant acquittals from ghl_opportunities.acquittal_due_date
+ *
+ * Produces a single JSON snapshot at:
+ *   thoughts/shared/data/compliance-calendar/YYYY-MM-DD.json
+ *
+ * Severity scoring per item:
+ *   🔴 critical = days_until_due ≤ 7  OR  status='overdue'
+ *   🟠 high     = days_until_due ≤ 30
+ *   🟡 medium   = days_until_due ≤ 90
+ *    -          = days_until_due >  90 (not at-risk)
+ *
+ * Usage:
+ *   node scripts/build-compliance-calendar.mjs              # write today's snapshot
+ *   node scripts/build-compliance-calendar.mjs --dry-run    # print to stdout, don't write
+ *   node scripts/build-compliance-calendar.mjs --stdout     # write AND print
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { config as loadEnv } from 'dotenv'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import yaml from 'js-yaml'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+loadEnv({ path: path.join(REPO, '.env.local') })
+loadEnv({ path: path.join(REPO, '.env') })
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const ALSO_STDOUT = process.argv.includes('--stdout')
+
+const WIKI_PATH = path.join(REPO, 'wiki', 'finance', 'compliance-calendar.md')
+const OUT_DIR = path.join(REPO, 'thoughts', 'shared', 'data', 'compliance-calendar')
+
+const supabase = createClient(
+  process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+)
+
+// ── Frontmatter parser (js-yaml) ──
+
+function parseFrontmatter(md) {
+  const m = md.match(/^---\n([\s\S]*?)\n---/)
+  if (!m) throw new Error('No YAML frontmatter found in wiki file')
+  const doc = yaml.load(m[1])
+  return doc ?? {}
+}
+
+// ── Dynamic grant acquittals ──
+
+async function loadGrantAcquittals() {
+  const { data, error } = await supabase
+    .from('ghl_opportunities')
+    .select('ghl_id, name, project_code, monetary_value, acquittal_due_date, acquittal_status, pipeline_name')
+    .not('acquittal_due_date', 'is', null)
+    .neq('acquittal_status', 'complete')
+  if (error) {
+    console.error(`Warning: failed to load grant acquittals — ${error.message}`)
+    return []
+  }
+  return (data ?? []).map(g => ({
+    id: `grant-acquittal-${g.ghl_id}`,
+    title: `Acquittal: ${g.name ?? 'Unnamed grant'}`,
+    type: 'GRANT_ACQUITTAL',
+    entity: 'pty-ltd',
+    due_date: g.acquittal_due_date,
+    status: g.acquittal_status === 'overdue' ? 'overdue' : 'pending',
+    lead_times_days: [60, 30, 14, 7, 1],
+    notes: `Pipeline: ${g.pipeline_name ?? '—'} · Value: ${g.monetary_value ?? 0}`,
+    owner: 'ben',
+    project_code: g.project_code,
+    source: 'ghl_opportunities',
+    monetary_value: Number(g.monetary_value ?? 0),
+  }))
+}
+
+// ── Severity scoring ──
+
+function daysUntil(dateInput) {
+  if (!dateInput) return null
+  let dueIso
+  if (dateInput instanceof Date) {
+    dueIso = dateInput.toISOString().slice(0, 10)
+  } else if (typeof dateInput === 'string') {
+    dueIso = dateInput.slice(0, 10)
+  } else {
+    return null
+  }
+  const due = new Date(dueIso + 'T00:00:00Z').getTime()
+  const today = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z').getTime()
+  return Math.round((due - today) / (24 * 60 * 60 * 1000))
+}
+
+function normaliseDateField(d) {
+  if (d == null) return null
+  if (d instanceof Date) return d.toISOString().slice(0, 10)
+  return String(d).slice(0, 10)
+}
+
+function severity(item, dDays) {
+  if (item.status === 'filed' || item.status === 'superseded' || item.status === 'waived') return null
+  if (dDays == null) return null
+  if (dDays < 0 || dDays <= 7) return 'critical'
+  if (dDays <= 30) return 'high'
+  if (dDays <= 90) return 'medium'
+  return null
+}
+
+// ── Main ──
+
+async function main() {
+  const md = readFileSync(WIKI_PATH, 'utf8')
+  const fm = parseFrontmatter(md)
+  const wikiObligations = (fm.obligations ?? []).map(o => ({
+    ...o,
+    source: 'wiki',
+    owner: o.owner ?? 'ben',
+  }))
+
+  const grantAcquittals = await loadGrantAcquittals()
+  const all = [...wikiObligations, ...grantAcquittals]
+
+  const enriched = all.map(o => {
+    const dDays = daysUntil(o.due_date)
+    const sev = severity(o, dDays)
+    return {
+      ...o,
+      due_date: normaliseDateField(o.due_date),
+      earliest_filable: normaliseDateField(o.earliest_filable),
+      last_filed_at: normaliseDateField(o.last_filed_at),
+      days_until_due: dDays,
+      severity: sev,
+      at_risk: sev != null,
+    }
+  })
+
+  // Sort: at-risk first by days_until_due asc, then non-at-risk by due_date asc
+  enriched.sort((a, b) => {
+    if (a.at_risk && !b.at_risk) return -1
+    if (!a.at_risk && b.at_risk) return 1
+    if (a.days_until_due == null && b.days_until_due == null) return 0
+    if (a.days_until_due == null) return 1
+    if (b.days_until_due == null) return -1
+    return a.days_until_due - b.days_until_due
+  })
+
+  const counters = enriched.reduce((acc, o) => {
+    if (o.severity === 'critical') acc.critical += 1
+    else if (o.severity === 'high') acc.high += 1
+    else if (o.severity === 'medium') acc.medium += 1
+    else if (o.status === 'filed') acc.filed += 1
+    return acc
+  }, { critical: 0, high: 0, medium: 0, filed: 0 })
+
+  const snapshot = {
+    generatedAt: new Date().toISOString(),
+    sources: {
+      wiki: { path: 'wiki/finance/compliance-calendar.md', count: wikiObligations.length },
+      grants: { table: 'ghl_opportunities', count: grantAcquittals.length },
+    },
+    counters,
+    obligations: enriched,
+  }
+
+  if (ALSO_STDOUT || DRY_RUN) {
+    console.log(JSON.stringify(snapshot, null, 2))
+  }
+  if (DRY_RUN) {
+    console.error(`\nDRY-RUN — would write to ${path.join(OUT_DIR, todayStr() + '.json')}`)
+    console.error(`Totals: ${counters.critical} 🔴 critical · ${counters.high} 🟠 high · ${counters.medium} 🟡 medium · ${counters.filed} ✓ filed`)
+    return
+  }
+
+  if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true })
+  const outPath = path.join(OUT_DIR, todayStr() + '.json')
+  writeFileSync(outPath, JSON.stringify(snapshot, null, 2))
+  console.error(`Wrote ${outPath}`)
+  console.error(`Totals: ${counters.critical} 🔴 critical · ${counters.high} 🟠 high · ${counters.medium} 🟡 medium · ${counters.filed} ✓ filed`)
+}
+
+function todayStr() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/scripts/capture-receipts.mjs
+++ b/scripts/capture-receipts.mjs
@@ -13,9 +13,12 @@
  *   node scripts/capture-receipts.mjs --days 90    # Full backfill
  *   node scripts/capture-receipts.mjs --dry-run    # Preview without saving
  *   node scripts/capture-receipts.mjs --verbose    # Detailed output
+ *   node scripts/capture-receipts.mjs --recapture-forwarded-missing  # Do not treat old Dext forwards as fully captured
  *   node scripts/capture-receipts.mjs --mailbox benjamin@act.place  # Single mailbox
+ *   node scripts/capture-receipts.mjs --user accounts@act.place      # Alias for --mailbox
  */
 
+import './lib/load-env.mjs';
 import { execSync } from 'child_process';
 import { google } from 'googleapis';
 import { createClient } from '@supabase/supabase-js';
@@ -24,12 +27,19 @@ import { recordSyncStatus } from './lib/sync-status.mjs';
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const VERBOSE = args.includes('--verbose');
+const RECAPTURE_FORWARDED_MISSING = args.includes('--recapture-forwarded-missing');
 const daysBack = (() => {
   const idx = args.indexOf('--days');
   return idx !== -1 ? parseInt(args[idx + 1], 10) : 3;
 })();
 const singleMailbox = (() => {
   const idx = args.indexOf('--mailbox');
+  if (idx !== -1) return args[idx + 1];
+  const userIdx = args.indexOf('--user');
+  return userIdx !== -1 ? args[userIdx + 1] : null;
+})();
+const explicitMailboxes = (() => {
+  const idx = args.indexOf('--mailboxes');
   return idx !== -1 ? args[idx + 1] : null;
 })();
 
@@ -68,7 +78,7 @@ function loadSecrets() {
 
 function getSecret(name) {
   const secrets = loadSecrets();
-  return secrets[name] || process.env[name];
+  return process.env[name] || secrets[name];
 }
 
 async function getGmailForUser(userEmail) {
@@ -91,6 +101,7 @@ async function getGmailForUser(userEmail) {
 
 function getDelegatedUsers() {
   if (singleMailbox) return [singleMailbox];
+  if (explicitMailboxes) return explicitMailboxes.split(',').map(e => e.trim()).filter(Boolean);
   const multiUser = getSecret('GOOGLE_DELEGATED_USERS');
   if (multiUser) return multiUser.split(',').map(e => e.trim()).filter(Boolean);
   const singleUser = getSecret('GOOGLE_DELEGATED_USER');
@@ -157,6 +168,7 @@ function loadVendorPatterns() {
     { name: 'Audible', from: ['audible.com', 'audible.com.au'] },
     // === Utilities & Insurance ===
     { name: 'Telstra', from: ['telstra.com', 'telstra.com.au'] },
+    { name: 'Belong', from: ['belong.com.au'] },
     { name: 'AGL', from: ['agl.com.au'] },
     { name: 'Origin Energy', from: ['originenergy.com.au'] },
     { name: 'RACQ', from: ['racq.com.au'] },
@@ -239,6 +251,10 @@ function isLikelyReceipt(subject, from) {
   const subjectLower = (subject || '').toLowerCase();
   const fromLower = (from || '').toLowerCase();
 
+  if (subjectLower.includes('payment is due soon') || subjectLower.includes('payment due soon')) {
+    return false;
+  }
+
   // Strong positive signals — definitely a receipt
   const strongReceiptSignals = [
     'receipt', 'invoice', 'tax invoice', 'your payment', 'payment confirmed',
@@ -266,6 +282,7 @@ function isLikelyReceipt(subject, from) {
     'how to set up', 'how to get', 'save time', 'organize your',
     'invite your', 'to do today', 'top tips', 'data import',
     'overdue acquittal', 'urgent - overdue',
+    'payment is due soon', 'payment due soon',
   ];
   if (marketingSignals.some(s => subjectLower.includes(s))) return false;
 
@@ -283,7 +300,7 @@ function isLikelyReceipt(subject, from) {
 // Vendors that send HTML receipts (no PDF attachment) — need special handling
 const HTML_RECEIPT_VENDORS = new Set([
   'uber', 'apple', 'telstra', 'garmin', 'obsidian',
-  'highlevel', 'mighty networks', 'docplay', 'audible',
+  'belong', 'highlevel', 'mighty networks', 'docplay', 'audible',
 ]);
 
 function isHtmlReceiptVendor(vendorName) {
@@ -495,8 +512,10 @@ async function uploadToStorage(supabase, filePath, fileBuffer, contentType) {
 // ============================================================================
 
 async function getAlreadyCaptured(supabase) {
-  // Fetch all gmail_message_ids from receipt_emails + dext_forwarded_emails
+  // Fetch all gmail_message_ids from receipt_emails. Old Dext forward logs are
+  // only a transport audit; they do not prove a usable receipt/file exists.
   const ids = new Set();
+  const receiptEmailIds = new Set();
 
   // receipt_emails (new pipeline)
   let page = 0;
@@ -508,16 +527,24 @@ async function getAlreadyCaptured(supabase) {
       .not('gmail_message_id', 'is', null)
       .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
     if (error) break;
-    for (const row of data || []) ids.add(row.gmail_message_id);
+    for (const row of data || []) {
+      ids.add(row.gmail_message_id);
+      receiptEmailIds.add(row.gmail_message_id);
+    }
     if (!data || data.length < PAGE_SIZE) break;
     page++;
   }
 
-  // dext_forwarded_emails (old pipeline — don't recapture these)
-  const { data: forwarded } = await supabase
-    .from('dext_forwarded_emails')
-    .select('gmail_message_id');
-  for (const row of forwarded || []) ids.add(row.gmail_message_id);
+  if (!RECAPTURE_FORWARDED_MISSING) {
+    // dext_forwarded_emails (old pipeline) - by default, keep historical
+    // behaviour and do not recapture forwarded messages.
+    const { data: forwarded } = await supabase
+      .from('dext_forwarded_emails')
+      .select('gmail_message_id');
+    for (const row of forwarded || []) ids.add(row.gmail_message_id);
+  }
+
+  ids.receiptEmailCount = receiptEmailIds.size;
 
   return ids;
 }
@@ -531,6 +558,9 @@ async function main() {
   log('=== Receipt Capture (Gmail → Supabase) ===');
   log(`Scanning last ${daysBack} days`);
   if (DRY_RUN) log('DRY RUN — nothing will be saved');
+  if (RECAPTURE_FORWARDED_MISSING) {
+    log('Recapture mode: Dext-forwarded emails without receipt_emails rows will be scanned again');
+  }
 
   const supabase = getSupabase();
   const users = getDelegatedUsers();
@@ -632,9 +662,10 @@ async function main() {
         if (attachments.length === 0) {
           // No PDF attachment — try HTML receipt extraction for known vendors
           let htmlAmount = amount;
+          let htmlPart = null;
           if (isHtmlReceiptVendor(vendor)) {
             // Decode email body HTML
-            const htmlPart = findHtmlPart(fullMessage.payload);
+            htmlPart = findHtmlPart(fullMessage.payload);
             if (htmlPart) {
               const htmlData = extractReceiptFromHtml(htmlPart);
               if (htmlData?.amount && !htmlAmount) htmlAmount = htmlData.amount;
@@ -646,6 +677,16 @@ async function main() {
           totals.noAttachment++;
 
           if (!DRY_RUN) {
+            let uploadedPath = null;
+            let htmlBuffer = null;
+            let htmlFilename = null;
+            if (htmlPart && htmlAmount) {
+              htmlBuffer = Buffer.from(htmlPart, 'utf8');
+              htmlFilename = `${(vendor || 'receipt').replace(/[^a-zA-Z0-9._-]/g, '_')}-${msg.id}.html`;
+              const storagePath = `${userEmail}/${new Date().getFullYear()}/${msg.id}/${htmlFilename}`;
+              uploadedPath = await uploadToStorage(supabase, storagePath, htmlBuffer, 'text/html');
+            }
+
             await supabase.from('receipt_emails').upsert({
               gmail_message_id: msg.id,
               mailbox: userEmail,
@@ -654,6 +695,10 @@ async function main() {
               received_at: msg.date ? new Date(msg.date).toISOString() : null,
               vendor_name: vendor,
               amount_detected: htmlAmount,
+              attachment_url: uploadedPath ? `receipt-attachments/${uploadedPath}` : null,
+              attachment_filename: htmlFilename,
+              attachment_content_type: uploadedPath ? 'text/html' : null,
+              attachment_size_bytes: htmlBuffer?.length || null,
               source: 'gmail',
               status: 'captured',
             }, { onConflict: 'gmail_message_id' });

--- a/scripts/compliance-alerts.mjs
+++ b/scripts/compliance-alerts.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Compliance alerts — daily Telegram nudge for obligations matching T-30/T-7/T-1.
+ *
+ * Reads the latest snapshot at thoughts/shared/data/compliance-calendar/.
+ * Fires Telegram only when an obligation's days_until_due matches EXACTLY one
+ * of its lead_times_days entries (so you don't get nagged every day).
+ *
+ * Cron: daily 7:30am AEST (PM2 entry in ecosystem.config.cjs).
+ *
+ * Usage:
+ *   node scripts/compliance-alerts.mjs              # send if any matches
+ *   node scripts/compliance-alerts.mjs --dry-run    # print message, don't send
+ *   node scripts/compliance-alerts.mjs --force      # send even if no exact match (for testing)
+ */
+
+import { config as loadEnv } from 'dotenv'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { sendTelegram } from './lib/telegram.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+loadEnv({ path: path.join(REPO, '.env.local') })
+loadEnv({ path: path.join(REPO, '.env') })
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const FORCE = process.argv.includes('--force')
+
+const SNAPSHOT_DIR = path.join(REPO, 'thoughts', 'shared', 'data', 'compliance-calendar')
+
+function readLatestSnapshot() {
+  if (!existsSync(SNAPSHOT_DIR)) return null
+  const files = readdirSync(SNAPSHOT_DIR).filter(f => f.endsWith('.json')).sort()
+  if (files.length === 0) return null
+  return JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, files[files.length - 1]), 'utf8'))
+}
+
+const SEV_EMOJI = { critical: '🔴', high: '🟠', medium: '🟡' }
+
+function formatObligation(o, leadTime) {
+  const sev = SEV_EMOJI[o.severity] ?? '⚪'
+  const tag = leadTime != null
+    ? (leadTime === 1 ? `*[T-1 DUE TOMORROW]*` : `[T-${leadTime}]`)
+    : `[${o.days_until_due ?? '?'}d]`
+  const refundLine = o.expected_refund_aud ? `   💰 expected refund: $${o.expected_refund_aud.toLocaleString()}\n` : ''
+  const moneyLine = o.monetary_value ? `   💵 value: $${Number(o.monetary_value).toLocaleString()}\n` : ''
+  return `${sev} ${tag} *${o.title}*\n   📅 due ${o.due_date} · ${o.entity}\n${refundLine}${moneyLine}`
+}
+
+async function main() {
+  const snap = readLatestSnapshot()
+  if (!snap) {
+    console.error('No compliance snapshot found — run `node scripts/build-compliance-calendar.mjs` first')
+    process.exit(2)
+  }
+
+  // For each obligation, find the largest lead_time entry where days_until_due === entry.
+  // (Largest because if both T-30 and T-7 match — they shouldn't on the same day —
+  // we want the most actionable signal. In practice exactly one matches per day.)
+  const matches = []
+  for (const o of snap.obligations) {
+    if (!o.lead_times_days || !o.severity) continue
+    const dd = o.days_until_due
+    if (dd == null) continue
+    const matchingLead = o.lead_times_days.find(d => d === dd)
+    if (matchingLead != null) matches.push({ o, leadTime: matchingLead })
+    else if (dd < 0 && o.severity === 'critical') matches.push({ o, leadTime: null }) // overdue
+  }
+
+  if (matches.length === 0 && !FORCE) {
+    console.log('No lead-time matches today — no Telegram sent.')
+    return
+  }
+
+  const today = new Date().toISOString().slice(0, 10)
+  const lines = [
+    `📋 *Compliance alerts — ${today}*`,
+    '',
+  ]
+  for (const { o, leadTime } of matches) {
+    lines.push(formatObligation(o, leadTime))
+  }
+  if (matches.length === 0 && FORCE) {
+    lines.push('_No matches today — forced send for testing._')
+  }
+  lines.push('')
+  lines.push('📖 Full calendar: https://github.com/Acurioustractor/act-global-infrastructure/blob/main/wiki/finance/compliance-calendar.md')
+  lines.push('🎯 Operate: https://command.act.place/finance/command')
+
+  const message = lines.join('\n')
+  console.log(message)
+  console.log('')
+
+  if (DRY_RUN) {
+    console.log('--- DRY-RUN — Telegram NOT sent ---')
+    return
+  }
+
+  const ok = await sendTelegram(message)
+  console.log(ok ? '✓ Sent' : '✗ Telegram send failed (check env)')
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/scripts/compute-project-health.mjs
+++ b/scripts/compute-project-health.mjs
@@ -46,34 +46,54 @@ if (loadError) {
 
 const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
 
+async function fetchAllRows(buildQuery, label) {
+  const rows = [];
+  const pageSize = 1000;
+
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await buildQuery()
+      .range(from, from + pageSize - 1);
+
+    if (error) {
+      throw new Error(`${label}: ${error.message}`);
+    }
+    if (!data || data.length === 0) break;
+
+    rows.push(...data);
+    if (data.length < pageSize) break;
+  }
+
+  return rows;
+}
+
 async function computeProjectHealth(code, project) {
   // Parallel fetch all metrics
   const [
-    txResult,
-    invResult,
-    oppsResult,
+    transactions,
+    invoices,
+    opportunities,
     contactsResult,
     emailsResult,
-    grantsResult,
-    subsResult,
+    grants,
+    subs,
   ] = await Promise.all([
     // Transactions
-    supabase
+    fetchAllRows(() => supabase
       .from('xero_transactions')
       .select('total, type')
-      .eq('project_code', code),
+      .eq('project_code', code), `xero_transactions:${code}`),
 
     // Invoices
-    supabase
+    fetchAllRows(() => supabase
       .from('xero_invoices')
       .select('total, amount_due, type')
-      .eq('project_code', code),
+      .eq('project_code', code), `xero_invoices:${code}`),
 
     // GHL opportunities
-    supabase
+    fetchAllRows(() => supabase
       .from('ghl_opportunities')
       .select('monetary_value, status')
-      .eq('project_code', code),
+      .eq('project_code', code), `ghl_opportunities:${code}`),
 
     // GHL contacts (by tag)
     supabase
@@ -88,24 +108,18 @@ async function computeProjectHealth(code, project) {
       .contains('project_codes', [code]),
 
     // Grant applications
-    supabase
+    fetchAllRows(() => supabase
       .from('grant_applications')
       .select('status, amount_requested, outcome_amount')
-      .eq('project_code', code),
+      .eq('project_code', code), `grant_applications:${code}`),
 
     // Subscriptions
-    supabase
+    fetchAllRows(() => supabase
       .from('subscriptions')
       .select('amount')
       .contains('project_codes', [code])
-      .eq('account_status', 'active'),
+      .eq('account_status', 'active'), `subscriptions:${code}`),
   ]);
-
-  const transactions = txResult.data || [];
-  const invoices = invResult.data || [];
-  const opportunities = oppsResult.data || [];
-  const grants = grantsResult.data || [];
-  const subs = subsResult.data || [];
 
   // Financial metrics
   let income = 0, expenses = 0;

--- a/scripts/generate-dext-routing-pack.mjs
+++ b/scripts/generate-dext-routing-pack.mjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+/**
+ * Generate a human setup pack for Dext sections, supplier rules, project
+ * tracking, and safe publish policies.
+ *
+ * Usage:
+ *   node scripts/generate-dext-routing-pack.mjs
+ *   node scripts/generate-dext-routing-pack.mjs --csv Dext/nicholas-marchesi-2026-05-15.csv
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const DATE = todayInBrisbane();
+const CONFIG_PATH = 'config/dext-routing-sections.json';
+const DEFAULT_CSV = 'Dext/nicholas-marchesi-2026-05-15.csv';
+const CSV_PATH = valueAfter('--csv') || (existsSync(DEFAULT_CSV) ? DEFAULT_CSV : null);
+const OUT_DIR = join('thoughts', 'shared', 'reports', `dext-routing-pack-${DATE}`);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function todayInBrisbane() {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Australia/Brisbane',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        field += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+    if (ch === ',' && !inQuotes) {
+      row.push(field);
+      field = '';
+      continue;
+    }
+    if ((ch === '\n' || ch === '\r') && !inQuotes) {
+      if (ch === '\r' && text[i + 1] === '\n') i += 1;
+      row.push(field);
+      if (row.some((value) => value.length > 0)) rows.push(row);
+      row = [];
+      field = '';
+      continue;
+    }
+    field += ch;
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    if (row.some((value) => value.length > 0)) rows.push(row);
+  }
+
+  const [headers, ...dataRows] = rows;
+  return dataRows.map((values) => Object.fromEntries(headers.map((header, index) => [header, values[index] || ''])));
+}
+
+function parseNumber(value) {
+  const cleaned = String(value || '').replace(/[^0-9.-]/g, '');
+  const number = Number(cleaned);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function csvEscape(value) {
+  const string = value === null || value === undefined ? '' : String(value);
+  if (!/[",\n]/.test(string)) return string;
+  return `"${string.replace(/"/g, '""')}"`;
+}
+
+function writeCsv(path, rows, headers) {
+  const lines = [
+    headers.join(','),
+    ...rows.map((row) => headers.map((header) => csvEscape(row[header])).join(',')),
+  ];
+  writeFileSync(path, `${lines.join('\n')}\n`);
+}
+
+function supplierRoute(config, supplier) {
+  const normalized = String(supplier || '').toLowerCase();
+  for (const group of config.supplier_defaults) {
+    for (const candidate of group.suppliers) {
+      if (normalized.includes(candidate.toLowerCase()) || candidate.toLowerCase().includes(normalized)) {
+        return group;
+      }
+    }
+  }
+  return null;
+}
+
+function summarizeExport(config) {
+  if (!CSV_PATH || !existsSync(CSV_PATH)) return { rows: [], supplierRows: [], categoryRows: [] };
+  const rows = parseCsv(readFileSync(CSV_PATH, 'utf8'));
+  const suppliers = new Map();
+  const categories = new Map();
+
+  for (const row of rows) {
+    const supplier = row.Supplier?.trim() || '(blank)';
+    const category = row.Category?.trim() || '(blank)';
+    const amount = Math.abs(parseNumber(row['Total (AUD)']));
+
+    const supplierEntry = suppliers.get(supplier) || { supplier, count: 0, amount: 0 };
+    supplierEntry.count += 1;
+    supplierEntry.amount += amount;
+    suppliers.set(supplier, supplierEntry);
+
+    const categoryEntry = categories.get(category) || { category, count: 0, amount: 0 };
+    categoryEntry.count += 1;
+    categoryEntry.amount += amount;
+    categories.set(category, categoryEntry);
+  }
+
+  const supplierRows = [...suppliers.values()]
+    .sort((a, b) => b.count - a.count || b.amount - a.amount)
+    .map((entry) => {
+      const route = supplierRoute(config, entry.supplier);
+      return {
+        supplier: entry.supplier,
+        receipt_count: entry.count,
+        total_aud_abs: entry.amount.toFixed(2),
+        suggested_category: route?.category || 'Manual review',
+        suggested_project: route?.project || 'ASK_USER',
+        payment_method: route?.payment_method || 'review',
+        publish_destination: route?.publish_destination || 'Manual review',
+        auto_publish: route?.auto_publish ?? false,
+        rd_default: route?.rd_default || 'review',
+      };
+    });
+
+  const categoryRows = [...categories.values()]
+    .sort((a, b) => b.count - a.count || b.amount - a.amount)
+    .map((entry) => {
+      const route = config.category_defaults.find((item) => item.dext_category === entry.category);
+      return {
+        category: entry.category,
+        receipt_count: entry.count,
+        total_aud_abs: entry.amount.toFixed(2),
+        default_project: route?.default_project || 'ASK_USER',
+        tax_rate: route?.tax_rate || 'review',
+        rd_default: route?.rd_default || 'review',
+        publish_policy: route?.publish_policy || 'manual_review',
+        notes: route?.notes || '',
+      };
+    });
+
+  return { rows, supplierRows, categoryRows };
+}
+
+function bulletList(items) {
+  return items.map((item) => `- ${item}`).join('\n');
+}
+
+function fieldValueLabel(value) {
+  if (value.code && value.name) return `${value.code} · ${value.name}`;
+  return value.name || value.code || '';
+}
+
+const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+const exportSummary = summarizeExport(config);
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+writeCsv(join(OUT_DIR, 'dext-supplier-routing.csv'), exportSummary.supplierRows, [
+  'supplier',
+  'receipt_count',
+  'total_aud_abs',
+  'suggested_category',
+  'suggested_project',
+  'payment_method',
+  'publish_destination',
+  'auto_publish',
+  'rd_default',
+]);
+
+writeCsv(join(OUT_DIR, 'dext-category-routing.csv'), exportSummary.categoryRows, [
+  'category',
+  'receipt_count',
+  'total_aud_abs',
+  'default_project',
+  'tax_rate',
+  'rd_default',
+  'publish_policy',
+  'notes',
+]);
+
+const fieldRows = [];
+for (const field of config.dext_fields_to_configure) {
+  for (const value of field.values) {
+    fieldRows.push({
+      field: field.field,
+      required: field.required,
+      name_or_code: fieldValueLabel(value),
+      use_for: value.use_for,
+      xero_destination: value.xero_destination || '',
+      default_publish: value.default_publish || '',
+    });
+  }
+}
+writeCsv(join(OUT_DIR, 'dext-fields-to-add.csv'), fieldRows, [
+  'field',
+  'required',
+  'name_or_code',
+  'use_for',
+  'xero_destination',
+  'default_publish',
+]);
+
+const md = [
+  '# Dext Routing Pack',
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  `Config: ${CONFIG_PATH}`,
+  CSV_PATH ? `Dext export: ${CSV_PATH}` : 'Dext export: not provided',
+  '',
+  '## Operating Rule',
+  '',
+  'Dext is the evidence/OCR intake. Xero is the accounting source of truth. Supabase/workbench is the review queue. For historical cleanup, do not bulk publish from Dext unless a bank line and Xero action are known.',
+  '',
+  '## Global Settings',
+  '',
+  `- Legacy cleanup auto-publish default: ${config.global_settings.legacy_cleanup_mode.auto_publish_default}`,
+  `- Legacy paid card destination: ${config.global_settings.legacy_cleanup_mode.publish_destination_for_paid_card_spend}`,
+  `- New ACT Pty auto-publish default: ${config.global_settings.new_act_pty_mode.auto_publish_default}`,
+  `- Auto-publish sample requirement: ${config.global_settings.new_act_pty_mode.sample_requirement}`,
+  '',
+  '## Dext Fields To Add',
+  '',
+  '| Field | Value | Use | Destination / Publish |',
+  '|---|---|---|---|',
+  ...fieldRows.map((row) => `| ${row.field} | ${row.name_or_code} | ${row.use_for} | ${[row.xero_destination, row.default_publish].filter(Boolean).join(' / ')} |`),
+  '',
+  '## Category Defaults',
+  '',
+  '| Dext Category | Project | Tax | R&D | Publish | Notes |',
+  '|---|---|---|---|---|---|',
+  ...config.category_defaults.map((row) => `| ${row.dext_category} | ${row.default_project} | ${row.tax_rate} | ${row.rd_default} | ${row.publish_policy} | ${row.notes} |`),
+  '',
+  '## Supplier Groups',
+  '',
+  ...config.supplier_defaults.map((group) => [
+    `### ${group.category}`,
+    '',
+    `- Suppliers: ${group.suppliers.join(', ')}`,
+    `- Project: ${group.project}`,
+    `- Payment method: ${group.payment_method}`,
+    `- Publish destination: ${group.publish_destination}`,
+    `- Auto-publish: ${group.auto_publish}`,
+    `- R&D: ${group.rd_default}`,
+    '',
+  ].join('\n')),
+  '## Never Auto-Publish',
+  '',
+  bulletList(config.never_auto_publish),
+  '',
+  '## Latest Dext Export Summary',
+  '',
+  `- Parsed export rows: ${exportSummary.rows.length}`,
+  `- Supplier rows in CSV: ${exportSummary.supplierRows.length}`,
+  `- Category rows in CSV: ${exportSummary.categoryRows.length}`,
+  '',
+  '### Top Supplier Routing',
+  '',
+  '| Supplier | Count | Amount | Project | Category | Auto-publish |',
+  '|---|---:|---:|---|---|---|',
+  ...exportSummary.supplierRows.slice(0, 40).map((row) => `| ${row.supplier} | ${row.receipt_count} | $${row.total_aud_abs} | ${row.suggested_project} | ${row.suggested_category} | ${row.auto_publish} |`),
+  '',
+  '## Output Files',
+  '',
+  `- ${join(OUT_DIR, 'dext-fields-to-add.csv')}`,
+  `- ${join(OUT_DIR, 'dext-category-routing.csv')}`,
+  `- ${join(OUT_DIR, 'dext-supplier-routing.csv')}`,
+  '',
+  '## Verification Status',
+  '',
+  'verified: Generated from config/dext-routing-sections.json and the latest Dext CSV export when present.',
+  'inferred: Suggested project/category/routing is based on configured ACT bookkeeping rules and vendor names, not Dext UI state.',
+  'unverified: No live Dext settings were changed or checked by this script.',
+  '',
+].join('\n');
+
+writeFileSync(join(OUT_DIR, 'README.md'), md);
+writeFileSync(join(OUT_DIR, 'README.md.provenance.md'), [
+  '# Provenance - Dext Routing Pack',
+  '',
+  `Report: ${join(OUT_DIR, 'README.md')}`,
+  `Generated: ${new Date().toISOString()}`,
+  `Command: node scripts/generate-dext-routing-pack.mjs${CSV_PATH ? ` --csv ${CSV_PATH}` : ''}`,
+  '',
+  '## Sources',
+  '',
+  `- ${CONFIG_PATH}`,
+  CSV_PATH ? `- ${CSV_PATH}` : '- No Dext export CSV used',
+  '',
+  '## Verified',
+  '',
+  '- Config file was parsed.',
+  CSV_PATH ? '- Dext export CSV was parsed with multiline-safe parser.' : '- No CSV parse was needed.',
+  '- Output CSV and Markdown files were written locally.',
+  '',
+  '## Unknown',
+  '',
+  '- Live Dext supplier rules and Xero connection settings.',
+  '- Whether suggested mappings have been applied inside Dext.',
+  '',
+].join('\n'));
+
+console.log('Dext routing pack generated');
+console.log(`  Config:       ${CONFIG_PATH}`);
+console.log(`  Dext export:  ${CSV_PATH || '(none)'}`);
+console.log(`  Suppliers:    ${exportSummary.supplierRows.length}`);
+console.log(`  Categories:   ${exportSummary.categoryRows.length}`);
+console.log(`  Report:       ${join(OUT_DIR, 'README.md')}`);

--- a/scripts/idea-board-reminders.mjs
+++ b/scripts/idea-board-reminders.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Pilot lifecycle reminder cron — Pass 2B B4.
+ *
+ * Stage-aware staleness ladder (Q4):
+ *   idea       → 90 days   (still raw — gentle nudge)
+ *   scope      → 30 days   (actively shaping — push)
+ *   fundraise  → 14 days   (asking for money — chase)
+ *   start      → never     (in flight, look-back only)
+ *   killed     → never     (terminal)
+ *
+ * Snooze cap (Q6): 3 per idea. Snoozed-burned ideas tagged in DM.
+ *
+ * Cap (Q4): max 5 per owner per nightly DM to avoid overwhelm. Stalest items first.
+ *
+ * Cron: daily 8:00am AEST (PM2 entry in ecosystem.config.cjs).
+ *
+ * Usage:
+ *   node scripts/idea-board-reminders.mjs              # send if any stale
+ *   node scripts/idea-board-reminders.mjs --dry-run    # print, don't send
+ *   node scripts/idea-board-reminders.mjs --owner ben  # only for one owner
+ */
+
+import { config as loadEnv } from 'dotenv';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+import { sendTelegram, buildInlineKeyboard } from './lib/telegram.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..');
+loadEnv({ path: path.join(REPO, '.env.local') });
+loadEnv({ path: path.join(REPO, '.env') });
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const ownerIdx = process.argv.indexOf('--owner');
+const OWNER_FILTER = ownerIdx >= 0 ? process.argv[ownerIdx + 1] : null;
+
+const STAGE_STALE_DAYS = {
+  idea: 90,
+  scope: 30,
+  fundraise: 14,
+};
+
+const MAX_PER_DM = 5;
+const SNOOZE_LIMIT = 3;
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } },
+);
+
+function chatIdForOwner(owner) {
+  // Per-owner override (e.g. TELEGRAM_CHAT_ID_NIC). Falls back to default TELEGRAM_CHAT_ID for ben.
+  const upper = owner.toUpperCase();
+  return process.env[`TELEGRAM_CHAT_ID_${upper}`] ?? process.env.TELEGRAM_CHAT_ID;
+}
+
+async function loadStaleIdeas() {
+  const now = new Date();
+  const thresholdISOByStage = Object.fromEntries(
+    Object.entries(STAGE_STALE_DAYS).map(([stage, days]) => {
+      const t = new Date(now);
+      t.setUTCDate(t.getUTCDate() - days);
+      return [stage, t.toISOString()];
+    }),
+  );
+
+  // Pull all candidate stages in one query, filter staleness in JS for clarity.
+  // stage_entered_at is the canonical "time in current stage" — set on every
+  // transition. updated_at moves on every edit (trigger), so it can't be used.
+  let q = supabase
+    .from('idea_board')
+    .select('id, text, lifecycle_stage, owner, stage_entered_at, created_at, value_estimate')
+    .in('lifecycle_stage', Object.keys(STAGE_STALE_DAYS));
+  if (OWNER_FILTER) q = q.eq('owner', OWNER_FILTER);
+  const { data: rows, error } = await q;
+  if (error) throw new Error(`Failed to load idea_board: ${error.message}`);
+
+  const stale = (rows ?? []).filter((r) => {
+    const stage = r.lifecycle_stage;
+    const threshold = thresholdISOByStage[stage];
+    const stageStartedAt = r.stage_entered_at ?? r.created_at;
+    return threshold && stageStartedAt < threshold;
+  });
+
+  // Active snooze check — exclude ideas whose latest snooze hasn't expired yet.
+  const ids = stale.map((r) => r.id);
+  let activeSnoozes = new Set();
+  let snoozeCounts = new Map();
+  if (ids.length > 0) {
+    const { data: snoozes } = await supabase
+      .from('idea_snoozes')
+      .select('idea_id, snoozed_until')
+      .in('idea_id', ids);
+    const todayDate = now.toISOString().slice(0, 10);
+    for (const s of snoozes ?? []) {
+      snoozeCounts.set(s.idea_id, (snoozeCounts.get(s.idea_id) ?? 0) + 1);
+      if (s.snoozed_until > todayDate) activeSnoozes.add(s.idea_id);
+    }
+  }
+
+  return stale
+    .filter((r) => !activeSnoozes.has(r.id))
+    .map((r) => {
+      const stageStartedAt = r.stage_entered_at ?? r.created_at;
+      const ageDays = Math.floor((now - new Date(stageStartedAt)) / (1000 * 60 * 60 * 24));
+      const snoozeCount = snoozeCounts.get(r.id) ?? 0;
+      return { ...r, ageDays, snoozeCount, snoozeBurned: snoozeCount >= SNOOZE_LIMIT };
+    });
+}
+
+function buildKeyboardRows(idea) {
+  const id = idea.id;
+  const stage = idea.lifecycle_stage;
+  const rows = [];
+
+  const progressionButtons = [];
+  if (stage === 'idea' || stage === 'scope') {
+    progressionButtons.push({ text: '→ fundraise', callbackData: `idea:to_fundraise:${id}` });
+  }
+  if (stage === 'fundraise' || stage === 'scope') {
+    progressionButtons.push({ text: '→ start', callbackData: `idea:to_start:${id}` });
+  }
+  if (progressionButtons.length > 0) rows.push(progressionButtons);
+
+  const decisionRow = [{ text: '❌ kill', callbackData: `idea:kill:${id}` }];
+  if (!idea.snoozeBurned) {
+    decisionRow.push({ text: '💤 snooze 14d', callbackData: `idea:snooze:${id}:14` });
+  }
+  rows.push(decisionRow);
+
+  return rows;
+}
+
+function formatIdeaLine(idea) {
+  const stageEmoji = { idea: '💡', scope: '🔍', fundraise: '💸' };
+  const emoji = stageEmoji[idea.lifecycle_stage] ?? '•';
+  const burnedTag = idea.snoozeBurned ? ' · 💤×3 forced decision' : idea.snoozeCount > 0 ? ` · 💤×${idea.snoozeCount}` : '';
+  const valueTag = idea.value_estimate > 0 ? ` · ~$${Number(idea.value_estimate).toLocaleString()}` : '';
+  const text = idea.text.length > 100 ? idea.text.slice(0, 97) + '…' : idea.text;
+  return `${emoji} *${idea.lifecycle_stage}* · ${idea.ageDays}d idle${valueTag}${burnedTag}\n   _${escapeMd(text)}_`;
+}
+
+function escapeMd(s) {
+  return String(s).replace(/([_*[\]()~`>#+\-=|{}.!])/g, '\\$1');
+}
+
+async function main() {
+  const stale = await loadStaleIdeas();
+  if (stale.length === 0) {
+    console.log('No stale ideas across any owner — no reminders sent.');
+    return;
+  }
+
+  // Group by owner, oldest first, cap.
+  const byOwner = new Map();
+  for (const idea of stale) {
+    if (!byOwner.has(idea.owner)) byOwner.set(idea.owner, []);
+    byOwner.get(idea.owner).push(idea);
+  }
+
+  for (const [owner, items] of byOwner.entries()) {
+    items.sort((a, b) => b.ageDays - a.ageDays);
+    const shown = items.slice(0, MAX_PER_DM);
+    const overflow = items.length - shown.length;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const headerLines = [
+      `💡 *Pilot lifecycle nudge — ${today}*`,
+      `_${shown.length}${overflow > 0 ? ` of ${items.length}` : ''} stale idea${items.length === 1 ? '' : 's'} need a move_`,
+      '',
+    ];
+
+    const chatId = chatIdForOwner(owner);
+
+    if (DRY_RUN) {
+      console.log(`\n=== owner=${owner} chat=${chatId ?? '<unset>'} ===`);
+      console.log(headerLines.join('\n'));
+      for (const idea of shown) {
+        console.log('\n' + formatIdeaLine(idea));
+        console.log('  buttons:', JSON.stringify(buildKeyboardRows(idea)));
+      }
+      if (overflow > 0) console.log(`\n(…${overflow} more capped — view at /ideas)`);
+      continue;
+    }
+
+    if (!chatId) {
+      console.warn(`No chat ID for owner=${owner} (set TELEGRAM_CHAT_ID_${owner.toUpperCase()} or TELEGRAM_CHAT_ID); skipping`);
+      continue;
+    }
+
+    await sendTelegram(headerLines.join('\n'), { chatId });
+    for (const idea of shown) {
+      const replyMarkup = buildInlineKeyboard(buildKeyboardRows(idea));
+      await sendTelegram(formatIdeaLine(idea), { replyMarkup, chatId });
+    }
+    if (overflow > 0) {
+      await sendTelegram(`…${overflow} more capped — view at /ideas`, { chatId });
+    }
+    console.log(`Sent ${shown.length} reminders to owner=${owner}${overflow > 0 ? ` (+${overflow} overflow)` : ''}`);
+  }
+}
+
+main().catch((err) => {
+  console.error('idea-board-reminders failed:', err);
+  process.exit(1);
+});

--- a/scripts/import-dext-export-evidence.mjs
+++ b/scripts/import-dext-export-evidence.mjs
@@ -1,0 +1,459 @@
+#!/usr/bin/env node
+/**
+ * Import a Dext CSV + local PDF/JPG export into the canonical receipt evidence
+ * table. This does not write to Xero or reconcile anything.
+ *
+ * Usage:
+ *   node scripts/import-dext-export-evidence.mjs /path/export.csv --files-dir /path/export-folder
+ *   node scripts/import-dext-export-evidence.mjs /path/export.csv --files-dir /path/export-folder --apply
+ */
+
+import './lib/load-env.mjs';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  throw new Error('Missing Supabase URL/service role env vars');
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const csvPath = args.find((arg) => !arg.startsWith('--'));
+const APPLY = args.includes('--apply');
+const filesDir = valueAfter('--files-dir');
+const DATE = todayInBrisbane();
+const OUT_DIR = join('thoughts', 'shared', 'reports', `dext-export-evidence-${DATE}`);
+const STORAGE_PREFIX = `dext-export/${DATE}`;
+
+if (!csvPath) {
+  console.error('Usage: node scripts/import-dext-export-evidence.mjs <csv-path> --files-dir <folder> [--apply]');
+  process.exit(1);
+}
+
+if (!existsSync(csvPath)) throw new Error(`CSV not found: ${csvPath}`);
+if (!filesDir || !existsSync(filesDir)) throw new Error(`Files directory not found: ${filesDir || '(missing)'}`);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1];
+}
+
+function todayInBrisbane() {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Australia/Brisbane',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (ch === '"') {
+      if (inQuotes && text[i + 1] === '"') {
+        field += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (ch === ',' && !inQuotes) {
+      row.push(field);
+      field = '';
+      continue;
+    }
+
+    if ((ch === '\n' || ch === '\r') && !inQuotes) {
+      if (ch === '\r' && text[i + 1] === '\n') i += 1;
+      row.push(field);
+      if (row.some((value) => value.length > 0)) rows.push(row);
+      row = [];
+      field = '';
+      continue;
+    }
+
+    field += ch;
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    if (row.some((value) => value.length > 0)) rows.push(row);
+  }
+
+  const [headers, ...dataRows] = rows;
+  return dataRows.map((values) => Object.fromEntries(headers.map((header, index) => [header, values[index] || ''])));
+}
+
+const MONTHS = {
+  Jan: '01',
+  Feb: '02',
+  Mar: '03',
+  Apr: '04',
+  May: '05',
+  Jun: '06',
+  Jul: '07',
+  Aug: '08',
+  Sep: '09',
+  Oct: '10',
+  Nov: '11',
+  Dec: '12',
+};
+
+function parseDextDate(value) {
+  const match = String(value || '').trim().match(/^(\d{1,2})-([A-Za-z]{3})-(\d{4})$/);
+  if (!match) return null;
+  const day = match[1].padStart(2, '0');
+  const month = MONTHS[match[2]];
+  if (!month) return null;
+  return `${match[3]}-${month}-${day}`;
+}
+
+function parseNumber(value) {
+  const cleaned = String(value || '').replace(/[^0-9.-]/g, '');
+  if (!cleaned) return null;
+  const number = Number(cleaned);
+  return Number.isFinite(number) ? number : null;
+}
+
+function cleanText(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function compactText(value) {
+  return cleanText(value).replace(/\s+/g, '');
+}
+
+function contentTypeFor(path) {
+  const ext = extname(path).toLowerCase();
+  if (ext === '.pdf') return 'application/pdf';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.png') return 'image/png';
+  return 'application/octet-stream';
+}
+
+function scoreFile(record, fileName) {
+  const haystack = compactText(fileName);
+  const supplier = compactText(record.supplier);
+  const number = compactText(record.documentNumber);
+  const date = String(record.documentDate || '').replace(/-/g, '');
+  let score = 0;
+  if (number && haystack.includes(number)) score += 5;
+  if (date && haystack.includes(date)) score += 3;
+  if (supplier && haystack.includes(supplier.slice(0, Math.min(20, supplier.length)))) score += 2;
+  return score;
+}
+
+function findFile(record, files) {
+  const ranked = files
+    .map((file) => ({ file, score: scoreFile(record, basename(file)) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return ranked[0]?.file || null;
+}
+
+function money(value) {
+  return Number(value || 0).toLocaleString('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    minimumFractionDigits: 2,
+  });
+}
+
+function csvEscape(value) {
+  const string = value === null || value === undefined ? '' : String(value);
+  if (!/[",\n]/.test(string)) return string;
+  return `"${string.replace(/"/g, '""')}"`;
+}
+
+function writeCsv(path, rows, headers) {
+  const lines = [
+    headers.join(','),
+    ...rows.map((row) => headers.map((header) => csvEscape(row[header])).join(',')),
+  ];
+  writeFileSync(path, `${lines.join('\n')}\n`);
+}
+
+async function uploadFile(record) {
+  if (!record.localFilePath) return null;
+  const body = readFileSync(record.localFilePath);
+  const ext = extname(record.localFilePath).toLowerCase() || '.bin';
+  const safeId = String(record.receiptId).replace(/[^a-zA-Z0-9_-]/g, '-');
+  const storagePath = `${STORAGE_PREFIX}/${safeId}${ext}`;
+  const contentType = contentTypeFor(record.localFilePath);
+
+  const { error } = await sb.storage
+    .from('receipt-attachments')
+    .upload(storagePath, body, { contentType, upsert: true });
+  if (error) throw new Error(`Storage upload failed for ${record.receiptId}: ${error.message}`);
+
+  return {
+    storagePath,
+    contentType,
+    size: body.length,
+    sha256: createHash('sha256').update(body).digest('hex'),
+  };
+}
+
+const rawRecords = parseCsv(readFileSync(csvPath, 'utf8'));
+const files = readdirSync(filesDir)
+  .map((file) => join(filesDir, file))
+  .filter((file) => statSync(file).isFile());
+
+const records = rawRecords.map((row) => {
+  const receiptId = row['Receipt ID']?.trim();
+  const documentDate = parseDextDate(row.Date);
+  const totalAud = parseNumber(row['Total (AUD)']);
+  const totalOriginal = parseNumber(row.Total);
+  const taxAud = parseNumber(row['Tax (AUD)']);
+  const supplier = row.Supplier?.trim() || null;
+  const documentNumber = row['Invoice Number']?.trim() || null;
+  const normalized = {
+    receiptId,
+    supplier,
+    documentDate,
+    documentNumber,
+    totalAud,
+    totalOriginal,
+    taxAud,
+    currency: row.Currency?.trim() || 'AUD',
+    category: row.Category?.trim() || null,
+    project: row.Project?.trim() || null,
+    project2: row['Project 2']?.trim() || null,
+    paymentMethod: row['Payment Method']?.trim() || null,
+    bankAccount: row['Bank Account']?.trim() || null,
+    status: row.Status?.trim() || null,
+    owner: row.Owner?.trim() || null,
+    image: row.Image?.trim() || null,
+    raw: row,
+  };
+  normalized.localFilePath = findFile(normalized, files);
+  return normalized;
+});
+
+const valid = records.filter((record) => record.receiptId && record.documentDate && record.totalAud !== null);
+const invalid = records.filter((record) => !valid.includes(record));
+const missingFiles = valid.filter((record) => !record.localFilePath);
+const nonZero = valid.filter((record) => Math.abs(record.totalAud || 0) > 0.005);
+const statusCounts = new Map();
+const supplierCounts = new Map();
+for (const record of valid) {
+  statusCounts.set(record.status || 'Unknown', (statusCounts.get(record.status || 'Unknown') || 0) + 1);
+  supplierCounts.set(record.supplier || '(blank)', (supplierCounts.get(record.supplier || '(blank)') || 0) + 1);
+}
+
+let upserted = 0;
+let uploaded = 0;
+let errors = 0;
+const importRows = [];
+
+if (APPLY) {
+  for (const record of valid) {
+    try {
+      const upload = await uploadFile(record);
+      if (upload) uploaded += 1;
+
+      const row = {
+        source: 'dext_receipt',
+        source_record_id: record.receiptId,
+        source_table: 'dext_export',
+        subject: record.supplier ? `Dext export receipt from ${record.supplier}` : 'Dext export receipt',
+        received_at: record.documentDate ? `${record.documentDate}T00:00:00+10:00` : null,
+        vendor_name: record.supplier,
+        document_number: record.documentNumber,
+        document_date: record.documentDate,
+        amount_total: record.totalAud,
+        tax_amount: record.taxAud,
+        currency_code: 'AUD',
+        attachment_url: upload?.storagePath || record.image || null,
+        attachment_storage_path: upload?.storagePath || null,
+        attachment_filename: record.localFilePath ? basename(record.localFilePath) : null,
+        attachment_content_type: upload?.contentType || (record.localFilePath ? contentTypeFor(record.localFilePath) : null),
+        attachment_size_bytes: upload?.size || null,
+        file_sha256: upload?.sha256 || null,
+        project_code: record.project || null,
+        extracted_fields: {
+          category: record.category,
+          currency_original: record.currency,
+          total_original: record.totalOriginal,
+          project_2: record.project2,
+          payment_method: record.paymentMethod,
+          bank_account: record.bankAccount,
+          dext_status: record.status,
+          owner: record.owner,
+          image_url: record.image,
+        },
+        provenance: {
+          imported_by: 'scripts/import-dext-export-evidence.mjs',
+          csv_path: csvPath,
+          files_dir: filesDir,
+          imported_at: new Date().toISOString(),
+        },
+        status: 'candidate',
+        updated_at: new Date().toISOString(),
+      };
+
+      const { error } = await sb
+        .from('finance_receipt_documents')
+        .upsert(row, { onConflict: 'source,source_record_id' });
+      if (error) throw error;
+      upserted += 1;
+    } catch (error) {
+      errors += 1;
+      console.error(`ERROR ${record.receiptId}: ${error.message}`);
+    }
+  }
+}
+
+mkdirSync(OUT_DIR, { recursive: true });
+
+for (const record of valid) {
+  importRows.push({
+    receipt_id: record.receiptId,
+    date: record.documentDate,
+    supplier: record.supplier,
+    invoice_number: record.documentNumber,
+    amount_aud: record.totalAud,
+    tax_aud: record.taxAud,
+    category: record.category,
+    project: record.project,
+    status: record.status,
+    local_file: record.localFilePath || '',
+    file_found: record.localFilePath ? 'yes' : 'no',
+    image: record.image,
+  });
+}
+
+writeCsv(join(OUT_DIR, 'dext-export-records.csv'), importRows, [
+  'receipt_id',
+  'date',
+  'supplier',
+  'invoice_number',
+  'amount_aud',
+  'tax_aud',
+  'category',
+  'project',
+  'status',
+  'file_found',
+  'local_file',
+  'image',
+]);
+
+writeCsv(join(OUT_DIR, 'missing-local-files.csv'), missingFiles.map((record) => ({
+  receipt_id: record.receiptId,
+  date: record.documentDate,
+  supplier: record.supplier,
+  invoice_number: record.documentNumber,
+  amount_aud: record.totalAud,
+  image: record.image,
+})), ['receipt_id', 'date', 'supplier', 'invoice_number', 'amount_aud', 'image']);
+
+const topSuppliers = [...supplierCounts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 20);
+const summary = [
+  '# Dext Export Evidence Import',
+  '',
+  `Generated: ${new Date().toISOString()}`,
+  `Mode: ${APPLY ? 'APPLY' : 'READ ONLY'}`,
+  `Supabase: ${SUPABASE_URL}`,
+  '',
+  '## Inputs',
+  '',
+  `- CSV: ${csvPath}`,
+  `- Files directory: ${filesDir}`,
+  '',
+  '## Summary',
+  '',
+  `- Parsed rows: ${records.length}`,
+  `- Valid rows: ${valid.length}`,
+  `- Invalid rows: ${invalid.length}`,
+  `- Non-zero rows: ${nonZero.length}`,
+  `- Local files found: ${valid.length - missingFiles.length}`,
+  `- Local files missing: ${missingFiles.length}`,
+  `- Total absolute AUD value: ${money(nonZero.reduce((sum, record) => sum + Math.abs(record.totalAud || 0), 0))}`,
+  `- Uploaded files: ${uploaded}`,
+  `- Evidence rows upserted: ${upserted}`,
+  `- Errors: ${errors}`,
+  '',
+  '## Status Counts',
+  '',
+  ...[...statusCounts.entries()].sort((a, b) => b[1] - a[1]).map(([status, count]) => `- ${status}: ${count}`),
+  '',
+  '## Top Suppliers',
+  '',
+  ...topSuppliers.map(([supplier, count]) => `- ${supplier}: ${count}`),
+  '',
+  '## Output Files',
+  '',
+  `- ${join(OUT_DIR, 'dext-export-records.csv')}`,
+  `- ${join(OUT_DIR, 'missing-local-files.csv')}`,
+  '',
+  '## Verification Status',
+  '',
+  `verified: Parsed the Dext CSV with multiline-safe parsing and checked local evidence files in ${filesDir}.`,
+  APPLY
+    ? 'verified: Uploaded local receipt files to Supabase Storage and upserted finance_receipt_documents rows.'
+    : 'verified: Dry-run mode performed no Supabase writes and no Xero writes.',
+  'unverified: No Xero UI reconciliation or Dext publishing action was performed by this script.',
+  '',
+].join('\n');
+
+writeFileSync(join(OUT_DIR, 'summary.md'), summary);
+writeFileSync(join(OUT_DIR, 'summary.md.provenance.md'), [
+  '# Provenance - Dext Export Evidence Import',
+  '',
+  `Report: ${join(OUT_DIR, 'summary.md')}`,
+  `Generated: ${new Date().toISOString()}`,
+  `Command: node scripts/import-dext-export-evidence.mjs ${csvPath} --files-dir ${filesDir}${APPLY ? ' --apply' : ''}`,
+  '',
+  '## Queried Sources',
+  '',
+  '- Local Dext CSV export',
+  '- Local Dext PDF/JPG export directory',
+  APPLY ? '- Supabase Storage bucket receipt-attachments' : '- Supabase was configured but not written in dry-run mode',
+  APPLY ? '- public.finance_receipt_documents' : '',
+  '',
+  '## Verified',
+  '',
+  '- CSV parse count, valid row count, local file matching count.',
+  APPLY ? '- Supabase upload/upsert counts from script execution.' : '- No write mode was enabled.',
+  '',
+  '## Unknown / Not Checked',
+  '',
+  '- Xero UI reconciliation status.',
+  '- Whether each Dext item is still unpublished inside Dext.',
+  '- BAS lodgement figures.',
+  '',
+].filter(Boolean).join('\n'));
+
+console.log(`Dext export evidence ${APPLY ? 'apply' : 'dry-run'} complete`);
+console.log(`  Supabase:          ${SUPABASE_URL}`);
+console.log(`  Parsed rows:       ${records.length}`);
+console.log(`  Valid rows:        ${valid.length}`);
+console.log(`  Local files found: ${valid.length - missingFiles.length}`);
+console.log(`  Missing files:     ${missingFiles.length}`);
+console.log(`  Non-zero rows:     ${nonZero.length}`);
+console.log(`  Total AUD value:   ${money(nonZero.reduce((sum, record) => sum + Math.abs(record.totalAud || 0), 0))}`);
+console.log(`  Uploaded files:    ${uploaded}`);
+console.log(`  Upserted rows:     ${upserted}`);
+console.log(`  Errors:            ${errors}`);
+console.log(`  Report:            ${join(OUT_DIR, 'summary.md')}`);

--- a/scripts/import-dext-to-pipeline.mjs
+++ b/scripts/import-dext-to-pipeline.mjs
@@ -336,13 +336,17 @@ async function scrapeReceiptFiles() {
           ? `${receipt.vendor_name.replace(/[^a-zA-Z0-9]/g, '-')}-receipt.${result.ext}`
           : `receipt.${result.ext}`;
 
-        await supabase.rpc('update_receipt_attachment', {
-          receipt_id: receipt.id,
-          new_attachment_url: storagePath,
-          new_filename: filename,
-          new_content_type: result.contentType,
-          new_size_bytes: result.buffer.length,
-        });
+        const { error: updateError } = await supabase
+          .from('receipt_emails')
+          .update({
+            attachment_url: storagePath,
+            attachment_filename: filename,
+            attachment_content_type: result.contentType,
+            attachment_size_bytes: result.buffer.length,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', receipt.id);
+        if (updateError) throw new Error(`Receipt update failed: ${updateError.message}`);
 
         totalBytes += result.buffer.length;
         downloaded++;
@@ -381,23 +385,51 @@ if (DRY_RUN) {
   process.exit(0);
 }
 
-// Batch insert via RPC (bypasses PostgREST table cache issues)
+async function existingMessageIds(ids) {
+  const existing = new Set();
+  for (let i = 0; i < ids.length; i += 100) {
+    const batch = ids.slice(i, i + 100);
+    const { data, error } = await supabase
+      .from('receipt_emails')
+      .select('gmail_message_id')
+      .in('gmail_message_id', batch);
+    if (error) throw new Error(`existing receipt lookup failed: ${error.message}`);
+    for (const row of data || []) existing.add(row.gmail_message_id);
+  }
+  return existing;
+}
+
+// Batch insert directly. The old insert_receipt_emails RPC is intentionally
+// avoided here because its search_path can drift and fail with
+// "relation receipt_emails does not exist".
 const BATCH_SIZE = 50;
 let inserted = 0;
+let skipped = 0;
 let errors = 0;
 
 for (let i = 0; i < transformed.length; i += BATCH_SIZE) {
   const batch = transformed.slice(i, i + BATCH_SIZE);
+  const ids = batch.map((row) => row.gmail_message_id);
 
-  const { data, error } = await supabase.rpc('insert_receipt_emails', {
-    rows: batch,
-  });
+  try {
+    const existing = await existingMessageIds(ids);
+    const toInsert = batch.filter((row) => !existing.has(row.gmail_message_id));
 
-  if (error) {
+    if (toInsert.length === 0) {
+      skipped += batch.length;
+    } else {
+      const { data, error } = await supabase
+        .from('receipt_emails')
+        .insert(toInsert)
+        .select('id');
+
+      if (error) throw error;
+      inserted += data?.length || 0;
+      skipped += batch.length - toInsert.length;
+    }
+  } catch (error) {
     log(`ERROR batch ${Math.floor(i / BATCH_SIZE) + 1}: ${error.message}`);
     errors += batch.length;
-  } else {
-    inserted += data || 0;
   }
 
   // Progress
@@ -405,8 +437,6 @@ for (let i = 0; i < transformed.length; i += BATCH_SIZE) {
     log(`  Progress: ${Math.min(i + BATCH_SIZE, transformed.length)}/${transformed.length}`);
   }
 }
-
-const skipped = transformed.length - inserted - errors;
 
 log(`\n=== Import Summary ===`);
 log(`  Inserted: ${inserted}`);
@@ -416,18 +446,15 @@ log(`  Total: ${transformed.length}`);
 
 // Show pipeline status after import
 try {
-  const { data: statusData } = await supabase.rpc('insert_receipt_emails', { rows: [] });
-  // Status query via PostgREST may fail if cache is stale — that's OK
-  const { data: countData, error: countErr } = await supabase
-    .from('receipt_emails')
-    .select('status');
+  const { data: countData, error: countErr } = await supabase.rpc('exec_sql', {
+    query: `SELECT status, count(*)::int AS count
+            FROM receipt_emails
+            GROUP BY status
+            ORDER BY count DESC`,
+  });
   if (countData && !countErr) {
-    const counts = {};
-    for (const r of countData) counts[r.status] = (counts[r.status] || 0) + 1;
     console.log('\n  Pipeline status after import:');
-    for (const [s, c] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
-      console.log(`    ${s}: ${c}`);
-    }
+    for (const row of countData) console.log(`    ${row.status}: ${row.count}`);
   }
 } catch {
   // Non-critical — data is already imported

--- a/scripts/lib/finance/xero-client.mjs
+++ b/scripts/lib/finance/xero-client.mjs
@@ -42,6 +42,7 @@ export async function createXeroClient(supabase, opts = {}) {
   const clientSecret = process.env.XERO_CLIENT_SECRET;
   const tenantId = process.env.XERO_TENANT_ID;
   const tokenFile = opts.tokenFile || path.join(process.cwd(), '.xero-tokens.json');
+  const envFile = opts.envFile || path.join(process.cwd(), '.env.local');
 
   if (!clientId || !clientSecret || !tenantId) {
     throw new Error('Missing XERO_CLIENT_ID, XERO_CLIENT_SECRET, or XERO_TENANT_ID');
@@ -124,6 +125,24 @@ export async function createXeroClient(supabase, opts = {}) {
           throw new Error(`Xero token rotation failed to persist — both file and Supabase save failed. Next run will use a revoked refresh token.`);
         }
       }
+    }
+
+    // Keep the legacy .env.local mirror current for older scripts and MCP
+    // wrapper fallbacks. Xero refresh tokens are single-use, so stale mirrors
+    // are the most common cause of 401/invalid_grant loops.
+    try {
+      if (existsSync(envFile)) {
+        let envBody = readFileSync(envFile, 'utf8');
+        const line = `XERO_REFRESH_TOKEN=${newRefreshToken}`;
+        if (/^XERO_REFRESH_TOKEN=/m.test(envBody)) {
+          envBody = envBody.replace(/^XERO_REFRESH_TOKEN=.*/m, line);
+        } else {
+          envBody = `${envBody.trimEnd()}\n${line}\n`;
+        }
+        writeFileSync(envFile, envBody);
+      }
+    } catch (e) {
+      console.warn(`[xero-client] Failed to update ${envFile}: ${e.message}`);
     }
   }
 

--- a/scripts/lib/projects/suggest-code.mjs
+++ b/scripts/lib/projects/suggest-code.mjs
@@ -1,0 +1,191 @@
+/**
+ * AI-suggest a project_code (ACT-XX) for a newly-starting idea.
+ *
+ * Plan: ~/.claude/plans/coo-cio-cfo-money-brain-phase2.md § B3.
+ *
+ * Pattern:
+ *   import { suggestProjectCode, confirmProjectCode } from './lib/projects/suggest-code.mjs'
+ *   const suggestion = await suggestProjectCode({ ideaText, ideaId })
+ *   // present `suggestion` to user, get confirm or override
+ *   await confirmProjectCode({ ideaId, code: confirmed, name, organizationId })
+ *
+ * Anthropic Haiku is used because naming is a cheap 2-letter pick. The model
+ * sees existing project codes so it doesn't collide.
+ */
+
+import 'dotenv/config';
+import Anthropic from '@anthropic-ai/sdk';
+import { createClient } from '@supabase/supabase-js';
+
+const ACT_ORG_ID = '88f84b66-f0fd-4fcf-9ec9-3cfc682303c5';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } },
+);
+
+const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+async function loadExistingCodes() {
+  const { data, error } = await supabase
+    .from('projects')
+    .select('code, name, status')
+    .order('code')
+    .limit(500);
+  if (error) throw new Error(`Failed to load projects: ${error.message}`);
+  return data ?? [];
+}
+
+/**
+ * @param {{ ideaText: string, ideaId?: string, hint?: string }} input
+ * @returns {Promise<{ code: string, name: string, rationale: string, conflicts: string[] }>}
+ */
+export async function suggestProjectCode({ ideaText, hint }) {
+  if (!ideaText || ideaText.trim().length === 0) {
+    throw new Error('ideaText required');
+  }
+  const existing = await loadExistingCodes();
+  const codeList = existing.map((p) => `${p.code} (${p.name})`).join('\n');
+
+  const prompt = `You name new ACT (A Curious Tractor) projects. Convention: ACT-XX where XX is 2-3 uppercase letters that abbreviate the project name memorably.
+
+Existing project codes (avoid collision):
+${codeList}
+
+Pick a new code for this idea:
+"""
+${ideaText}
+"""${hint ? `\n\nHint from user: ${hint}` : ''}
+
+Return JSON only:
+{
+  "code": "ACT-XX",
+  "name": "Short Project Name (3-5 words, title case)",
+  "rationale": "1-line why this code"
+}
+
+Rules:
+- Code must start with "ACT-"
+- 2-3 letters after the dash
+- Don't reuse any existing code above
+- Name should be the actual thing the idea is, not a marketing slogan`;
+
+  const resp = await anthropic.messages.create({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 200,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const text = resp.content[0].type === 'text' ? resp.content[0].text : '';
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(`Could not parse JSON from model response: ${text.slice(0, 200)}`);
+  }
+  const parsed = JSON.parse(jsonMatch[0]);
+
+  if (!/^ACT-[A-Z]{2,4}$/.test(parsed.code)) {
+    throw new Error(`Model returned invalid code format: ${parsed.code}`);
+  }
+
+  const conflicts = existing.filter((p) => p.code === parsed.code).map((p) => `${p.code} (${p.name})`);
+  if (conflicts.length > 0) {
+    // Model collided despite the list — fall back to a numeric suffix
+    let suffix = 2;
+    while (existing.some((p) => p.code === `${parsed.code}${suffix}`)) suffix += 1;
+    parsed.code = `${parsed.code}${suffix}`;
+  }
+
+  return {
+    code: parsed.code,
+    name: parsed.name,
+    rationale: parsed.rationale ?? '',
+    conflicts,
+  };
+}
+
+/**
+ * Apply a confirmed code: INSERT projects + UPDATE idea_board.project_code.
+ *
+ * @param {{ ideaId: string, code: string, name: string, organizationId?: string }} input
+ * @returns {Promise<{ projectId: string, code: string, name: string }>}
+ */
+export async function confirmProjectCode({ ideaId, code, name, organizationId }) {
+  if (!ideaId) throw new Error('ideaId required');
+  if (!/^ACT-[A-Z0-9]{2,5}$/.test(code)) throw new Error(`Invalid code format: ${code}`);
+  if (!name) throw new Error('name required');
+
+  const orgId = organizationId ?? ACT_ORG_ID;
+
+  // Check for existing project with this code first (race protection)
+  const { data: existingProject } = await supabase
+    .from('projects')
+    .select('id, code')
+    .eq('code', code)
+    .maybeSingle();
+
+  let projectId;
+  if (existingProject) {
+    projectId = existingProject.id;
+  } else {
+    const { data: inserted, error: insertErr } = await supabase
+      .from('projects')
+      .insert({
+        code,
+        name,
+        tier: 'satellite',
+        status: 'active',
+        organization_id: orgId,
+      })
+      .select('id, code, name')
+      .single();
+    if (insertErr) throw new Error(`Failed to insert project: ${insertErr.message}`);
+    projectId = inserted.id;
+  }
+
+  const { error: updateErr } = await supabase
+    .from('idea_board')
+    .update({ project_code: code, updated_at: new Date().toISOString() })
+    .eq('id', ideaId);
+  if (updateErr) throw new Error(`Failed to link idea: ${updateErr.message}`);
+
+  return { projectId, code, name };
+}
+
+// CLI entry point: node scripts/lib/projects/suggest-code.mjs --idea-id <uuid>
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const ideaIdIdx = args.indexOf('--idea-id');
+  const ideaId = ideaIdIdx >= 0 ? args[ideaIdIdx + 1] : null;
+  const confirmIdx = args.indexOf('--confirm');
+  const confirmCode = confirmIdx >= 0 ? args[confirmIdx + 1] : null;
+  const hintIdx = args.indexOf('--hint');
+  const hint = hintIdx >= 0 ? args[hintIdx + 1] : null;
+
+  if (!ideaId) {
+    console.error('Usage: node scripts/lib/projects/suggest-code.mjs --idea-id <uuid> [--hint "..."] [--confirm ACT-XX]');
+    process.exit(1);
+  }
+
+  const { data: idea, error } = await supabase
+    .from('idea_board')
+    .select('id, text, lifecycle_stage')
+    .eq('id', ideaId)
+    .single();
+  if (error || !idea) {
+    console.error(`Idea not found: ${error?.message ?? 'no row'}`);
+    process.exit(1);
+  }
+
+  if (confirmCode) {
+    // Re-run suggestion to grab name (or could pass --name)
+    const suggestion = await suggestProjectCode({ ideaText: idea.text, hint });
+    const finalName = suggestion.code === confirmCode ? suggestion.name : idea.text.slice(0, 60);
+    const result = await confirmProjectCode({ ideaId, code: confirmCode, name: finalName });
+    console.log(JSON.stringify({ confirmed: true, ...result }, null, 2));
+  } else {
+    const suggestion = await suggestProjectCode({ ideaText: idea.text, hint });
+    console.log(JSON.stringify({ suggestion, idea: { id: idea.id, text: idea.text } }, null, 2));
+    console.log('\nTo apply: re-run with --confirm ' + suggestion.code);
+  }
+}

--- a/scripts/lib/telegram.mjs
+++ b/scripts/lib/telegram.mjs
@@ -14,27 +14,32 @@
  * @param {string} message - Markdown-formatted message text
  * @param {Object} [opts]
  * @param {string} [opts.parseMode='Markdown'] - 'Markdown' or 'HTML'
+ * @param {Object} [opts.replyMarkup] - Telegram InlineKeyboardMarkup (use buildInlineKeyboard helper)
+ * @param {string|number} [opts.chatId] - Override TELEGRAM_CHAT_ID (e.g. per-owner DM)
  * @returns {Promise<boolean>} true if sent successfully
  */
-export async function sendTelegram(message, { parseMode = 'Markdown' } = {}) {
+export async function sendTelegram(message, { parseMode = 'Markdown', replyMarkup, chatId: chatIdOverride } = {}) {
   const botToken = process.env.TELEGRAM_BOT_TOKEN;
-  const chatId = process.env.TELEGRAM_CHAT_ID;
+  const chatId = chatIdOverride ?? process.env.TELEGRAM_CHAT_ID;
 
   if (!botToken || !chatId) {
     console.log('Telegram not configured (missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID)');
     return false;
   }
 
+  const body = {
+    chat_id: chatId,
+    text: message,
+    parse_mode: parseMode,
+    disable_web_page_preview: true,
+  };
+  if (replyMarkup) body.reply_markup = replyMarkup;
+
   try {
     const res = await fetch(`https://api.telegram.org/bot${botToken}/sendMessage`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: chatId,
-        text: message,
-        parse_mode: parseMode,
-        disable_web_page_preview: true,
-      }),
+      body: JSON.stringify(body),
     });
 
     if (res.ok) {
@@ -49,4 +54,18 @@ export async function sendTelegram(message, { parseMode = 'Markdown' } = {}) {
     console.error('Telegram send error:', err.message);
     return false;
   }
+}
+
+/**
+ * Build a Telegram InlineKeyboardMarkup from a 2D array of {text, callbackData} buttons.
+ *
+ * @param {Array<Array<{text: string, callbackData: string}>>} rows
+ * @returns {{inline_keyboard: Array<Array<{text: string, callback_data: string}>>}}
+ */
+export function buildInlineKeyboard(rows) {
+  return {
+    inline_keyboard: rows.map((row) =>
+      row.map(({ text, callbackData }) => ({ text, callback_data: callbackData })),
+    ),
+  };
 }

--- a/scripts/match-receipts-to-xero.mjs
+++ b/scripts/match-receipts-to-xero.mjs
@@ -33,6 +33,14 @@ function log(msg) {
   console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
 }
 
+async function updateReceiptRow(receiptId, updates) {
+  const { error } = await supabase
+    .from('receipt_emails')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', receiptId);
+  if (error) throw error;
+}
+
 // ============================================================================
 // MATCHING ENGINE
 // ============================================================================
@@ -491,43 +499,28 @@ async function main() {
     let applied = 0;
 
     for (const { receipt, match } of matches) {
-      const isInvoice = match.tx._is_invoice;
-      const updateParams = {
-        receipt_id: receipt.id,
-        new_status: 'matched',
-        new_xero_transaction_id: isInvoice ? null : match.tx.id,
-        new_xero_bank_transaction_id: isInvoice ? null : match.tx.xero_transaction_id,
-        new_match_confidence: match.score,
-        new_match_method: match.method || 'auto_heuristic',
-        new_project_code: match.tx.project_code || null,
-      };
-
-      // For invoice matches, store the invoice ID separately
-      if (isInvoice) {
-        // Use direct update for invoice matches since RPC doesn't have xero_invoice_id param
-        const { error: directErr } = await supabase
-          .from('receipt_emails')
-          .update({
+      try {
+        const isInvoice = match.tx._is_invoice;
+        if (isInvoice) {
+          await updateReceiptRow(receipt.id, {
             status: 'matched',
             xero_invoice_id: match.tx.xero_transaction_id,
             match_confidence: match.score,
             match_method: match.method || 'auto_heuristic',
-          })
-          .eq('id', receipt.id);
-        if (directErr) {
-          log(`  ERROR: ${receipt.vendor_name}: ${directErr.message}`);
+          });
         } else {
-          applied++;
+          await updateReceiptRow(receipt.id, {
+            status: 'matched',
+            xero_transaction_id: match.tx.id,
+            xero_bank_transaction_id: match.tx.xero_transaction_id,
+            match_confidence: match.score,
+            match_method: match.method || 'auto_heuristic',
+            project_code: match.tx.project_code || null,
+          });
         }
-        continue;
-      }
-
-      const { error } = await supabase.rpc('update_receipt_match', updateParams);
-
-      if (error) {
-        log(`  ERROR: ${receipt.vendor_name}: ${error.message}`);
-      } else {
         applied++;
+      } catch (error) {
+        log(`  ERROR: ${receipt.vendor_name}: ${error.message}`);
       }
     }
     log(`Applied: ${applied}/${matches.length}`);
@@ -539,11 +532,10 @@ async function main() {
     if (remainingAmbiguous.length > 0) {
       log(`Marking ${remainingAmbiguous.length} ambiguous as 'review'...`);
       for (const { receipt, match } of remainingAmbiguous) {
-        await supabase.rpc('update_receipt_match', {
-          receipt_id: receipt.id,
-          new_status: 'review',
-          new_match_confidence: match.score,
-          new_match_method: 'needs_review',
+        await updateReceiptRow(receipt.id, {
+          status: 'review',
+          match_confidence: match.score,
+          match_method: 'needs_review',
         });
       }
 

--- a/scripts/monday-morning-chain.mjs
+++ b/scripts/monday-morning-chain.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Monday morning chain — runs the 5:30-9:10 weekly sequence as one job.
+ *
+ * Each step runs in sequence. A failure in one step DOES NOT abort the
+ * chain (so a flaky weekly-project-pulse doesn't kill the
+ * weekly-reconciliation that follows). All step results land in a
+ * wiki/cockpit/monday-chain-YYYY-MM-DD.md log and (with --telegram)
+ * a single Telegram summary at the end.
+ *
+ * Why one wrapper instead of six PM2 entries:
+ *   - Single failure surface (one log file, one Telegram alert)
+ *   - Cannot have steps overlap when one runs long
+ *   - Easy to drop or reorder a step (edit the array, not 6 PM2 entries)
+ *   - Failure isolation: step 1 failing doesn't kill step 2-6
+ *
+ * Usage:
+ *   node scripts/monday-morning-chain.mjs                # all steps, no telegram
+ *   node scripts/monday-morning-chain.mjs --telegram     # also send summary
+ *   node scripts/monday-morning-chain.mjs --skip ghl-cleanup,grant-seed
+ *   node scripts/monday-morning-chain.mjs --only weekly-reconciliation,money-framework
+ *   node scripts/monday-morning-chain.mjs --dry-run      # print the plan
+ *
+ * Cron (replaces 6 entries): 'monday-morning-chain' at 5:30am Mon.
+ */
+
+import './lib/load-env.mjs';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const WIKI_DIR = path.join(ROOT, 'wiki', 'cockpit');
+
+const args = process.argv.slice(2);
+const SEND_TELEGRAM = args.includes('--telegram');
+const DRY_RUN = args.includes('--dry-run');
+
+function valueAfter(flag) {
+  const i = args.indexOf(flag);
+  return i === -1 ? null : args[i + 1];
+}
+
+const SKIP_SET = new Set(
+  (valueAfter('--skip') || '').split(',').map((s) => s.trim()).filter(Boolean),
+);
+const ONLY_SET = new Set(
+  (valueAfter('--only') || '').split(',').map((s) => s.trim()).filter(Boolean),
+);
+
+const TG_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TG_CHAT = (process.env.TELEGRAM_AUTHORIZED_USERS || '').split(',')[0]?.trim();
+
+// Ordered chain. Edit here, not in 6 PM2 entries.
+const CHAIN = [
+  {
+    name: 'weekly-project-pulse',
+    script: 'scripts/weekly-project-pulse.mjs',
+    args: [],
+    timeoutMs: 5 * 60 * 1000,
+    purpose: 'Per-project open-actions pulse to Notion',
+  },
+  {
+    name: 'ghl-cleanup-auto',
+    script: 'scripts/cleanup-stale-ghl-opps.mjs',
+    args: ['--apply'],
+    timeoutMs: 10 * 60 * 1000,
+    purpose: 'Auto-archive past-deadline grants + stale ACT Events invites',
+  },
+  {
+    name: 'grant-seed-weekly',
+    script: 'scripts/seed-ghl-grants.mjs',
+    args: ['--count', '5'],
+    timeoutMs: 10 * 60 * 1000,
+    purpose: 'Seed top-5 fresh ACT-fit grants into GHL',
+  },
+  {
+    name: 'xero-payments-sync',
+    script: 'scripts/sync-xero-payments.mjs',
+    args: ['--days=180'],
+    timeoutMs: 10 * 60 * 1000,
+    purpose: 'Sync Xero Payments (deposit↔invoice link table)',
+  },
+  {
+    name: 'weekly-reconciliation',
+    script: 'scripts/weekly-reconciliation.mjs',
+    args: [],
+    timeoutMs: 15 * 60 * 1000,
+    purpose: 'Reconciliation report + R&D pack grading + Telegram',
+  },
+  {
+    name: 'money-framework-sync',
+    script: 'scripts/sync-money-framework-to-notion.mjs',
+    args: [],
+    timeoutMs: 15 * 60 * 1000,
+    purpose: 'Refresh ACT Money Framework Notion panels',
+  },
+];
+
+function isSelected(step) {
+  if (ONLY_SET.size > 0 && !ONLY_SET.has(step.name)) return false;
+  if (SKIP_SET.has(step.name)) return false;
+  return true;
+}
+
+function runStep(step) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const log = { name: step.name, start: new Date(start).toISOString(), stdoutBytes: 0, stderrBytes: 0 };
+    const stdoutChunks = [];
+    const stderrChunks = [];
+
+    const child = spawn('node', [step.script, ...step.args], {
+      cwd: ROOT,
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let killed = false;
+    const timer = setTimeout(() => {
+      killed = true;
+      child.kill('SIGTERM');
+      setTimeout(() => child.kill('SIGKILL'), 5000);
+    }, step.timeoutMs);
+
+    child.stdout.on('data', (data) => {
+      stdoutChunks.push(data);
+      log.stdoutBytes += data.length;
+      // Also surface live so PM2 logs show progress
+      process.stdout.write(data);
+    });
+    child.stderr.on('data', (data) => {
+      stderrChunks.push(data);
+      log.stderrBytes += data.length;
+      process.stderr.write(data);
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      const end = Date.now();
+      log.end = new Date(end).toISOString();
+      log.durationMs = end - start;
+      log.exitCode = code;
+      log.signal = signal || null;
+      log.timedOut = killed;
+      log.ok = !killed && code === 0;
+      const stderr = Buffer.concat(stderrChunks).toString();
+      log.stderrTail = stderr.slice(-1000);
+      const stdout = Buffer.concat(stdoutChunks).toString();
+      log.stdoutTail = stdout.slice(-500);
+      resolve(log);
+    });
+  });
+}
+
+async function sendTelegram(text) {
+  if (!SEND_TELEGRAM) return false;
+  if (!TG_TOKEN || !TG_CHAT) {
+    console.log('[telegram] creds not set, skipping');
+    return false;
+  }
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${TG_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TG_CHAT, text, parse_mode: 'Markdown', disable_web_page_preview: true }),
+    });
+    return res.ok;
+  } catch (err) {
+    console.warn(`[telegram] failed: ${err.message}`);
+    return false;
+  }
+}
+
+function fmtDuration(ms) {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  return `${m}m${rs.toString().padStart(2, '0')}`;
+}
+
+async function main() {
+  const today = new Date().toISOString().slice(0, 10);
+  const selectedSteps = CHAIN.filter(isSelected);
+
+  console.log('━'.repeat(72));
+  console.log(`Monday morning chain — ${today}`);
+  console.log('━'.repeat(72));
+  console.log(`${selectedSteps.length} of ${CHAIN.length} steps selected.`);
+  selectedSteps.forEach((s, i) => console.log(`  ${i + 1}. ${s.name} (${s.script})`));
+  console.log();
+
+  if (DRY_RUN) {
+    console.log('Dry run — no steps executed.');
+    return;
+  }
+
+  const startedAt = Date.now();
+  const logs = [];
+  for (const step of selectedSteps) {
+    console.log();
+    console.log(`▶ ${step.name} — ${step.purpose}`);
+    console.log('─'.repeat(72));
+    const log = await runStep(step);
+    logs.push(log);
+    const status = log.ok ? '✓' : log.timedOut ? '⏰' : '✗';
+    console.log();
+    console.log(`${status} ${step.name}  ${fmtDuration(log.durationMs)}  exit=${log.exitCode}${log.timedOut ? ' TIMED OUT' : ''}`);
+  }
+
+  const totalMs = Date.now() - startedAt;
+  const okCount = logs.filter((l) => l.ok).length;
+  const failCount = logs.length - okCount;
+
+  // Markdown log
+  if (!existsSync(WIKI_DIR)) mkdirSync(WIKI_DIR, { recursive: true });
+  const logPath = path.join(WIKI_DIR, `monday-chain-${today}.md`);
+  const lines = [];
+  lines.push('---');
+  lines.push(`title: Monday chain — ${today}`);
+  lines.push(`status: published`);
+  lines.push(`generated_by: scripts/monday-morning-chain.mjs`);
+  lines.push(`steps_total: ${logs.length}`);
+  lines.push(`steps_ok: ${okCount}`);
+  lines.push(`steps_failed: ${failCount}`);
+  lines.push(`total_duration_ms: ${totalMs}`);
+  lines.push('---');
+  lines.push('');
+  lines.push(`# Monday chain — ${today}`);
+  lines.push('');
+  lines.push(`Total: ${fmtDuration(totalMs)}.  OK ${okCount} / ${logs.length}. Failures: ${failCount}.`);
+  lines.push('');
+  lines.push('| # | Step | Duration | Exit | Status |');
+  lines.push('|---|---|---:|---:|:-:|');
+  logs.forEach((log, i) => {
+    const status = log.ok ? 'ok' : log.timedOut ? 'TIMEOUT' : 'FAIL';
+    lines.push(`| ${i + 1} | ${log.name} | ${fmtDuration(log.durationMs)} | ${log.exitCode ?? 'null'} | ${status} |`);
+  });
+  lines.push('');
+  for (const log of logs) {
+    if (log.ok) continue;
+    lines.push(`## ${log.name} — ${log.timedOut ? 'TIMED OUT' : 'FAILED'}`);
+    lines.push('');
+    lines.push('Stderr tail:');
+    lines.push('```');
+    lines.push(log.stderrTail || '(empty)');
+    lines.push('```');
+    lines.push('');
+  }
+  writeFileSync(logPath, lines.join('\n'));
+  console.log();
+  console.log(`Log: ${logPath}`);
+
+  // Telegram summary
+  if (SEND_TELEGRAM) {
+    const summaryLines = [`🌅 *Monday chain* — ${today}`, ''];
+    summaryLines.push(`Total: ${fmtDuration(totalMs)}.  OK ${okCount} / ${logs.length}.`);
+    if (failCount > 0) summaryLines.push(`*Failures: ${failCount}* ⚠`);
+    summaryLines.push('');
+    logs.forEach((log, i) => {
+      const status = log.ok ? '✓' : log.timedOut ? '⏰' : '✗';
+      summaryLines.push(`${status} ${i + 1}. ${log.name} ${fmtDuration(log.durationMs)}`);
+    });
+    if (failCount > 0) {
+      summaryLines.push('');
+      summaryLines.push('Failed steps:');
+      logs.filter((l) => !l.ok).forEach((l) => {
+        summaryLines.push(`• ${l.name}: ${l.timedOut ? 'TIMED OUT' : `exit ${l.exitCode}`}`);
+      });
+      summaryLines.push('');
+      summaryLines.push(`Log: \`wiki/cockpit/monday-chain-${today}.md\``);
+    }
+    await sendTelegram(summaryLines.join('\n'));
+  }
+
+  // Exit non-zero if any step failed so PM2 logs flag the failure.
+  if (failCount > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/narrate-weekly-digest.mjs
+++ b/scripts/narrate-weekly-digest.mjs
@@ -1,0 +1,346 @@
+#!/usr/bin/env node
+/**
+ * Weekly narrative digest — Sonnet 4.6 turns the raw money-command numbers
+ * into "the 5 things you need to know this week" in ACT (Curtis) voice.
+ *
+ * Reads same sources as money-command-digest.mjs (coverage, drift queue,
+ * incoming 90d, cash, lifetime ledger) PLUS the delta vs the snapshot from
+ * 7 days ago (not yesterday), then asks Sonnet to surface what changed
+ * that matters, in plain language, no AI tells.
+ *
+ * Output:
+ *   - stdout (always)
+ *   - wiki/cockpit/weekly-narrative-YYYY-MM-DD.md (committed artifact)
+ *   - Telegram (if --telegram and chat creds set)
+ *
+ * Usage:
+ *   node scripts/narrate-weekly-digest.mjs              # print only
+ *   node scripts/narrate-weekly-digest.mjs --telegram   # also send Telegram
+ *   node scripts/narrate-weekly-digest.mjs --no-write   # skip wiki/ write
+ *   node scripts/narrate-weekly-digest.mjs --model haiku  # cheaper
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { trackedClaudeCompletion } from './lib/llm-client.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const SNAPSHOT_DIR = path.join(ROOT, 'thoughts', 'shared', 'data', 'money-command-snapshots');
+const WIKI_DIR = path.join(ROOT, 'wiki', 'cockpit');
+const FY_START = '2025-07-01';
+const SCRIPT_NAME = 'narrate-weekly-digest';
+
+const args = process.argv.slice(2);
+const SEND_TELEGRAM = args.includes('--telegram');
+const NO_WRITE = args.includes('--no-write');
+const MODEL_TAG = valueAfter('--model') || 'sonnet';
+const MODEL =
+  MODEL_TAG === 'haiku' ? 'claude-haiku-4-5'
+  : MODEL_TAG === 'opus' ? 'claude-opus-4-7'
+  : 'claude-sonnet-4-6';
+
+function valueAfter(flag) {
+  const i = args.indexOf(flag);
+  return i === -1 ? null : args[i + 1];
+}
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || process.env.SUPABASE_SHARED_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const TG_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TG_CHAT = (process.env.TELEGRAM_AUTHORIZED_USERS || '').split(',')[0]?.trim();
+
+const fmt = (n) => '$' + Number(n || 0).toLocaleString('en-AU', { maximumFractionDigits: 0 });
+
+const STAGE_PROBABILITY = [
+  [/(won|invoiced|harvest|graduation)/i, 1.00],
+  [/(submitted|growth|negotiation)/i, 0.70],
+  [/(proposed|invited|application.in.progress)/i, 0.50],
+  [/(germination|scoping|needs.assessment)/i, 0.25],
+  [/(grant.opportunity.identified)/i, 0.00],
+  [/(identified|signal|new.lead|new.inquiry|outreach)/i, 0.10],
+  [/(lost|cancelled|dropped)/i, 0.00],
+];
+function stageProb(stage) {
+  if (!stage) return 0.10;
+  for (const [re, p] of STAGE_PROBABILITY) if (re.test(stage)) return p;
+  return 0.10;
+}
+
+async function loadCoverage() {
+  const countTagged = async (table, filters = (q) => q, taggedColumn = 'project_code') => {
+    const total = await filters(supabase.from(table).select('*', { count: 'exact', head: true }));
+    const tagged = await filters(supabase.from(table).select('*', { count: 'exact', head: true }).not(taggedColumn, 'is', null));
+    return { total: total.count ?? 0, tagged: tagged.count ?? 0 };
+  };
+  const [transactions, invoices, opportunities] = await Promise.all([
+    countTagged('xero_transactions', (q) => q.gte('date', FY_START)),
+    countTagged('xero_invoices', (q) => q.eq('type', 'ACCREC').gte('date', FY_START)),
+    countTagged('ghl_opportunities', (q) => q.eq('status', 'open')),
+  ]);
+  return { transactions, invoices, opportunities };
+}
+
+async function loadIncoming() {
+  const [stateRes, oppsRes] = await Promise.all([
+    supabase.from('v_project_money_state').select('receivables, grants_in_flight'),
+    supabase.from('ghl_opportunities').select('monetary_value, stage_name').eq('status', 'open'),
+  ]);
+  const state = stateRes.data ?? [];
+  const opps = oppsRes.data ?? [];
+  const receivables = state.reduce((s, r) => s + Number(r.receivables ?? 0), 0);
+  const grantsInFlight = state.reduce((s, r) => s + Number(r.grants_in_flight ?? 0), 0);
+  const pipelineWeighted = opps.reduce((s, o) => s + Number(o.monetary_value ?? 0) * stageProb(o.stage_name), 0);
+  return { receivables, grantsInFlight, pipelineWeighted, projected90d: receivables + pipelineWeighted + grantsInFlight };
+}
+
+async function loadCash() {
+  const { data } = await supabase.from('xero_bank_accounts').select('current_balance, status, name');
+  if (!data || !data.length) return { total: 0, accounts: [] };
+  const live = data.filter((a) => a.status !== 'ARCHIVED');
+  return {
+    total: live.reduce((s, a) => s + Number(a.current_balance ?? 0), 0),
+    accounts: live.map((a) => ({ name: a.name, balance: Number(a.current_balance ?? 0) })),
+  };
+}
+
+async function loadDriftTop3() {
+  const { data: invs } = await supabase
+    .from('xero_invoices')
+    .select('contact_name, total, invoice_number')
+    .gte('date', FY_START)
+    .is('project_code', null)
+    .eq('type', 'ACCREC')
+    .order('total', { ascending: false })
+    .limit(3);
+  const { data: opps } = await supabase
+    .from('ghl_opportunities')
+    .select('name, monetary_value')
+    .eq('status', 'open')
+    .is('project_code', null)
+    .order('monetary_value', { ascending: false, nullsFirst: false })
+    .limit(3);
+  return { invs: invs ?? [], opps: opps ?? [] };
+}
+
+async function loadOverdueAR() {
+  const today = new Date().toISOString().slice(0, 10);
+  const { data } = await supabase
+    .from('xero_invoices')
+    .select('contact_name, invoice_number, total, amount_due, due_date, date')
+    .eq('type', 'ACCREC')
+    .eq('status', 'AUTHORISED')
+    .gt('amount_due', 0)
+    .lt('due_date', today)
+    .order('amount_due', { ascending: false })
+    .limit(5);
+  return data ?? [];
+}
+
+async function loadWeekDeltas() {
+  if (!existsSync(SNAPSHOT_DIR)) return null;
+  const files = readdirSync(SNAPSHOT_DIR).filter((f) => f.endsWith('.json')).sort();
+  if (!files.length) return null;
+  const target = new Date();
+  target.setDate(target.getDate() - 7);
+  const targetIso = target.toISOString().slice(0, 10);
+  const lastWeekFile = files.find((f) => f.startsWith(targetIso) || f >= targetIso);
+  if (!lastWeekFile) return null;
+  try {
+    return JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, lastWeekFile), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const SYSTEM_PROMPT = `You are A Curious Tractor's money narrator. You write the weekly digest in Ian Curtis voice — architectural, not decorative.
+
+Method (every paragraph):
+1. Name the room (the bank account, the bill, the spreadsheet, the meeting room).
+2. Name the body (the cash, the receivables, the receipts pile).
+3. Load the abstract noun (runway, coverage, capacity) by putting it in the room against the body — let the institutional word break.
+4. Stop the line. No "because", "which demonstrates", "highlighting", "reflecting".
+
+Forbidden words (AI tells — reject on sight): delve, crucial, pivotal, vital, significant, tapestry, landscape, underscore, highlight (verb), showcase, leverage, foster, cultivate, empower, nestled, in the heart of, at the forefront of, world-class, robust, vibrant, dynamic, thriving, navigate (as metaphor).
+
+Forbidden constructions: "not just X, but Y", "X represents Y", "stands as a testament", "plays a pivotal role", em dashes (— or –). Use periods, commas, colons.
+
+Plainness test: could a fourteen-year-old in Doomadgee say this without translation? If not, cut.
+
+Format the output as:
+
+## This week
+
+One paragraph. Plain. The state of things.
+
+## Five things to know
+
+1. **<headline>**: one or two sentences. Name the body, name the number, stop the line.
+2. ...
+3. ...
+4. ...
+5. ...
+
+## Action this week
+
+3 bullets max. Each begins with a verb (chase, file, void, attach, tag, call).
+
+Total length: 250-400 words. Tighter is better.`;
+
+function buildUserPrompt(data) {
+  const lines = [];
+  lines.push(`Date: ${new Date().toISOString().slice(0, 10)}`);
+  lines.push('');
+  lines.push(`# Cash and incoming`);
+  lines.push(`Cash in bank: ${fmt(data.cash.total)} across ${data.cash.accounts.length} accounts.`);
+  if (data.cash.accounts.length) {
+    data.cash.accounts.slice(0, 5).forEach((a) => {
+      lines.push(`  ${a.name}: ${fmt(a.balance)}`);
+    });
+  }
+  lines.push('');
+  lines.push(`Projected 90-day incoming: ${fmt(data.incoming.projected90d)}`);
+  lines.push(`  Receivables (AR): ${fmt(data.incoming.receivables)}`);
+  lines.push(`  Pipeline (weighted): ${fmt(data.incoming.pipelineWeighted)}`);
+  lines.push(`  Grants in flight: ${fmt(data.incoming.grantsInFlight)}`);
+  lines.push('');
+
+  if (data.weekAgo) {
+    lines.push(`# Week-over-week deltas`);
+    if (data.weekAgo.cash != null) lines.push(`  Cash 7d ago: ${fmt(data.weekAgo.cash)}  →  Δ ${fmt(data.cash.total - data.weekAgo.cash)}`);
+    if (data.weekAgo.incoming?.projected90d != null) {
+      lines.push(`  Incoming 90d 7d ago: ${fmt(data.weekAgo.incoming.projected90d)}  →  Δ ${fmt(data.incoming.projected90d - data.weekAgo.incoming.projected90d)}`);
+    }
+    lines.push('');
+  }
+
+  const c = data.coverage;
+  lines.push(`# Coverage (tagged / total)`);
+  lines.push(`  Xero transactions (FY26): ${c.transactions.tagged}/${c.transactions.total} (${(c.transactions.tagged * 100 / Math.max(c.transactions.total, 1)).toFixed(1)}%)`);
+  lines.push(`  Xero invoices (FY26 ACCREC): ${c.invoices.tagged}/${c.invoices.total} (${(c.invoices.tagged * 100 / Math.max(c.invoices.total, 1)).toFixed(1)}%)`);
+  lines.push(`  Open opportunities: ${c.opportunities.tagged}/${c.opportunities.total} (${(c.opportunities.tagged * 100 / Math.max(c.opportunities.total, 1)).toFixed(1)}%)`);
+  lines.push('');
+
+  if (data.overdueAR.length) {
+    lines.push(`# Overdue AR (top 5 by amount due)`);
+    data.overdueAR.forEach((inv) => {
+      lines.push(`  ${inv.invoice_number} ${inv.contact_name} ${fmt(inv.amount_due)} (due ${inv.due_date})`);
+    });
+    lines.push('');
+  }
+
+  if (data.drift.invs.length || data.drift.opps.length) {
+    lines.push(`# Drift queue (untagged top 3)`);
+    data.drift.invs.forEach((inv) => lines.push(`  invoice  ${inv.invoice_number} ${inv.contact_name} ${fmt(inv.total)}`));
+    data.drift.opps.forEach((opp) => lines.push(`  opportunity  ${opp.name} ${fmt(opp.monetary_value)}`));
+    lines.push('');
+  }
+
+  lines.push(`Write the weekly narrative in the required format. Focus on what changed this week. Name names, name amounts. No filler.`);
+  return lines.join('\n');
+}
+
+async function sendTelegram(text) {
+  if (!TG_TOKEN || !TG_CHAT) {
+    console.log('[telegram] creds not set, skipping');
+    return false;
+  }
+  // Telegram has a 4096 char limit per message; chunk if needed.
+  const chunks = [];
+  let remaining = text;
+  while (remaining.length > 0) {
+    if (remaining.length <= 4000) {
+      chunks.push(remaining);
+      break;
+    }
+    const slice = remaining.slice(0, 4000);
+    const lastNewline = slice.lastIndexOf('\n');
+    const cut = lastNewline > 2000 ? lastNewline : 4000;
+    chunks.push(remaining.slice(0, cut));
+    remaining = remaining.slice(cut);
+  }
+  for (const chunk of chunks) {
+    const res = await fetch(`https://api.telegram.org/bot${TG_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TG_CHAT, text: chunk, parse_mode: 'Markdown', disable_web_page_preview: true }),
+    });
+    if (!res.ok) {
+      console.warn(`[telegram] ${res.status} ${(await res.text()).slice(0, 200)}`);
+      return false;
+    }
+  }
+  return true;
+}
+
+async function main() {
+  console.log('━'.repeat(72));
+  console.log('Weekly narrative digest');
+  console.log('━'.repeat(72));
+  console.log(`Model: ${MODEL}  •  Telegram: ${SEND_TELEGRAM ? 'yes' : 'no'}`);
+  console.log();
+  console.log('Loading data…');
+
+  const [coverage, incoming, cash, drift, overdueAR, weekAgo] = await Promise.all([
+    loadCoverage(),
+    loadIncoming(),
+    loadCash(),
+    loadDriftTop3(),
+    loadOverdueAR(),
+    loadWeekDeltas(),
+  ]);
+
+  const data = { coverage, incoming, cash, drift, overdueAR, weekAgo };
+  const userPrompt = buildUserPrompt(data);
+
+  console.log('Asking Sonnet to narrate…');
+  const narrative = await trackedClaudeCompletion(userPrompt, SCRIPT_NAME, {
+    model: MODEL,
+    system: SYSTEM_PROMPT,
+    maxTokens: 900,
+    operation: 'narrate_weekly',
+  });
+
+  console.log();
+  console.log('━'.repeat(72));
+  console.log(narrative);
+  console.log('━'.repeat(72));
+  console.log();
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (!NO_WRITE) {
+    if (!existsSync(WIKI_DIR)) mkdirSync(WIKI_DIR, { recursive: true });
+    const outPath = path.join(WIKI_DIR, `weekly-narrative-${today}.md`);
+    const front = [
+      '---',
+      `title: Weekly money narrative — ${today}`,
+      `status: published`,
+      `generated_by: scripts/narrate-weekly-digest.mjs`,
+      `model: ${MODEL}`,
+      `cash_in_bank: ${cash.total}`,
+      `incoming_90d: ${incoming.projected90d}`,
+      `coverage_xero_txns: ${(coverage.transactions.tagged * 100 / Math.max(coverage.transactions.total, 1)).toFixed(1)}%`,
+      '---',
+      '',
+    ].join('\n');
+    writeFileSync(outPath, front + narrative + '\n');
+    console.log(`Wrote ${outPath}`);
+  }
+
+  if (SEND_TELEGRAM) {
+    const tgMessage = `📰 *Weekly money narrative* — ${today}\n\n${narrative}`;
+    const sent = await sendTelegram(tgMessage);
+    if (sent) console.log('Telegram: sent');
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/ocr-dext-processing.mjs
+++ b/scripts/ocr-dext-processing.mjs
@@ -17,23 +17,33 @@
  * Usage:
  *   node scripts/ocr-dext-processing.mjs                # Dry run, all candidates
  *   node scripts/ocr-dext-processing.mjs --apply         # Write updates
+ *   node scripts/ocr-dext-processing.mjs --local --apply # Local-only OCR, no external AI
  *   node scripts/ocr-dext-processing.mjs --apply --limit 5  # Small test batch
  *   node scripts/ocr-dext-processing.mjs --concurrency 3    # Parallel workers (default 3)
  */
 import './lib/load-env.mjs';
 import { createClient } from '@supabase/supabase-js';
 import { GoogleGenAI, Type } from '@google/genai';
+import { execFile as execFileCb } from 'child_process';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { extname, join } from 'path';
+import { promisify } from 'util';
+
+const execFile = promisify(execFileCb);
+const CLI_ARGS = process.argv.slice(2);
+const USE_LOCAL_OCR = CLI_ARGS.includes('--local');
 
 const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || 'https://tednluwflfhxyucgwigh.supabase.co';
 const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
 const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
-if (!GEMINI_API_KEY) {
+if (!USE_LOCAL_OCR && !GEMINI_API_KEY) {
   console.error('GEMINI_API_KEY not set');
   process.exit(1);
 }
-const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
+const ai = USE_LOCAL_OCR ? null : new GoogleGenAI({ apiKey: GEMINI_API_KEY });
 
 // Gemini 2.5 Flash Lite — vision-capable, ~10× cheaper than Claude Haiku 4.5.
 // Falls back to gemini-flash-latest if Lite is overloaded.
@@ -121,7 +131,9 @@ function mediaTypeFor(contentType, filename) {
   return 'image/jpeg'; // safe default
 }
 
-async function extractFieldsFromReceipt(buffer, mediaType) {
+async function extractFieldsFromReceipt(buffer, mediaType, row = null) {
+  if (USE_LOCAL_OCR) return extractFieldsFromReceiptLocal(buffer, mediaType, row);
+
   // Gemini accepts images and PDFs via inlineData parts — native multimodal
   const inlineData = { mimeType: mediaType, data: buffer.toString('base64') };
 
@@ -165,6 +177,157 @@ async function extractFieldsFromReceipt(buffer, mediaType) {
   return { extracted, usage: response.usageMetadata };
 }
 
+function fileExtFor(mediaType) {
+  if (mediaType === 'application/pdf') return '.pdf';
+  if (mediaType === 'image/png') return '.png';
+  if (mediaType === 'image/heic') return '.heic';
+  if (mediaType === 'image/webp') return '.webp';
+  if (mediaType === 'image/tiff') return '.tiff';
+  return '.jpg';
+}
+
+async function extractTextLocal(buffer, mediaType) {
+  const dir = await mkdtemp(join(tmpdir(), 'act-receipt-ocr-'));
+  try {
+    const inputPath = join(dir, `receipt${fileExtFor(mediaType)}`);
+    await writeFile(inputPath, buffer);
+
+    if (mediaType === 'application/pdf') {
+      const { stdout } = await execFile('pdftotext', ['-layout', inputPath, '-'], { timeout: 30000, maxBuffer: 5 * 1024 * 1024 });
+      if (stdout.trim().length > 40) return stdout;
+
+      const pngPath = join(dir, 'page-0.png');
+      const pngPrefix = join(dir, 'page-0');
+      try {
+        await execFile('pdftoppm', ['-f', '1', '-singlefile', '-r', '200', '-png', '-gray', inputPath, pngPrefix], { timeout: 60000 });
+      } catch {
+        await execFile('magick', ['-density', '200', `${inputPath}[0]`, '-colorspace', 'Gray', pngPath], { timeout: 60000 });
+      }
+      const ocr = await execFile('tesseract', [pngPath, 'stdout', '--psm', '6'], { timeout: 60000, maxBuffer: 5 * 1024 * 1024 });
+      return ocr.stdout;
+    }
+
+    let ocrPath = inputPath;
+    if (!['image/jpeg', 'image/png', 'image/tiff'].includes(mediaType)) {
+      ocrPath = join(dir, `converted${extname(inputPath) === '.png' ? '.jpg' : '.png'}`);
+      await execFile('magick', [inputPath, '-auto-orient', '-colorspace', 'Gray', ocrPath], { timeout: 60000 });
+    }
+
+    const { stdout } = await execFile('tesseract', [ocrPath, 'stdout', '--psm', '6'], { timeout: 60000, maxBuffer: 5 * 1024 * 1024 });
+    return stdout;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function normalizeOcrLines(text) {
+  return text
+    .split(/\r?\n/)
+    .map(line => line.replace(/\s+/g, ' ').trim())
+    .filter(Boolean);
+}
+
+function parseVendorFromText(text) {
+  const skip = /(tax invoice|receipt|duplicate|eftpos|merchant|customer copy|abn|tax inv|invoice no|date|time|total|visa|mastercard|approved|purchase|terminal|cashier|subtotal|gst|forwarded message|begin forwarded|external sender|email not displaying|good morning|hi there|booking reference|policy number|order confirmation|loyalty offer|console)/i;
+  for (const line of normalizeOcrLines(text).slice(0, 18)) {
+    const cleaned = line
+      .replace(/\bABN\b.*$/i, '')
+      .replace(/[^A-Za-z0-9&'()./ -]/g, '')
+      .trim();
+    if (cleaned.length >= 3 && /[A-Za-z]/.test(cleaned) && !skip.test(cleaned)) {
+      return cleaned.slice(0, 80);
+    }
+  }
+  return null;
+}
+
+function inferVendorFromFilename(filename) {
+  if (!filename || /^receipt\./i.test(filename) || /unknown-supplier/i.test(filename)) return null;
+  const stem = filename
+    .replace(/\.[^.]+$/, '')
+    .replace(/[-_]+receipt$/i, '')
+    .replace(/[-_]+invoice$/i, '')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+  if (!stem || /^download\s+\d+/i.test(stem)) return null;
+  return stem.slice(0, 80);
+}
+
+function parseDateFromText(text) {
+  const monthMap = {
+    jan: '01', january: '01', feb: '02', february: '02', mar: '03', march: '03',
+    apr: '04', april: '04', may: '05', jun: '06', june: '06', jul: '07', july: '07',
+    aug: '08', august: '08', sep: '09', sept: '09', september: '09', oct: '10', october: '10',
+    nov: '11', november: '11', dec: '12', december: '12',
+  };
+
+  const iso = text.match(/\b(20\d{2})[-/](\d{1,2})[-/](\d{1,2})\b/);
+  if (iso) return `${iso[1]}-${iso[2].padStart(2, '0')}-${iso[3].padStart(2, '0')}`;
+
+  const au = text.match(/\b(\d{1,2})[/-](\d{1,2})[/-](20\d{2}|\d{2})\b/);
+  if (au) {
+    const year = au[3].length === 2 ? `20${au[3]}` : au[3];
+    return `${year}-${au[2].padStart(2, '0')}-${au[1].padStart(2, '0')}`;
+  }
+
+  const named = text.match(/\b(\d{1,2})\s+([A-Za-z]{3,9})\s+(20\d{2}|\d{2})\b/);
+  if (named) {
+    const month = monthMap[named[2].toLowerCase()];
+    if (month) {
+      const year = named[3].length === 2 ? `20${named[3]}` : named[3];
+      return `${year}-${month}-${named[1].padStart(2, '0')}`;
+    }
+  }
+
+  return null;
+}
+
+function parseAmountFromText(text) {
+  const lines = normalizeOcrLines(text);
+  const money = /(?:AUD|A\$|\$)?\s*([0-9]{1,3}(?:,[0-9]{3})*\.[0-9]{2}|[0-9]+\.[0-9]{2})/g;
+  const candidates = [];
+
+  for (const line of lines) {
+    const lower = line.toLowerCase();
+    let match;
+    while ((match = money.exec(line)) !== null) {
+      const amount = Number(match[1].replace(/,/g, ''));
+      if (!Number.isFinite(amount) || amount <= 0 || amount > 100000) continue;
+      let weight = 1;
+      if (/(grand\s+total|amount\s+paid|total\s+paid|payment\s+total|balance\s+due)/i.test(lower)) weight = 5;
+      else if (/\btotal\b/i.test(lower)) weight = 4;
+      else if (/\bamount\b|\bpaid\b/i.test(lower)) weight = 3;
+      else if (/\bgst\b|\btax\b|\bsubtotal\b|\bchange\b/i.test(lower)) weight = 0.5;
+      candidates.push({ amount, weight });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => (b.weight - a.weight) || (b.amount - a.amount));
+  return candidates[0].amount;
+}
+
+async function extractFieldsFromReceiptLocal(buffer, mediaType, row = null) {
+  const text = await extractTextLocal(buffer, mediaType);
+  const vendorName = parseVendorFromText(text) || inferVendorFromFilename(row?.attachment_filename);
+  const date = parseDateFromText(text);
+  const amount = parseAmountFromText(text);
+  const knownFields = [vendorName, date, amount].filter(Boolean).length;
+  const confidence = knownFields === 3 ? 'high' : amount && vendorName ? 'medium' : 'low';
+
+  return {
+    extracted: {
+      vendor_name: vendorName || 'UNKNOWN',
+      transaction_date: date || 'UNKNOWN',
+      total_amount: amount || 0,
+      currency: 'AUD',
+      confidence,
+      notes: confidence === 'low' ? 'local OCR extracted limited fields' : 'local OCR',
+    },
+    usage: null,
+  };
+}
+
 function normalizeDate(s) {
   if (!s || s === 'UNKNOWN') return null;
   const iso = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
@@ -180,7 +343,7 @@ async function processRow(row, apply) {
     if (!buffer) return { row, status: 'skip', reason: 'no attachment' };
 
     const mediaType = mediaTypeFor(row.attachment_content_type, row.attachment_filename);
-    const { extracted, usage } = await extractFieldsFromReceipt(buffer, mediaType);
+      const { extracted, usage } = await extractFieldsFromReceipt(buffer, mediaType, row);
 
     const vendorName = extracted.vendor_name && extracted.vendor_name !== 'UNKNOWN' ? extracted.vendor_name : null;
     const date = normalizeDate(extracted.transaction_date);
@@ -196,7 +359,11 @@ async function processRow(row, apply) {
       usage,
     };
 
-    if (apply && (vendorName || date || amount)) {
+    const shouldWrite = USE_LOCAL_OCR
+      ? Boolean(vendorName && amount != null)
+      : Boolean(vendorName || date || amount);
+
+    if (apply && shouldWrite) {
       const update = {
         updated_at: new Date().toISOString(),
       };
@@ -204,7 +371,7 @@ async function processRow(row, apply) {
       if (amount != null) update.amount_detected = amount;
       if (currency) update.currency = currency;
       if (date) update.received_at = new Date(date + 'T12:00:00Z').toISOString();
-      update.match_method = `ocr_haiku_${confidence}`;
+      update.match_method = `${USE_LOCAL_OCR ? 'ocr_local' : 'ocr_haiku'}_${confidence}`;
       // Keep status as 'review' so the matcher can pick it up on next run
       if (row.status === 'review' || row.status === 'captured' || row.status === 'failed') {
         update.status = 'review';
@@ -221,14 +388,14 @@ async function processRow(row, apply) {
 }
 
 async function main() {
-  const args = process.argv.slice(2);
+  const args = CLI_ARGS;
   const apply = args.includes('--apply');
   const limitIdx = args.indexOf('--limit');
   const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : null;
   const concIdx = args.indexOf('--concurrency');
   const concurrency = concIdx !== -1 ? parseInt(args[concIdx + 1], 10) : 3;
 
-  console.log(`OCR Dext Processing — ${apply ? 'APPLY' : 'DRY RUN'} | model: ${MODEL} | concurrency: ${concurrency}${limit ? ` | limit: ${limit}` : ''}\n`);
+  console.log(`OCR Dext Processing — ${apply ? 'APPLY' : 'DRY RUN'} | mode: ${USE_LOCAL_OCR ? 'local' : MODEL} | concurrency: ${concurrency}${limit ? ` | limit: ${limit}` : ''}\n`);
 
   // Fetch target rows: receipts missing vendor/amount
   const sourcesIdx = args.indexOf('--sources');

--- a/scripts/poll-pre-publish-dext-grader.mjs
+++ b/scripts/poll-pre-publish-dext-grader.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Pre-publish Dext grader — polling wrapper around ai-route-dext-doc.mjs.
+ *
+ * Runs on cron every 15 min. Grades every fresh finance_receipt_document
+ * (OCR'd Dext or email receipt) that doesn't have an AI suggestion yet.
+ * Result lands in finance_ai_routing_suggestions so the workbench can
+ * surface "Here's the AI grade — accept / change / reject" before you
+ * publish to Xero.
+ *
+ * This is the "AI looks at every receipt before you do" step.
+ *
+ * Usage:
+ *   node scripts/poll-pre-publish-dext-grader.mjs              # dry run
+ *   node scripts/poll-pre-publish-dext-grader.mjs --apply      # auto-apply high-conf
+ *   node scripts/poll-pre-publish-dext-grader.mjs --batch 50   # bigger batch
+ *
+ * Cron: every 15 min during business hours, 8:00-18:00 AEST weekdays.
+ *   pm2 entry "pre-publish-dext-grader" → ecosystem.config.cjs
+ */
+
+import './lib/load-env.mjs';
+import { spawnSync } from 'node:child_process';
+import { createClient } from '@supabase/supabase-js';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const TELEGRAM = args.includes('--telegram');
+const BATCH = numberAfter('--batch', 30);
+const MIN_CONFIDENCE = numberAfter('--min-confidence', 0.85);
+
+function valueAfter(flag) {
+  const i = args.indexOf(flag);
+  return i === -1 ? null : args[i + 1];
+}
+function numberAfter(flag, fallback) {
+  const raw = valueAfter(flag);
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const TG_TOKEN = process.env.TELEGRAM_BOT_TOKEN;
+const TG_CHAT = (process.env.TELEGRAM_AUTHORIZED_USERS || '').split(',')[0]?.trim();
+
+async function pendingCount() {
+  const { data: graded } = await sb
+    .from('finance_ai_routing_suggestions')
+    .select('source_record_id')
+    .eq('source_table', 'finance_receipt_documents')
+    .eq('prompt_version', 'v1')
+    .eq('model', 'claude-sonnet-4-6');
+  const gradedSet = new Set((graded || []).map((r) => r.source_record_id));
+
+  const { count } = await sb
+    .from('finance_receipt_documents')
+    .select('*', { count: 'exact', head: true })
+    .not('vendor_name', 'is', null)
+    .not('amount_total', 'is', null);
+
+  // approximate — gradedSet is a tighter check via run-result diff
+  return { ungradedApprox: Math.max((count || 0) - gradedSet.size, 0), totalDocs: count || 0, gradedCount: gradedSet.size };
+}
+
+async function sendTelegram(text) {
+  if (!TG_TOKEN || !TG_CHAT) return false;
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${TG_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: TG_CHAT, text, parse_mode: 'Markdown' }),
+    });
+    return res.ok;
+  } catch (err) {
+    console.warn('telegram failed:', err.message);
+    return false;
+  }
+}
+
+async function main() {
+  const before = await pendingCount();
+  console.log(`Pre-publish Dext grader poll: ${before.ungradedApprox} ungraded of ${before.totalDocs} documents.`);
+
+  if (before.ungradedApprox === 0) {
+    console.log('Nothing to grade. Exiting clean.');
+    return;
+  }
+
+  const runArgs = ['scripts/ai-route-dext-doc.mjs', '--source', 'documents', '--limit', String(BATCH)];
+  if (APPLY) runArgs.push('--apply', '--min-confidence', String(MIN_CONFIDENCE));
+
+  console.log(`Running: node ${runArgs.join(' ')}`);
+  const result = spawnSync('node', runArgs, { stdio: 'inherit', cwd: path.resolve(__dirname, '..') });
+  if (result.status !== 0) {
+    console.error('Grader exited non-zero:', result.status);
+    process.exit(result.status || 1);
+  }
+
+  const after = await pendingCount();
+  const newlyGraded = after.gradedCount - before.gradedCount;
+  console.log(`\nNewly graded: ${newlyGraded}.  Remaining ungraded: ${after.ungradedApprox}.`);
+
+  if (TELEGRAM && newlyGraded > 0) {
+    // Top high-confidence + risky to surface in the alert
+    const { data: latest } = await sb
+      .from('finance_ai_routing_suggestions')
+      .select('vendor_name, amount, suggested_project_code, confidence, risk_flags, reason')
+      .eq('source_table', 'finance_receipt_documents')
+      .gte('created_at', new Date(Date.now() - 30 * 60 * 1000).toISOString())
+      .order('confidence', { ascending: false })
+      .limit(10);
+
+    const safe = (latest || []).filter((r) => r.confidence >= MIN_CONFIDENCE && r.suggested_project_code !== 'ASK_USER' && r.suggested_project_code !== 'SL_REVIEW');
+    const review = (latest || []).filter((r) => r.confidence < MIN_CONFIDENCE || r.suggested_project_code === 'ASK_USER' || r.suggested_project_code === 'SL_REVIEW');
+
+    const lines = [`🔍 Pre-publish Dext grader: ${newlyGraded} new docs graded.`];
+    if (safe.length) {
+      lines.push('', `*Safe to publish (≥${(MIN_CONFIDENCE * 100).toFixed(0)}%)*:`);
+      safe.slice(0, 5).forEach((r) => {
+        lines.push(`• ${r.suggested_project_code}  ${r.vendor_name?.slice(0, 30)}  $${Number(r.amount).toLocaleString()}  ${(r.confidence * 100).toFixed(0)}%`);
+      });
+    }
+    if (review.length) {
+      lines.push('', `*Need review*:`);
+      review.slice(0, 5).forEach((r) => {
+        const flags = r.risk_flags?.length ? ` [${r.risk_flags.slice(0, 3).join(',')}]` : '';
+        lines.push(`• ${r.suggested_project_code}  ${r.vendor_name?.slice(0, 30)}  $${Number(r.amount).toLocaleString()}  ${(r.confidence * 100).toFixed(0)}%${flags}`);
+      });
+    }
+    lines.push('', 'Open /finance/workbench filter=needs_project to triage.');
+    await sendTelegram(lines.join('\n'));
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/refresh-xero-token.mjs
+++ b/scripts/refresh-xero-token.mjs
@@ -5,7 +5,7 @@
  */
 import '../lib/load-env.mjs';
 import { createClient } from '@supabase/supabase-js';
-import { writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 
 const XERO_CLIENT_ID = process.env.XERO_CLIENT_ID;
 const XERO_CLIENT_SECRET = process.env.XERO_CLIENT_SECRET;
@@ -13,6 +13,21 @@ const XERO_CLIENT_SECRET = process.env.XERO_CLIENT_SECRET;
 const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+function updateEnvRefreshToken(refreshToken) {
+  const envFile = '.env.local';
+  if (!existsSync(envFile)) return false;
+
+  let envBody = readFileSync(envFile, 'utf8');
+  const line = `XERO_REFRESH_TOKEN=${refreshToken}`;
+  if (/^XERO_REFRESH_TOKEN=/m.test(envBody)) {
+    envBody = envBody.replace(/^XERO_REFRESH_TOKEN=.*/m, line);
+  } else {
+    envBody = `${envBody.trimEnd()}\n${line}\n`;
+  }
+  writeFileSync(envFile, envBody);
+  return true;
+}
 
 async function main() {
   console.log('=== Xero Token Refresh ===\n');
@@ -80,6 +95,9 @@ async function main() {
     expires_at: expiresAt.getTime(),
   }, null, 2));
   console.log('Saved to .xero-tokens.json');
+  if (updateEnvRefreshToken(tokens.refresh_token)) {
+    console.log('Saved rotated refresh token to .env.local');
+  }
 
   // Verify: get connections
   console.log('\nVerifying connection...');
@@ -104,6 +122,8 @@ async function main() {
     { name: 'BankTransactions', url: 'https://api.xero.com/api.xro/2.0/BankTransactions?page=1&pageSize=1' },
     { name: 'Invoices', url: 'https://api.xero.com/api.xro/2.0/Invoices?page=1&pageSize=1' },
     { name: 'Contacts', url: 'https://api.xero.com/api.xro/2.0/Contacts?page=1&pageSize=1' },
+    { name: 'Receipts', url: 'https://api.xero.com/api.xro/2.0/Receipts' },
+    { name: 'ExpenseClaims', url: 'https://api.xero.com/api.xro/2.0/ExpenseClaims' },
     { name: 'TrackingCategories', url: 'https://api.xero.com/api.xro/2.0/TrackingCategories' },
     { name: 'ManualJournals', url: 'https://api.xero.com/api.xro/2.0/ManualJournals?page=1&pageSize=1' },
     { name: 'Reports/ProfitAndLoss', url: 'https://api.xero.com/api.xro/2.0/Reports/ProfitAndLoss' },
@@ -142,16 +162,31 @@ async function main() {
   // Check what scopes we NEED for full suite
   const NEEDED_SCOPES = [
     'openid', 'profile', 'email', 'offline_access',
-    'accounting.transactions',           // read+write bank transactions
-    'accounting.transactions.read',      // read transactions
-    'accounting.contacts',               // read+write contacts
-    'accounting.contacts.read',          // read contacts
-    'accounting.attachments',            // upload attachments
-    'accounting.settings',               // tracking categories read+write
-    'accounting.settings.read',          // tracking categories read
-    'accounting.reports.read',           // P&L, balance sheet, budget
-    'accounting.budgets.read',           // budget reports
-    'accounting.journals.read',          // manual journals read
+    'accounting.transactions',
+    'accounting.transactions.read',
+    'accounting.banktransactions',
+    'accounting.banktransactions.read',
+    'accounting.invoices',
+    'accounting.invoices.read',
+    'accounting.payments',
+    'accounting.payments.read',
+    'accounting.contacts',
+    'accounting.contacts.read',
+    'accounting.attachments',
+    'accounting.settings',
+    'accounting.settings.read',
+    'accounting.reports.read',
+    'accounting.reports.aged.read',
+    'accounting.reports.balancesheet.read',
+    'accounting.reports.profitandloss.read',
+    'accounting.reports.trialbalance.read',
+    'accounting.budgets.read',
+    'accounting.journals.read',
+    'accounting.manualjournals',
+    'accounting.manualjournals.read',
+    'assets.read',
+    'files',
+    'files.read',
   ];
 
   console.log('\n=== Scope Recommendations ===');

--- a/scripts/sync-compliance-calendar-to-notion.mjs
+++ b/scripts/sync-compliance-calendar-to-notion.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+/**
+ * Sync compliance calendar → Notion. Outbound-only mirror.
+ *
+ * Reads thoughts/shared/data/compliance-calendar/<latest>.json and writes it
+ * as a child block under the Notion page identified by NOTION_COMPLIANCE_PAGE_ID.
+ *
+ * If NOTION_COMPLIANCE_PAGE_ID is unset, prints setup instructions and exits 0
+ * (so a missing env var doesn't break the daily cron chain).
+ *
+ * Strategy: clear the page's children, then write fresh blocks. Simple and safe
+ * for a read-only page — but DON'T point this at any page you hand-curate.
+ *
+ * Usage:
+ *   node scripts/sync-compliance-calendar-to-notion.mjs              # apply
+ *   node scripts/sync-compliance-calendar-to-notion.mjs --dry-run    # print payload, don't write
+ */
+
+import { config as loadEnv } from 'dotenv'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO = path.resolve(__dirname, '..')
+loadEnv({ path: path.join(REPO, '.env.local') })
+loadEnv({ path: path.join(REPO, '.env') })
+
+const DRY_RUN = process.argv.includes('--dry-run')
+const PAGE_ID = process.env.NOTION_COMPLIANCE_PAGE_ID
+const NOTION_TOKEN = process.env.NOTION_TOKEN
+
+const SNAPSHOT_DIR = path.join(REPO, 'thoughts', 'shared', 'data', 'compliance-calendar')
+
+function readLatestSnapshot() {
+  if (!existsSync(SNAPSHOT_DIR)) return null
+  const files = readdirSync(SNAPSHOT_DIR).filter(f => f.endsWith('.json')).sort()
+  if (files.length === 0) return null
+  return JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, files[files.length - 1]), 'utf8'))
+}
+
+const NOTION_API = 'https://api.notion.com/v1'
+const NOTION_VERSION = '2022-06-28'
+
+async function notionFetch(path, init = {}) {
+  const res = await fetch(`${NOTION_API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${NOTION_TOKEN}`,
+      'Notion-Version': NOTION_VERSION,
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {}),
+    },
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Notion ${path}: ${res.status} ${body.slice(0, 200)}`)
+  }
+  return res.json()
+}
+
+function severityEmoji(sev) {
+  return { critical: '🔴', high: '🟠', medium: '🟡' }[sev] ?? '⚪'
+}
+
+function statusEmoji(status) {
+  return { pending: '⏳', filed: '✓', overdue: '🔴', superseded: '—', waived: '—' }[status] ?? '?'
+}
+
+function buildBlocks(snap) {
+  const blocks = []
+  const today = new Date().toISOString().slice(0, 10)
+
+  // Heading
+  blocks.push({
+    type: 'heading_1',
+    heading_1: { rich_text: [{ type: 'text', text: { content: '📋 ACT Compliance Calendar' } }] },
+  })
+  blocks.push({
+    type: 'paragraph',
+    paragraph: {
+      rich_text: [
+        {
+          type: 'text',
+          text: { content: `Read-only mirror of wiki/finance/compliance-calendar.md. Refreshed ${today}. Source ledger lives in git — do not edit this Notion page.` },
+          annotations: { italic: true, color: 'gray' },
+        },
+      ],
+    },
+  })
+
+  // Counters
+  const c = snap.counters
+  blocks.push({
+    type: 'callout',
+    callout: {
+      icon: { type: 'emoji', emoji: '⚠️' },
+      rich_text: [{
+        type: 'text',
+        text: { content: `${c.critical} critical · ${c.high} high · ${c.medium} medium · ${c.filed} filed` },
+      }],
+      color: c.critical > 0 ? 'red_background' : c.high > 0 ? 'orange_background' : 'gray_background',
+    },
+  })
+
+  // Group by status: at-risk first, then upcoming, then filed
+  const atRisk = snap.obligations.filter(o => o.at_risk)
+  const upcoming = snap.obligations.filter(o => !o.at_risk && o.status === 'pending')
+  const filed = snap.obligations.filter(o => o.status === 'filed')
+
+  if (atRisk.length > 0) {
+    blocks.push({
+      type: 'heading_2',
+      heading_2: { rich_text: [{ type: 'text', text: { content: '🔥 At risk' } }] },
+    })
+    for (const o of atRisk) blocks.push(obligationBlock(o))
+  }
+
+  if (upcoming.length > 0) {
+    blocks.push({
+      type: 'heading_2',
+      heading_2: { rich_text: [{ type: 'text', text: { content: '📅 Upcoming' } }] },
+    })
+    for (const o of upcoming) blocks.push(obligationBlock(o))
+  }
+
+  if (filed.length > 0) {
+    blocks.push({
+      type: 'heading_2',
+      heading_2: { rich_text: [{ type: 'text', text: { content: '✓ Filed' } }] },
+    })
+    for (const o of filed) blocks.push(obligationBlock(o))
+  }
+
+  return blocks
+}
+
+function obligationBlock(o) {
+  const sev = severityEmoji(o.severity)
+  const st = statusEmoji(o.status)
+  const dueDate = o.due_date ?? '?'
+  const dd = o.days_until_due
+  const ddTag = dd == null ? '' : dd < 0 ? `(${Math.abs(dd)}d overdue)` : `(T-${dd}d)`
+  const refundLine = o.expected_refund_aud ? ` · expected refund $${o.expected_refund_aud.toLocaleString()}` : ''
+
+  return {
+    type: 'paragraph',
+    paragraph: {
+      rich_text: [
+        { type: 'text', text: { content: `${sev} ${st} ` } },
+        { type: 'text', text: { content: o.title }, annotations: { bold: true } },
+        { type: 'text', text: { content: ` · ${o.entity} · ${o.type}` }, annotations: { color: 'gray' } },
+        { type: 'text', text: { content: `\n📅 due ${dueDate} ${ddTag}${refundLine}` }, annotations: { color: 'gray' } },
+      ],
+    },
+  }
+}
+
+async function clearPageChildren(pageId) {
+  let cursor
+  const allBlockIds = []
+  do {
+    const res = await notionFetch(`/blocks/${pageId}/children?page_size=100${cursor ? `&start_cursor=${cursor}` : ''}`)
+    for (const b of res.results) allBlockIds.push(b.id)
+    cursor = res.has_more ? res.next_cursor : null
+  } while (cursor)
+  for (const id of allBlockIds) {
+    await notionFetch(`/blocks/${id}`, { method: 'DELETE' })
+  }
+  return allBlockIds.length
+}
+
+async function appendBlocks(pageId, blocks) {
+  // Notion appends max 100 children per request
+  for (let i = 0; i < blocks.length; i += 100) {
+    const chunk = blocks.slice(i, i + 100)
+    await notionFetch(`/blocks/${pageId}/children`, {
+      method: 'PATCH',
+      body: JSON.stringify({ children: chunk }),
+    })
+  }
+}
+
+async function main() {
+  if (!NOTION_TOKEN) {
+    console.error('NOTION_TOKEN not set. Skipping.')
+    process.exit(0)
+  }
+  if (!PAGE_ID) {
+    console.error('NOTION_COMPLIANCE_PAGE_ID not set. To enable:')
+    console.error('  1. Create a Notion page under the ACT Money Framework (titled e.g. "Compliance Calendar")')
+    console.error('  2. Share it with your Notion integration')
+    console.error('  3. Add `NOTION_COMPLIANCE_PAGE_ID=<page_id>` to .env.local')
+    console.error('  4. Re-run this script')
+    process.exit(0)
+  }
+
+  const snap = readLatestSnapshot()
+  if (!snap) {
+    console.error('No compliance snapshot found — run scripts/build-compliance-calendar.mjs first')
+    process.exit(2)
+  }
+
+  const blocks = buildBlocks(snap)
+  console.log(`Built ${blocks.length} Notion blocks from ${snap.obligations.length} obligations`)
+
+  if (DRY_RUN) {
+    console.log('DRY-RUN: payload preview (first 3 blocks):')
+    console.log(JSON.stringify(blocks.slice(0, 3), null, 2))
+    return
+  }
+
+  const cleared = await clearPageChildren(PAGE_ID)
+  console.log(`Cleared ${cleared} existing blocks`)
+  await appendBlocks(PAGE_ID, blocks)
+  console.log(`Wrote ${blocks.length} blocks to Notion page ${PAGE_ID}`)
+}
+
+main().catch(e => { console.error(e); process.exit(1) })

--- a/scripts/sync-xero-bank-feed.mjs
+++ b/scripts/sync-xero-bank-feed.mjs
@@ -63,6 +63,20 @@ function saveTokens(accessToken, refreshToken, expiresIn) {
       expires_at: Date.now() + (expiresIn * 1000) - 60000
     }, null, 2));
   } catch (e) {}
+
+  try {
+    const envFile = path.join(process.cwd(), '.env.local');
+    if (existsSync(envFile)) {
+      let envBody = readFileSync(envFile, 'utf8');
+      const line = `XERO_REFRESH_TOKEN=${refreshToken}`;
+      if (/^XERO_REFRESH_TOKEN=/m.test(envBody)) {
+        envBody = envBody.replace(/^XERO_REFRESH_TOKEN=.*/m, line);
+      } else {
+        envBody = `${envBody.trimEnd()}\n${line}\n`;
+      }
+      writeFileSync(envFile, envBody);
+    }
+  } catch (e) {}
 }
 
 async function loadTokenFromSupabase() {

--- a/scripts/sync-xero-to-supabase.mjs
+++ b/scripts/sync-xero-to-supabase.mjs
@@ -103,6 +103,22 @@ function saveTokens(accessToken, refreshToken, expiresIn) {
   } catch (e) {
     console.warn('Could not save tokens locally:', e.message);
   }
+
+  try {
+    const envFile = path.join(process.cwd(), '.env.local');
+    if (existsSync(envFile)) {
+      let envBody = readFileSync(envFile, 'utf8');
+      const line = `XERO_REFRESH_TOKEN=${refreshToken}`;
+      if (/^XERO_REFRESH_TOKEN=/m.test(envBody)) {
+        envBody = envBody.replace(/^XERO_REFRESH_TOKEN=.*/m, line);
+      } else {
+        envBody = `${envBody.trimEnd()}\n${line}\n`;
+      }
+      writeFileSync(envFile, envBody);
+    }
+  } catch (e) {
+    console.warn('Could not update .env.local refresh token:', e.message);
+  }
 }
 
 /**

--- a/scripts/sync-xero-tokens.mjs
+++ b/scripts/sync-xero-tokens.mjs
@@ -201,6 +201,14 @@ async function main() {
     process.exit(1);
   }
 
+  if (dryRun) {
+    console.log('\nDry run: not testing refresh tokens against Xero.');
+    console.log('Reason: Xero rotates refresh tokens on every successful refresh, so a true');
+    console.log('read-only dry run would invalidate the working token without persisting it.');
+    console.log('Run without --dry-run to diagnose and persist the refreshed token safely.');
+    return;
+  }
+
   console.log('\nTesting each candidate against Xero...');
   let working = null;
   for (const c of unique) {

--- a/scripts/tag-transactions-by-vendor.mjs
+++ b/scripts/tag-transactions-by-vendor.mjs
@@ -171,23 +171,10 @@ function matchKeywords(text, keywordMap) {
 }
 
 async function showStats() {
-  const { data: total } = await supabase
-    .from('xero_transactions')
-    .select('id', { count: 'exact', head: true });
-
-  const { data: tagged } = await supabase
-    .from('xero_transactions')
-    .select('id', { count: 'exact', head: true })
-    .not('project_code', 'is', null);
-
   const { data: byProject } = await supabase.rpc('exec_sql', {
     query: `SELECT project_code, COUNT(*) as count FROM xero_transactions WHERE project_code IS NOT NULL GROUP BY project_code ORDER BY count DESC`
   });
 
-  const totalCount = total?.length ?? 0;
-  const taggedCount = tagged?.length ?? 0;
-
-  // Use count from response headers
   const { count: totalC } = await supabase
     .from('xero_transactions')
     .select('*', { count: 'exact', head: true });
@@ -205,18 +192,9 @@ async function showStats() {
   console.log(`Coverage:            ${totalC > 0 ? ((taggedC / totalC) * 100).toFixed(1) : 0}%`);
 
   // By project distribution
-  const { data: distribution } = await supabase
-    .from('xero_transactions')
-    .select('project_code')
-    .not('project_code', 'is', null);
-
-  if (distribution) {
-    const counts = {};
-    for (const row of distribution) {
-      counts[row.project_code] = (counts[row.project_code] || 0) + 1;
-    }
+  if (byProject) {
     console.log('\n📁 Distribution by Project:');
-    for (const [code, count] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+    for (const { project_code: code, count } of byProject) {
       console.log(`  ${code.padEnd(12)} ${count}`);
     }
   }

--- a/scripts/upload-receipts-to-xero.mjs
+++ b/scripts/upload-receipts-to-xero.mjs
@@ -327,6 +327,20 @@ async function showStatus() {
   }
 }
 
+async function updateReceiptRow(receiptId, updates) {
+  const { error } = await supabase
+    .from('receipt_emails')
+    .update({
+      ...updates,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', receiptId);
+
+  if (error) {
+    throw new Error(`receipt_emails update failed for ${receiptId}: ${error.message}`);
+  }
+}
+
 // ============================================================================
 // MAIN: UPLOAD MATCHED RECEIPTS
 // ============================================================================
@@ -402,13 +416,13 @@ async function uploadMatchedReceipts() {
         const xStatus = entity?.Status;
         if (xStatus === 'DELETED' || xStatus === 'VOIDED') {
           log(`  SKIP: Xero entity is ${xStatus} — cannot attach. Resetting to captured.`);
-          await supabase.from('receipt_emails').update({
+          await updateReceiptRow(receipt.id, {
             status: 'captured',
             xero_bank_transaction_id: null,
             xero_invoice_id: null,
             xero_transaction_id: null,
             error_message: `Xero entity ${entityId} is ${xStatus} — match invalidated`,
-          }).eq('id', receipt.id);
+          });
           // Also fix the mirror so the matcher stops re-matching to this entity
           if (entityType === 'BankTransactions') {
             await supabase.from('xero_transactions')
@@ -425,10 +439,9 @@ async function uploadMatchedReceipts() {
       const existing = await getExistingAttachments(entityId, entityType);
       if (existing && existing.length > 0) {
         log(`  SKIP: Transaction already has ${existing.length} attachment(s)`);
-        await supabase.rpc('update_receipt_match', {
-          receipt_id: receipt.id,
-          new_status: 'uploaded',
-          new_error_message: `Already had ${existing.length} attachment(s) — skipped duplicate upload`,
+        await updateReceiptRow(receipt.id, {
+          status: 'uploaded',
+          error_message: `Already had ${existing.length} attachment(s) — skipped duplicate upload`,
         });
         skipped++;
         await sleep(XERO_DELAY_MS);
@@ -457,11 +470,10 @@ async function uploadMatchedReceipts() {
       );
 
       // Mark as uploaded
-      await supabase.rpc('update_receipt_match', {
-        receipt_id: receipt.id,
-        new_status: 'uploaded',
-        new_error_message: null,
-        new_retry_count: receipt.retry_count || 0,
+      await updateReceiptRow(receipt.id, {
+        status: 'uploaded',
+        error_message: null,
+        retry_count: receipt.retry_count || 0,
       });
 
       const attachmentId = result?.Attachments?.[0]?.AttachmentID || 'ok';
@@ -473,11 +485,10 @@ async function uploadMatchedReceipts() {
       const retryCount = (receipt.retry_count || 0) + 1;
       const newStatus = retryCount >= 3 ? 'failed' : 'matched'; // retry if < 3 attempts
 
-      await supabase.rpc('update_receipt_match', {
-        receipt_id: receipt.id,
-        new_status: newStatus,
-        new_error_message: err.message,
-        new_retry_count: retryCount,
+      await updateReceiptRow(receipt.id, {
+        status: newStatus,
+        error_message: err.message,
+        retry_count: retryCount,
       });
 
       failed++;

--- a/scripts/xero-copilot-execute.mjs
+++ b/scripts/xero-copilot-execute.mjs
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * Drive the /api/finance/xero-page-copilot/execute endpoint from the CLI.
+ *
+ * Most useful: bulk attach_evidence — for every bank_statement_line
+ * that has an approved receipt link AND a matched Xero bank
+ * transaction without an attachment, upload the receipt PDF.
+ *
+ * This is the "make the Xero copilot actually click buttons" path.
+ *
+ * Usage:
+ *   node scripts/xero-copilot-execute.mjs --action attach_evidence --dry-run
+ *   node scripts/xero-copilot-execute.mjs --action attach_evidence --limit 20 --apply
+ *   node scripts/xero-copilot-execute.mjs --action attach_evidence --quarter Q2 --apply
+ */
+
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { createXeroClient } from './lib/finance/xero-client.mjs';
+import { Buffer } from 'node:buffer';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing Supabase URL / service role env vars.');
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+const DRY_RUN = !APPLY || args.includes('--dry-run');
+const ACTION = valueAfter('--action') || 'attach_evidence';
+const LIMIT = numberAfter('--limit', 25);
+const QUARTER = valueAfter('--quarter') || null;
+
+function valueAfter(flag) {
+  const i = args.indexOf(flag);
+  return i === -1 ? null : args[i + 1];
+}
+function numberAfter(flag, fallback) {
+  const raw = valueAfter(flag);
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const FY26_QUARTERS = {
+  Q1: { start: '2025-07-01', end: '2025-09-30' },
+  Q2: { start: '2025-10-01', end: '2025-12-31' },
+  Q3: { start: '2026-01-01', end: '2026-03-31' },
+  Q4: { start: '2026-04-01', end: '2026-06-30' },
+};
+
+function moneyCents(n) {
+  return Math.round(Math.abs(Number(n) || 0) * 100);
+}
+
+async function findAttachEvidenceCandidates() {
+  // bank_statement_lines.matched_xero_transaction_id is often NULL even when
+  // an approved receipt exists. We resolve the Xero bank txn by date+amount
+  // (within a 7-day window) against xero_transactions.
+  //
+  // Final candidate needs:
+  //   1. approved+best receipt link in finance_receipt_bank_line_links
+  //   2. a Xero bank txn within 7 days of the bank line at the same amount
+  //   3. that Xero txn has has_attachments=false
+  //   4. finance_receipt_documents has a downloadable file path
+
+  const quarter = QUARTER ? FY26_QUARTERS[QUARTER.toUpperCase()] : null;
+
+  let linksQuery = sb
+    .from('finance_receipt_bank_line_links')
+    .select('id,bank_line_id,receipt_document_id,confidence,xero_action,link_status,is_best_candidate')
+    .eq('link_status', 'approved')
+    .eq('is_best_candidate', true)
+    .eq('xero_action', 'attach_file')
+    .order('confidence', { ascending: false })
+    .limit(LIMIT * 4);
+
+  const { data: links, error: linksErr } = await linksQuery;
+  if (linksErr) throw new Error(`finance_receipt_bank_line_links: ${linksErr.message}`);
+  if (!links?.length) return [];
+
+  const bankIds = [...new Set(links.map((l) => l.bank_line_id))];
+  let banksQuery = sb
+    .from('bank_statement_lines')
+    .select('id,date,payee,amount,bank_account')
+    .in('id', bankIds);
+  if (quarter) {
+    banksQuery = banksQuery.gte('date', quarter.start).lte('date', quarter.end);
+  }
+  const { data: banks, error: banksErr } = await banksQuery;
+  if (banksErr) throw new Error(`bank_statement_lines: ${banksErr.message}`);
+  const bankById = new Map((banks || []).map((b) => [b.id, b]));
+
+  const docIds = [...new Set(links.map((l) => l.receipt_document_id))];
+  const { data: docs, error: docsErr } = await sb
+    .from('finance_receipt_documents')
+    .select('id,vendor_name,document_date,amount_total,attachment_storage_path,attachment_url,attachment_filename,attachment_content_type')
+    .in('id', docIds);
+  if (docsErr) throw new Error(`finance_receipt_documents: ${docsErr.message}`);
+  const docById = new Map((docs || []).map((d) => [d.id, d]));
+
+  // Pull a wide window of Xero txns to match against.
+  const dates = (banks || []).map((b) => b.date).filter(Boolean).sort();
+  if (!dates.length) return [];
+  const minDate = dates[0];
+  const maxDate = dates[dates.length - 1];
+  const { data: xeroTxns, error: xeroErr } = await sb
+    .from('xero_transactions')
+    .select('xero_transaction_id,date,total,type,contact_name,has_attachments')
+    .gte('date', minDate)
+    .lte('date', maxDate)
+    .eq('has_attachments', false)
+    .in('type', ['SPEND', 'SPEND-OVERPAYMENT', 'SPEND-PREPAYMENT']);
+  if (xeroErr) throw new Error(`xero_transactions: ${xeroErr.message}`);
+
+  const candidates = [];
+  for (const link of links) {
+    if (candidates.length >= LIMIT) break;
+    const bank = bankById.get(link.bank_line_id);
+    if (!bank) continue;
+    const doc = docById.get(link.receipt_document_id);
+    if (!doc) continue;
+    if (!doc.attachment_storage_path && !doc.attachment_url) continue;
+
+    const bankCents = moneyCents(bank.amount);
+    const bankTime = new Date(`${bank.date}T00:00:00`).getTime();
+    const xeroMatch = (xeroTxns || []).find((x) => {
+      if (moneyCents(x.total) !== bankCents) return false;
+      const dt = new Date(`${x.date}T00:00:00`).getTime();
+      return Math.abs(dt - bankTime) <= 7 * 86400000;
+    });
+    if (!xeroMatch) continue;
+
+    candidates.push({
+      bankLineId: bank.id,
+      bankPayee: bank.payee,
+      bankAmount: bank.amount,
+      bankDate: bank.date,
+      xeroBankTransactionId: xeroMatch.xero_transaction_id,
+      xeroContact: xeroMatch.contact_name,
+      receiptDocId: doc.id,
+      receiptStoragePath: doc.attachment_storage_path,
+      receiptUrl: doc.attachment_url,
+      receiptFilename: doc.attachment_filename,
+      receiptMime: doc.attachment_content_type,
+      confidence: link.confidence,
+    });
+  }
+
+  return candidates;
+}
+
+async function loadReceiptBytes(candidate) {
+  if (candidate.receiptStoragePath) {
+    const cleaned = candidate.receiptStoragePath.replace(/^receipt-attachments\//, '');
+    const { data, error } = await sb.storage.from('receipt-attachments').download(cleaned);
+    if (error || !data) return null;
+    const arrayBuffer = await data.arrayBuffer();
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      filename: candidate.receiptFilename || cleaned.split('/').pop() || 'receipt.pdf',
+      mime: data.type || candidate.receiptMime || 'application/pdf',
+    };
+  }
+  if (candidate.receiptUrl && /^https?:\/\//i.test(candidate.receiptUrl)) {
+    const res = await fetch(candidate.receiptUrl);
+    if (!res.ok) return null;
+    const arrayBuffer = await res.arrayBuffer();
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      filename: candidate.receiptFilename || candidate.receiptUrl.split('/').pop() || 'receipt.pdf',
+      mime: res.headers.get('content-type') || candidate.receiptMime || 'application/pdf',
+    };
+  }
+  return null;
+}
+
+async function executeAttachEvidence() {
+  console.log('━'.repeat(72));
+  console.log('Xero copilot executor — attach_evidence');
+  console.log('━'.repeat(72));
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN (no writes)' : 'APPLY (will write to Xero)'}`);
+  console.log(`Limit: ${LIMIT}${QUARTER ? `  •  Quarter: ${QUARTER}` : ''}`);
+  console.log();
+
+  const candidates = await findAttachEvidenceCandidates();
+  console.log(`Found ${candidates.length} bank lines with approved receipt + un-attached Xero txn.`);
+  if (!candidates.length) return;
+
+  let xero;
+  if (!DRY_RUN) {
+    xero = await createXeroClient(sb);
+  }
+
+  const results = { ok: 0, failed: 0, errors: [] };
+
+  for (let i = 0; i < candidates.length; i += 1) {
+    const c = candidates[i];
+    const label = `[${i + 1}/${candidates.length}] ${c.bankDate} ${c.bankPayee?.slice(0, 30) || '?'} $${c.bankAmount}`;
+    if (DRY_RUN) {
+      console.log(`${label}  →  would PUT ${c.receiptFilename || 'receipt.pdf'} → BankTransactions/${c.xeroBankTransactionId}/Attachments/`);
+      results.ok += 1;
+      continue;
+    }
+
+    process.stdout.write(`${label}  …  `);
+    const bytes = await loadReceiptBytes(c);
+    if (!bytes) {
+      console.log('FAIL (cannot load receipt bytes)');
+      results.failed += 1;
+      results.errors.push({ bankLineId: c.bankLineId, reason: 'cannot load receipt' });
+      continue;
+    }
+
+    try {
+      await xero.uploadAttachment(
+        'BankTransactions',
+        c.xeroBankTransactionId,
+        bytes.filename,
+        bytes.buffer,
+        bytes.mime,
+      );
+
+      // Refresh mirror state so we don't re-pick this candidate.
+      await sb
+        .from('xero_transactions')
+        .update({ has_attachments: true })
+        .eq('xero_transaction_id', c.xeroBankTransactionId);
+
+      console.log(`OK (${bytes.filename})`);
+      results.ok += 1;
+    } catch (err) {
+      const msg = (err.message || String(err)).slice(0, 200);
+      console.log(`FAIL ${msg}`);
+      results.failed += 1;
+      results.errors.push({ bankLineId: c.bankLineId, xero: c.xeroBankTransactionId, reason: msg });
+    }
+  }
+
+  console.log();
+  console.log('━'.repeat(72));
+  console.log('Summary');
+  console.log('━'.repeat(72));
+  console.log(`Attached: ${results.ok}`);
+  console.log(`Failed:   ${results.failed}`);
+  if (results.errors.length) {
+    console.log('\nFailures:');
+    results.errors.slice(0, 5).forEach((e) => {
+      console.log(`  • ${e.bankLineId}: ${e.reason}`);
+    });
+  }
+  if (DRY_RUN) console.log('\nRun with --apply to actually upload to Xero.');
+}
+
+async function main() {
+  if (ACTION === 'attach_evidence') {
+    await executeAttachEvidence();
+  } else {
+    console.error(`Unsupported --action ${ACTION}. Supported: attach_evidence.`);
+    console.error('For find_match_bill and transfer, use the HTTP API directly (POST /api/finance/xero-page-copilot/execute).');
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/xero-files-library-scan.mjs
+++ b/scripts/xero-files-library-scan.mjs
@@ -9,13 +9,7 @@
  *
  * Safe: read-only. Surfaces candidates for human review.
  *
- * ⚠️ REQUIRES: Xero OAuth app must be authorized with `files` scope.
- * Current ACT app only has accounting scopes — this script will 401 until
- * the app is re-authorized with files.read. To fix:
- *   1. Update Xero app scopes at https://developer.xero.com
- *   2. Add: files.read
- *   3. Have Nic re-authorize at the OAuth consent screen
- *   4. New refresh token flows through sync-xero-tokens.mjs automatically
+ * Requires Xero OAuth scopes `files` and `files.read`.
  *
  * Usage:
  *   node scripts/xero-files-library-scan.mjs          # full scan
@@ -60,6 +54,27 @@ async function refreshXeroToken() {
   XERO_ACCESS_TOKEN = d.access_token;
   XERO_REFRESH_TOKEN = d.refresh_token;
   writeFileSync(TOKEN_FILE, JSON.stringify({ access_token: d.access_token, refresh_token: d.refresh_token, expires_at: Date.now() + d.expires_in * 1000 - 60000 }, null, 2));
+  if (SUPABASE_KEY) {
+    const expiresAt = new Date(Date.now() + d.expires_in * 1000 - 60000).toISOString();
+    await sb.from('xero_tokens').upsert({
+      id: 'default',
+      access_token: d.access_token,
+      refresh_token: d.refresh_token,
+      expires_at: expiresAt,
+      updated_at: new Date().toISOString(),
+      updated_by: 'xero-files-library-scan',
+    }, { onConflict: 'id' });
+  }
+  if (existsSync('.env.local')) {
+    let envBody = readFileSync('.env.local', 'utf8');
+    const line = `XERO_REFRESH_TOKEN=${d.refresh_token}`;
+    if (/^XERO_REFRESH_TOKEN=/m.test(envBody)) {
+      envBody = envBody.replace(/^XERO_REFRESH_TOKEN=.*/m, line);
+    } else {
+      envBody = `${envBody.trimEnd()}\n${line}\n`;
+    }
+    writeFileSync('.env.local', envBody);
+  }
   return true;
 }
 
@@ -202,7 +217,40 @@ async function main() {
   }
 
   writeFileSync(reportPath, lines.join('\n'));
+  writeFileSync(`${reportPath}.provenance.md`, [
+    '# Provenance: Xero Files Library Scan',
+    '',
+    `Report: ${reportPath}`,
+    `Generated: ${new Date().toISOString()}`,
+    '',
+    '## Data Sources Queried',
+    '- Xero Files API `GET /Files`.',
+    '- Xero Files API `GET /Folders`.',
+    '- Supabase `xero_transactions` for unreceipted SPEND transaction names.',
+    '- Supabase `xero_tokens` for token refresh persistence if required.',
+    '',
+    '## Mutations',
+    '- No Xero accounting or Files Library mutation was performed.',
+    '- OAuth token mirrors may be rotated and persisted when the access token is expired.',
+    '',
+    '## Verified',
+    '- File/folder counts come from live Xero Files API responses.',
+    '- Missing-vendor comparisons use current Supabase Xero transaction mirror rows.',
+    '',
+    '## Inferred',
+    '- Vendor matches are filename heuristics only; amount/date must be checked before linking.',
+    '',
+    '## Unknown',
+    '- Whether a floating file is the correct receipt until a human confirms image/PDF content.',
+    '',
+    '## Reproduce',
+    '```bash',
+    'node scripts/xero-files-library-scan.mjs',
+    '```',
+    '',
+  ].join('\n'));
   console.log(`\nReport: ${reportPath}`);
+  console.log(`Provenance: ${reportPath}.provenance.md`);
 }
 
 main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/xero-mcp-wrapper.sh
+++ b/scripts/xero-mcp-wrapper.sh
@@ -1,29 +1,67 @@
 #!/bin/bash
-# Wrapper that refreshes a Xero access token, then launches the MCP server
-# with XERO_CLIENT_BEARER_TOKEN so it uses bearer-token mode.
+# Wrapper that launches the official Xero MCP server in bearer-token mode.
+#
+# Xero rotates refresh tokens on every refresh. The ACT workspace has three
+# token mirrors (.env.local, .xero-tokens.json, Supabase xero_tokens), so this
+# wrapper must reconcile them before MCP starts or the server can boot with a
+# stale token and return 401 for every tool call.
 
 set -euo pipefail
 
-# Source env vars (Client ID, Secret, Refresh Token)
-ENV_FILE="$(dirname "$0")/../.env.local"
-if [ -f "$ENV_FILE" ]; then
-  export $(grep -E '^XERO_' "$ENV_FILE" | xargs)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOKEN_FILE="$REPO_ROOT/.xero-tokens.json"
+
+log() {
+  printf 'xero-mcp-wrapper: %s\n' "$*" >&2
+}
+
+cd "$REPO_ROOT"
+
+if [ ! -f "$REPO_ROOT/scripts/sync-xero-tokens.mjs" ]; then
+  log "missing scripts/sync-xero-tokens.mjs"
+  exit 1
 fi
 
-# Refresh the access token
-TOKEN_RESPONSE=$(curl -s -X POST https://identity.xero.com/connect/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "grant_type=refresh_token&client_id=${XERO_CLIENT_ID}&client_secret=${XERO_CLIENT_SECRET}&refresh_token=${XERO_REFRESH_TOKEN}")
+log "syncing Xero token mirrors"
+node "$REPO_ROOT/scripts/sync-xero-tokens.mjs" >&2
 
-ACCESS_TOKEN=$(echo "$TOKEN_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
-NEW_REFRESH=$(echo "$TOKEN_RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['refresh_token'])")
-
-# Persist the rotated refresh token back to .env.local
-if [ -n "$NEW_REFRESH" ] && [ "$NEW_REFRESH" != "null" ]; then
-  sed -i '' "s|^XERO_REFRESH_TOKEN=.*|XERO_REFRESH_TOKEN=${NEW_REFRESH}|" "$ENV_FILE"
+if [ ! -f "$TOKEN_FILE" ]; then
+  log "missing $TOKEN_FILE after token sync"
+  exit 1
 fi
 
-# Launch the MCP server in bearer-token mode
+ACCESS_TOKEN="$(
+  node -e "
+    const fs = require('fs');
+    const file = process.argv[1];
+    const token = JSON.parse(fs.readFileSync(file, 'utf8')).access_token;
+    if (!token) process.exit(1);
+    process.stdout.write(token);
+  " "$TOKEN_FILE"
+)"
+
+if [ -z "$ACCESS_TOKEN" ]; then
+  log "could not read access token from $TOKEN_FILE"
+  exit 1
+fi
+
 export XERO_CLIENT_BEARER_TOKEN="$ACCESS_TOKEN"
-unset XERO_CLIENT_ID XERO_CLIENT_SECRET XERO_REFRESH_TOKEN
-exec npx -y @xeroapi/xero-mcp-server@latest
+unset XERO_CLIENT_ID XERO_CLIENT_SECRET XERO_REFRESH_TOKEN XERO_ACCESS_TOKEN
+
+if [ "${XERO_MCP_WRAPPER_SMOKE:-}" = "1" ]; then
+  log "token ready"
+  exit 0
+fi
+
+if command -v npx >/dev/null 2>&1; then
+  NPX_BIN="$(command -v npx)"
+elif [ -x "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" 2>/dev/null | sort -V | tail -1)/bin/npx" ]; then
+  NPX_BIN="$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" | sort -V | tail -1)/bin/npx"
+else
+  log "npx not found"
+  exit 1
+fi
+
+log "launching @xeroapi/xero-mcp-server@latest"
+exec "$NPX_BIN" -y @xeroapi/xero-mcp-server@latest

--- a/supabase/migrations/20260516120000_finance_ai_routing.sql
+++ b/supabase/migrations/20260516120000_finance_ai_routing.sql
@@ -1,0 +1,53 @@
+-- AI routing suggestions for unrouted Dext / bank / Xero documents.
+-- The grader script writes here; the workbench reads here; --apply mode
+-- copies high-confidence suggestions into the source row's project_code.
+
+CREATE TABLE IF NOT EXISTS public.finance_ai_routing_suggestions (
+  id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_table           text NOT NULL CHECK (source_table IN (
+    'bank_statement_lines', 'receipt_emails', 'xero_transactions', 'finance_receipt_documents'
+  )),
+  source_record_id       text NOT NULL,
+
+  -- Frozen inputs at grade time
+  vendor_name            text,
+  amount                 numeric,
+  txn_date               date,
+  bank_account           text,
+  description            text,
+
+  -- Grader output
+  suggested_project_code text NOT NULL,
+  confidence             numeric NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  reason                 text,
+  risk_flags             text[] DEFAULT '{}',
+
+  model                  text NOT NULL,
+  prompt_version         text NOT NULL DEFAULT 'v1',
+  input_tokens           integer,
+  output_tokens          integer,
+
+  -- Lifecycle
+  created_at             timestamptz NOT NULL DEFAULT now(),
+  applied_at             timestamptz,
+  applied_to_source      boolean NOT NULL DEFAULT false,
+  rejected_at            timestamptz,
+  rejected_reason        text,
+  superseded_at          timestamptz,
+
+  UNIQUE (source_table, source_record_id, prompt_version, model)
+);
+
+CREATE INDEX IF NOT EXISTS finance_ai_routing_source_idx
+  ON public.finance_ai_routing_suggestions (source_table, source_record_id);
+
+CREATE INDEX IF NOT EXISTS finance_ai_routing_unapplied_idx
+  ON public.finance_ai_routing_suggestions (suggested_project_code, confidence DESC)
+  WHERE applied_to_source = false AND rejected_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS finance_ai_routing_high_conf_idx
+  ON public.finance_ai_routing_suggestions (created_at DESC)
+  WHERE confidence >= 0.85 AND applied_to_source = false;
+
+COMMENT ON TABLE public.finance_ai_routing_suggestions IS
+  'AI grader (Sonnet 4.6) suggestions for project codes on unrouted bank/receipt/Xero rows. Written by scripts/ai-route-dext-doc.mjs. High-confidence (>= 0.85, not ASK_USER/SL_REVIEW) auto-apply with --apply.';

--- a/supabase/migrations/20260517000000_idea_lifecycle.sql
+++ b/supabase/migrations/20260517000000_idea_lifecycle.sql
@@ -1,0 +1,60 @@
+-- Pass 2B B1 — Idea board lifecycle migration
+-- Plan: ~/.claude/plans/coo-cio-cfo-money-brain-phase2.md (Q3, Q4, Q6, Q7)
+--
+-- Adds explicit lifecycle stages, owner tracking, kill reasons, and a snooze
+-- table to idea_board so the pilot pipeline (73 captured ideas) becomes
+-- observable and accountable.
+
+BEGIN;
+
+-- 1. lifecycle_stage — explicit pre-funding flow
+ALTER TABLE idea_board
+  ADD COLUMN IF NOT EXISTS lifecycle_stage text DEFAULT 'idea';
+
+ALTER TABLE idea_board
+  DROP CONSTRAINT IF EXISTS idea_board_lifecycle_stage_check;
+
+ALTER TABLE idea_board
+  ADD CONSTRAINT idea_board_lifecycle_stage_check
+  CHECK (lifecycle_stage IN ('idea','scope','fundraise','start','killed'));
+
+-- 2. owner — per-person staleness reminders (default ben, Nic later)
+ALTER TABLE idea_board
+  ADD COLUMN IF NOT EXISTS owner text DEFAULT 'ben';
+
+-- 3. kill_reason — optional free-text when stage = 'killed' (Q12 default: optional)
+ALTER TABLE idea_board
+  ADD COLUMN IF NOT EXISTS kill_reason text;
+
+-- 4. Backfill 73 existing rows from legacy status field
+--    open      → idea       (still raw, not scoped yet)
+--    exploring → scope      (actively being shaped)
+--    doing     → start      (already in-flight, becomes look-back)
+--    done      → start      (shipped, also a look-back)
+UPDATE idea_board
+   SET lifecycle_stage = CASE status
+     WHEN 'open'      THEN 'idea'
+     WHEN 'exploring' THEN 'scope'
+     WHEN 'doing'     THEN 'start'
+     WHEN 'done'      THEN 'start'
+     ELSE 'idea'
+   END,
+       owner = COALESCE(owner, 'ben');
+
+-- 5. Index for stage filters + per-owner reminder queries
+CREATE INDEX IF NOT EXISTS idea_board_lifecycle_owner_idx
+  ON idea_board (lifecycle_stage, owner, updated_at DESC);
+
+-- 6. idea_snoozes — Q6: cap at 3 snoozes before forced decision
+CREATE TABLE IF NOT EXISTS idea_snoozes (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  idea_id      uuid NOT NULL REFERENCES idea_board(id) ON DELETE CASCADE,
+  snoozed_at   timestamptz NOT NULL DEFAULT now(),
+  snoozed_until date NOT NULL,
+  by_owner     text NOT NULL DEFAULT 'ben'
+);
+
+CREATE INDEX IF NOT EXISTS idea_snoozes_idea_id_idx ON idea_snoozes (idea_id);
+CREATE INDEX IF NOT EXISTS idea_snoozes_until_idx   ON idea_snoozes (snoozed_until);
+
+COMMIT;

--- a/supabase/migrations/20260517000100_idea_stage_entered_at.sql
+++ b/supabase/migrations/20260517000100_idea_stage_entered_at.sql
@@ -1,0 +1,24 @@
+-- Pass 2B B4 follow-up — track stage-entered timestamp so staleness reminders
+-- measure time-in-current-stage, not time-since-any-edit (which the updated_at
+-- trigger trg_idea_board_updated_at touches on every UPDATE).
+--
+-- Backfills from created_at since all existing 73 rows predate the lifecycle
+-- system. Going forward, executeTransitionIdeaStage writes this field on
+-- stage moves.
+
+BEGIN;
+
+ALTER TABLE idea_board
+  ADD COLUMN IF NOT EXISTS stage_entered_at timestamptz;
+
+UPDATE idea_board
+   SET stage_entered_at = COALESCE(stage_entered_at, created_at);
+
+ALTER TABLE idea_board
+  ALTER COLUMN stage_entered_at SET DEFAULT now(),
+  ALTER COLUMN stage_entered_at SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idea_board_stage_entered_idx
+  ON idea_board (lifecycle_stage, stage_entered_at);
+
+COMMIT;

--- a/thoughts/shared/data/compliance-calendar/2026-05-16.json
+++ b/thoughts/shared/data/compliance-calendar/2026-05-16.json
@@ -1,0 +1,230 @@
+{
+  "generatedAt": "2026-05-16T07:43:55.427Z",
+  "sources": {
+    "wiki": {
+      "path": "wiki/finance/compliance-calendar.md",
+      "count": 10
+    },
+    "grants": {
+      "table": "ghl_opportunities",
+      "count": 0
+    }
+  },
+  "counters": {
+    "critical": 0,
+    "high": 0,
+    "medium": 2,
+    "filed": 1
+  },
+  "obligations": [
+    {
+      "id": "sole-trader-pty-cutover",
+      "title": "Sole trader → Pty Ltd cutover",
+      "type": "ONE-OFF",
+      "entity": "both",
+      "due_date": "2026-06-30",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        30,
+        14,
+        7,
+        1
+      ],
+      "notes": "All commercial activity must transfer from Nicholas Marchesi\nsole trader (ABN 21 591 780 066) to A Curious Tractor Pty Ltd\n(ACN 697 347 676) by 30 Jun 2026. Canonical checklist at\nthoughts/shared/plans/act-entity-migration-checklist-2026-06-30.md\nwith ~50 line items: Xero new org, GHL re-keying, contract\nnovations, Stripe re-onboarding, etc.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 45,
+      "severity": "medium",
+      "at_risk": true
+    },
+    {
+      "id": "bas-q4-fy25-26",
+      "title": "BAS Q4 FY25-26 (Apr-Jun 2026)",
+      "type": "BAS",
+      "entity": "sole-trader",
+      "due_date": "2026-07-28",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "notes": "LAST sole-trader BAS. Cutover to Pty happens 30 Jun 2026, so\nthis quarter is split: Apr-Jun sole-trader BAS, Pty Ltd starts\nits own BAS lifecycle from Q1 FY26-27 (Jul-Sep 2026).\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 73,
+      "severity": "medium",
+      "at_risk": true
+    },
+    {
+      "id": "bas-q3-fy25-26",
+      "title": "BAS Q3 FY25-26 (Jan-Mar 2026)",
+      "type": "BAS",
+      "entity": "sole-trader",
+      "due_date": "2026-04-28",
+      "status": "filed",
+      "last_filed_at": "2026-04-24",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "notes": "GST + PAYG instalment. Lodged via tax agent.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "days_until_due": -18,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "bas-q1-fy26-27-pty",
+      "title": "BAS Q1 FY26-27 (Jul-Sep 2026) — FIRST Pty Ltd BAS",
+      "type": "BAS",
+      "entity": "pty-ltd",
+      "due_date": "2026-10-28",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "notes": "First BAS under A Curious Tractor Pty Ltd. Confirms ABN\nregistration is working for GST/PAYG.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 165,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "ato-annual-fy25-26-sole-trader",
+      "title": "ATO annual return FY25-26 (sole trader, Nicholas Marchesi)",
+      "type": "ATO",
+      "entity": "sole-trader",
+      "due_date": "2026-10-31",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        30,
+        7
+      ],
+      "notes": "Standard self-assessment. With tax agent extension can push\nto ~May 2027. Covers Jul 2025 – Jun 2026 sole-trader activity.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 168,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "acnc-annual-aiks-tractor",
+      "title": "ACNC Annual Information Statement — A Kind Tractor Ltd",
+      "type": "ACNC",
+      "entity": "a-kind-tractor-ltd",
+      "due_date": "2026-12-31",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        14
+      ],
+      "notes": "A Kind Tractor Ltd (ACN 669 029 341) is a registered charity\nbut dormant + NOT DGR. Annual statement required even when\ndormant. Lodge by 31 Dec for FY ending 30 Jun.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 229,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "bas-q2-fy26-27-pty",
+      "title": "BAS Q2 FY26-27 (Oct-Dec 2026)",
+      "type": "BAS",
+      "entity": "pty-ltd",
+      "due_date": "2027-02-28",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 288,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "ato-annual-fy25-26-pty",
+      "title": "ATO annual return FY25-26 (Pty Ltd partial year)",
+      "type": "ATO",
+      "entity": "pty-ltd",
+      "due_date": "2027-02-28",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        30,
+        7
+      ],
+      "notes": "Pty Ltd registered 2026-04-24, so FY25-26 covers only the\nApr-Jun 2026 stub. Full FY26-27 return due 2028.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 288,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "asic-annual-act-pty-1st",
+      "title": "ASIC annual review — A Curious Tractor Pty Ltd (first)",
+      "type": "ASIC",
+      "entity": "pty-ltd",
+      "due_date": "2027-04-24",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7
+      ],
+      "notes": "Registered 2026-04-24. Annual review due 2 months after each\nanniversary. ASIC sends a Company Statement; verify and pay\nthe annual review fee.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 343,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "rd-claim-fy25-26",
+      "title": "R&D Tax Incentive claim FY25-26 ($200K refund)",
+      "type": "R&D",
+      "entity": "pty-ltd",
+      "earliest_filable": "2026-07-01",
+      "due_date": "2027-04-30",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        14
+      ],
+      "expected_refund_aud": 200000,
+      "notes": "Path C locked 2026-04-27. FY24-25 forfeited (sole-trader period,\nineligible). Lodge via A Curious Tractor Pty Ltd Jul 2026 –\n30 Apr 2027. Evidence pack lives at thoughts/shared/rd-pack-fy26/.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "last_filed_at": null,
+      "days_until_due": 349,
+      "severity": null,
+      "at_risk": false
+    }
+  ]
+}

--- a/thoughts/shared/handoffs/2026-05-16-money-audit/ux-audit.md
+++ b/thoughts/shared/handoffs/2026-05-16-money-audit/ux-audit.md
@@ -1,0 +1,124 @@
+# Finance UX Audit — 2026-05-16
+
+Companion to `inventory.md` + `decisions.md`. After Pass A-I cleanup, 16 active finance routes remain. This audit walks each route, asks the same 5 questions, and proposes specific simplifications.
+
+## The 5 questions
+
+For every page:
+1. **Title test** — does the h1 tell you what this page is for in 6 words or less?
+2. **First-frame test** — what does the user see in the first second? (Loading skeleton, empty state, hero stat, action prompt?)
+3. **One-job test** — can you describe what this page is for in one sentence without "and"?
+4. **Redundancy test** — does another page already do this job?
+5. **Action test** — when the page is good, what does the user click next?
+
+## The 16 routes after Pass A
+
+| Route | LOC | Title clarity | First frame | One job | Verdict |
+|---|---:|---|---|---|---|
+| `/finance` | 210 | "Operate" → ✓ clear | 10 cards | Front door to finance ops | **Keep, add "what to do today" hero** |
+| `/finance/command` | 1064 | "Money in · out · alignment · incoming" → ✓ | At Risk Today pane | Single canonical money screen | **Keep as home** |
+| `/finance/overview` | 1042 | "Overview" → 🟡 vague | 5 metric cards (cash, runway, FY net, AR, payables) | CEO money cockpit | **Refocus on Founder Pay + Receipt Auto; rest absorbed into /command** |
+| `/finance/workbench` | 868 | (no h1, filter-driven) → 🟡 | Filters bar + queue | Unified action queue across 3 sources | **Keep, add "Start here" empty state hint** |
+| `/finance/money-alignment` | 444 | "Money Alignment" → ✓ | 4 sections | Coverage / freshness / review queue | **Merge into /command middle layer** |
+| `/finance/pipeline` | 1164 | "Pipeline" → ✓ | Stage columns | Deal-by-deal opportunity view | **Keep, distinct from /command** |
+| `/finance/projects` | 295 | "Projects Hub" → ✓ | Project list w/ tiers | Per-project P&L list | **Keep, drill-down works** |
+| `/finance/reconciliation` | 773 | "Reconciliation" → ✓ | Summary card | 95.3% match rate dashboard | **Keep, hero the % stat** |
+| `/finance/receipts-triage` | 254 | "Receipts Triage" → ✓ | Bucket counts | Triage queue (missing amount, vendor, file, junk) | **Merge into /workbench filter=receipt_gap** |
+| `/finance/receipt-evidence` | 1283 | (NEW, untracked) → ✓ | Evidence rows | Receipt evidence mirror | **Keep, biggest page on surface** |
+| `/finance/tagger-v2` | 864 | "Tagger V2" → 🟡 vague | Queue + project badges | Rapid tag UI | **Merge into /workbench filter=needs_project** |
+| `/finance/invoices` | 510 | "Invoices" → ✓ | AR/AP metrics | Invoice command | **Merge into /workbench source=xero_invoices** |
+| `/finance/dext-push-audit` | 602 | (NEW) → ✓ | Audit items | Prevent Dext-Xero duplicates | **Keep, specialized** |
+| `/finance/xero-page-copilot` | 564 | "Paste one Xero reconcile page" → ✓ | Paste textarea | Row-by-row action queue | **Keep, specialized** |
+| `/finance/board` | 687 | "Board" → 🟡 | 6 metric cards | Curated board view | **HOLD — role-dependent, see decisions.md** |
+| `/finance/accountant` | 574 | "Accountant" → 🟡 | 6 query cards | Curated accountant view | **HOLD** |
+| `/finance/revenue` | 386 | "Revenue" → 🟡 | Revenue chart + scenarios | Revenue stream sequencing | **HOLD** |
+
+## End-state target (after 2-3 more sessions)
+
+**11 finance routes** (down from 16):
+
+```
+/finance                       (index hub)
+/finance/command               (canonical home — Money Command)
+/finance/workbench             (action queue — absorbs tagger-v2, receipts-triage, invoices)
+/finance/xero-page-copilot     (paste-a-page tool)
+/finance/dext-push-audit       (Dext duplicate prevention)
+/finance/receipt-evidence      (evidence mirror)
+/finance/reconciliation        (95.3% match rate dashboard)
+/finance/overview              (CEO cockpit — refocused on Founder Pay + Receipt Auto)
+/finance/pipeline              (deal-by-deal)
+/finance/projects (+ [code])   (per-project P&L)
+/finance/board · /accountant · /revenue   (role views — HOLD)
+```
+
+## Top-3 concrete simplifications (shipping this session)
+
+### 1. Group nav by job-to-do
+
+Current: 14 unstructured finance items, alphabetical-ish. Cognitive load high.
+
+Proposed structure (5 groups):
+
+```
+Finance
+├── Today
+│   ├── Money Command           ⭐ canonical home
+│   ├── Workbench               ⭐ action queue
+│   ├── Xero Page Copilot
+│   └── Dext Push Audit
+├── Receipts & spending
+│   ├── Reconciliation
+│   ├── Receipts Triage
+│   └── Receipt Evidence
+├── Money state
+│   ├── CEO Cockpit (overview)
+│   ├── Money Alignment
+│   └── Projects P&L
+├── Pipeline & invoices
+│   ├── Pipeline
+│   ├── Invoice Command
+│   └── Rapid Tagger
+└── Role views
+    ├── Board Report
+    ├── Accountant Pack
+    └── Revenue Sequencing
+```
+
+### 2. /finance index — add "What needs you today?" hero
+
+The 10-card grid is fine. But add at the top: a single banner that reads from `/api/finance/command` and surfaces the top 3 *do-this-now* signals:
+
+> **3 things waiting**: 32 transactions untagged (Workbench) · 8 receipts ready to attach (`xero-copilot-execute`) · last digest 4 days ago (`narrate-weekly-digest`)
+
+One click each goes to the exact page + filter. The card grid becomes "explore further".
+
+### 3. /finance/reconciliation — hero the 95.3% match rate
+
+Currently the headline number is buried in section 2. Move it to the page header. The headline IS the page.
+
+## Lower-priority simplifications (next sessions)
+
+- **Title clarity pass** — pages with vague h1s ("Overview", "Tagger V2", "Board", "Accountant", "Revenue") rename to job-to-do titles ("CEO money cockpit", "Rapid tagger", "Board report", "Accountant pack", "Revenue sequencing"). Half of these are already-good labels in nav but the page h1 itself is shorter/weaker. Sync them.
+- **Workbench empty-state hint** — when filter returns 0, show "Nothing here. Try [another filter]" with a one-click swap.
+- **Tagger-v2 sunset** — when workbench's filter=needs_project is fully featured, deprecate tagger-v2 + redirect.
+- **Receipts-triage sunset** — same; workbench filter=receipt_gap supersedes.
+- **Invoices sunset** — workbench source=xero_invoices covers most. Keep page only for AR/AP collection drill.
+- **CEO cockpit refocus** — strip /finance/overview down to just FounderPayCard + ReceiptAutomationCard; everything else moves to /command.
+
+## AI-leverage UX additions
+
+Now that we have `finance_ai_routing_suggestions`, the workbench should grow these columns:
+- `ai_suggested_code` (the grader's pick)
+- `ai_confidence` (numeric badge)
+- `ai_reason` (tooltip)
+- `ai_risk_flags` (chips: high_value, duplicate_risk, etc.)
+
+When `ai_confidence >= 0.85` AND `ai_suggested_code` not in [ASK_USER, SL_REVIEW], show a one-click **Accept** button that applies the suggestion in place.
+
+This makes the workbench the "review AI's work" surface instead of the "do everything yourself" surface.
+
+## Out of scope
+
+- The 3 HOLD routes (board, accountant, revenue) need their own role-model refactor.
+- /finance/receipt-evidence at 1284 LOC is its own audit later.
+- The action tier of execute buttons (Xero copilot) needs UI in workbench, not its own page.

--- a/thoughts/shared/handoffs/2026-05-16-money-brain-phase2/current.md
+++ b/thoughts/shared/handoffs/2026-05-16-money-brain-phase2/current.md
@@ -1,0 +1,126 @@
+# Money Brain Phase 2 — Resume Handoff
+
+**Updated:** 2026-05-16T07:55:00Z
+**Goal:** Build COO+CIO+CFO+risk Money Brain on top of /finance/command
+**Branches:**
+- Phase 1 shipped to `main` via PR #63 (Pass A→I: /finance/command page + view + backfills + digest cron)
+- Phase 2 Pass A shipped to `feat/compliance-calendar-2026-05-16` (commit `c3e0e03`, **PR not open yet** — Tier 3 awaits Ben's verb)
+
+## Ledger
+
+### Now
+[->] Pass 2A complete. Ready for Pass 2B (pilot lifecycle) — fresh branch off main, design fully locked in plan file.
+
+### Last session — 12 grill questions + 6 build tasks
+- Q1-Q11: design decisions captured in `~/.claude/plans/coo-cio-cfo-money-brain-phase2.md`
+- Q12: build order = Compliance → Pilot → Accountability
+- Pass 2A built end-to-end: wiki canonical file → compute script → API → AT RISK pane → Telegram cron → Notion sync (graceful no-op without env)
+- Live state: 2 🟡 medium obligations today (cutover T-45, BAS Q4 T-73), 1 ✓ filed (BAS Q3)
+- Build clean (TS exit 0). Prerender errors on `/finance/invoices` + `/` are pre-existing, unrelated to changes; Vercel handles fine
+
+### Next — Pass 2B (Pilot Lifecycle, single session)
+
+**Branch:** `git checkout main && git pull --ff-only && git checkout -b feat/pilot-lifecycle-2026-05-17`
+
+**Tasks (in build order):**
+
+1. **B1 · Schema migration** — `supabase/migrations/20260517_idea_lifecycle.sql`:
+   - `ALTER TABLE idea_board ADD COLUMN lifecycle_stage text DEFAULT 'idea' CHECK (lifecycle_stage IN ('idea','scope','fundraise','start','killed'))`
+   - `ALTER TABLE idea_board ADD COLUMN owner text DEFAULT 'ben'`
+   - `ALTER TABLE idea_board ADD COLUMN kill_reason text`
+   - `CREATE TABLE idea_snoozes (id uuid PK, idea_id uuid FK references idea_board, snoozed_at timestamptz, snoozed_until date, by_owner text)`
+   - Backfill 73 existing rows: `open → idea`, `exploring → scope`, `doing → start`, `done → start`. All `owner = 'ben'`.
+   - Apply via `mcp__supabase__apply_migration`.
+
+2. **B2 · Telegram bot agent tools** in `apps/command-center/src/lib/telegram/bot.ts` (and `src/lib/agent-tools.ts`):
+   - `add_idea(text, category?, energy?, value_estimate?)` — sets `owner` from Telegram user ID (map via env or hardcode `ben`), stage `'idea'`
+   - `transition_idea_stage(id, stage, kill_reason?)` — validates state-machine moves; on `start` triggers AI-suggest flow
+   - `snooze_idea(id, days)` — INSERT into `idea_snoozes`; refuses if snooze_count >= 3
+   - Inline keyboard builder for reminders: `→ fundraise` `→ start` `❌ kill` `💤 snooze 14d`
+
+3. **B3 · AI-suggest project_code helper** — `scripts/lib/projects/suggest-code.mjs`:
+   - Input: idea text + existing `projects.code` list
+   - Anthropic call (Claude Haiku — cheap for 2-letter naming)
+   - Returns `ACT-XX` suffix
+   - On confirm: `INSERT INTO projects (code, name, tier, status)` (tier='satellite', status='active') + `UPDATE idea_board SET project_code = ?`
+
+4. **B4 · Reminder cron** — `scripts/idea-board-reminders.mjs`:
+   - Stage-aware tiered staleness: `idea` 90d · `scope` 30d · `fundraise` 14d · `start` never · `killed` never
+   - Group by `owner`, max 5 items per DM per night
+   - Inline buttons per item (via grammY `InlineKeyboardMarkup`)
+   - Add PM2 entry: daily 8:00am AEST (`'0 8 * * *'`)
+
+5. **B5 · `/ideas` page UX update** — `apps/command-center/src/app/ideas/page.tsx` (1057 LOC existing kanban):
+   - Replace status columns (open/exploring/doing/done) with lifecycle stages (idea/scope/fundraise/start/killed)
+   - Add owner badge + snooze count badge (`💤 ×2`)
+   - Deep-link target: `/ideas?focus=<idea_id>` opens specific card
+
+6. **B6 · Wire pilot risks into AT RISK TODAY pane** — `/api/finance/command/route.ts`:
+   - Extend the AT RISK aggregation (currently compliance + cash/runway + drift) to include stale ideas
+   - Severity: 🟠 if scope 30d+ or fundraise 14d+; 🟡 if snooze-burned (3 snoozes total)
+
+### After Pass 2B: Pass 2C — Accountability surfaces
+- `compliance_ack` + `idea_ack` lightweight tables
+- Debt counter on AT RISK pane (snapshot, not cumulative — settled in grill Q11)
+- Extend `scripts/weekly-money-digest.mjs` with compliance/idea/snooze/ack-gap sections
+- Friday 3pm Telegram delivery (existing cron, just add sections)
+
+## Locked design decisions
+
+Full plan + 12 grilled decisions: `~/.claude/plans/coo-cio-cfo-money-brain-phase2.md`
+
+Quick reference for Pass 2B:
+- Pilot stages: **idea → scope → fundraise → start + killed**
+- Reminder thresholds: **idea 90d · scope 30d · fundraise 14d · start never · killed never**
+- Owner column on idea_board, default `ben`
+- Capture path: **Telegram-first** via `/idea <text>` bot command
+- Reminder action loop: **inline Telegram buttons** (advance/kill/snooze)
+- Kill: **optional one-word reason** (encouraged not required)
+- Snooze: **3-strike cap** then forced decision
+- Project bridge on `→ start`: **AI-suggest, user confirms**; creates `projects` row but no GHL opp auto-creation
+
+## Open Tier-2/3 items (Ben's verb required)
+
+1. **Open PR for Pass 2A**: `gh pr create --base main --head feat/compliance-calendar-2026-05-16 --title "Pass 2A — compliance calendar + AT RISK TODAY pane"`
+2. **PM2 start** new crons: `pm2 start ecosystem.config.cjs --only compliance-snapshot,compliance-alerts,compliance-notion-sync && pm2 save`
+3. **Notion compliance page**: create page under ACT Money Framework, share with integration, add `NOTION_COMPLIANCE_PAGE_ID` to `.env.local`. Until then `compliance-notion-sync` cron logs gracefully and exits 0.
+4. **Smoke-test in browser** at http://localhost:3002/finance/command — visually confirm AT RISK pane renders the 2 medium items
+
+## Critical files (Pass 2A built/edited)
+
+- `wiki/finance/compliance-calendar.md` (NEW — canonical source, edit when filings happen or new entities added)
+- `scripts/build-compliance-calendar.mjs` (NEW)
+- `scripts/compliance-alerts.mjs` (NEW)
+- `scripts/sync-compliance-calendar-to-notion.mjs` (NEW)
+- `apps/command-center/src/app/api/finance/compliance-calendar/route.ts` (NEW)
+- `apps/command-center/src/app/finance/command/page.tsx` (EDIT — added `AtRiskTodaySection` above `TopLayer`)
+- `ecosystem.config.cjs` (EDIT — 3 new daily crons 7:00/7:30/7:45)
+- `thoughts/shared/data/compliance-calendar/2026-05-16.json` (seeded snapshot)
+
+## Operational notes
+
+- The `compliance-snapshot` cron at 7am rebuilds the JSON daily. Without it, the snapshot would go stale.
+- Add a new BAS quarter to the wiki annually (at FY rollover).
+- When a BAS is filed: edit the wiki to set `status: filed` + `last_filed_at: <date>`. Re-run `scripts/build-compliance-calendar.mjs` to refresh.
+- Grant acquittals are auto-pulled — when a grant gets an `acquittal_due_date` in GHL (via canonical alignment work), it shows up automatically on next cron run.
+- Pre-existing `/finance/invoices` + `/` prerender errors during `next build` — unrelated to Phase 2, Vercel handles fine. Don't waste time debugging.
+
+## Branch status
+
+```
+feat/compliance-calendar-2026-05-16 (this session — pushed, not PR'd)
+c3e0e03  feat(finance): Pass 2A — compliance calendar + AT RISK TODAY pane
+
+main (production)
+071155f  chore: auto-rebuild Tractorpedia viewer [skip ci]
+c2c5f74  Merge pull request #63 (Phase 1: /finance/command end-to-end)
+```
+
+## Resume sequence
+
+1. `/clear`
+2. Open this handoff: `thoughts/shared/handoffs/2026-05-16-money-brain-phase2/current.md`
+3. Re-read plan: `~/.claude/plans/coo-cio-cfo-money-brain-phase2.md`
+4. Decide: open PR for Pass 2A first, OR jump straight to Pass 2B
+5. If Pass 2B: `git checkout main && git pull && git checkout -b feat/pilot-lifecycle-2026-05-17`
+6. Start with B1 schema migration via `mcp__supabase__apply_migration`

--- a/wiki/finance/compliance-calendar.md
+++ b/wiki/finance/compliance-calendar.md
@@ -1,0 +1,216 @@
+---
+title: ACT Compliance Calendar (canonical)
+status: Active
+canonical_slug: compliance-calendar
+date: 2026-05-16
+owner: ben
+description: |
+  Single source of truth for ACT's fixed compliance obligations. Grant
+  acquittals are NOT listed here — they're auto-pulled from
+  ghl_opportunities.acquittal_due_date at calendar-build time.
+
+  Read by:
+    - scripts/build-compliance-calendar.mjs (merges with grant acquittals)
+    - /api/finance/compliance-calendar (live read for /finance/command)
+    - scripts/compliance-alerts.mjs (Telegram T-30/T-7/T-1)
+    - scripts/sync-compliance-calendar-to-notion.mjs (outbound mirror)
+
+  EDIT THIS FILE when:
+    - A new fixed obligation appears (annual review for a new entity, etc.)
+    - A due date moves (rare — most are statute-driven)
+    - An obligation is filed: change status to 'filed' and bump last_filed_at
+
+obligations:
+
+  # ─── BAS (sole-trader cohort, last 4 quarters before Pty cutover) ───
+
+  - id: bas-q3-fy25-26
+    title: BAS Q3 FY25-26 (Jan-Mar 2026)
+    type: BAS
+    entity: sole-trader
+    due_date: 2026-04-28
+    status: filed
+    last_filed_at: 2026-04-24
+    lead_times_days: [30, 7, 1]
+    notes: |
+      GST + PAYG instalment. Lodged via tax agent.
+
+  - id: bas-q4-fy25-26
+    title: BAS Q4 FY25-26 (Apr-Jun 2026)
+    type: BAS
+    entity: sole-trader
+    due_date: 2026-07-28
+    status: pending
+    lead_times_days: [30, 7, 1]
+    notes: |
+      LAST sole-trader BAS. Cutover to Pty happens 30 Jun 2026, so
+      this quarter is split: Apr-Jun sole-trader BAS, Pty Ltd starts
+      its own BAS lifecycle from Q1 FY26-27 (Jul-Sep 2026).
+
+  - id: bas-q1-fy26-27-pty
+    title: BAS Q1 FY26-27 (Jul-Sep 2026) — FIRST Pty Ltd BAS
+    type: BAS
+    entity: pty-ltd
+    due_date: 2026-10-28
+    status: pending
+    lead_times_days: [30, 7, 1]
+    notes: |
+      First BAS under A Curious Tractor Pty Ltd. Confirms ABN
+      registration is working for GST/PAYG.
+
+  - id: bas-q2-fy26-27-pty
+    title: BAS Q2 FY26-27 (Oct-Dec 2026)
+    type: BAS
+    entity: pty-ltd
+    due_date: 2027-02-28
+    status: pending
+    lead_times_days: [30, 7, 1]
+
+  # ─── R&D Tax Incentive (Pty Ltd) ───
+
+  - id: rd-claim-fy25-26
+    title: R&D Tax Incentive claim FY25-26 ($200K refund)
+    type: R&D
+    entity: pty-ltd
+    earliest_filable: 2026-07-01
+    due_date: 2027-04-30
+    status: pending
+    lead_times_days: [60, 14]
+    expected_refund_aud: 200000
+    notes: |
+      Path C locked 2026-04-27. FY24-25 forfeited (sole-trader period,
+      ineligible). Lodge via A Curious Tractor Pty Ltd Jul 2026 –
+      30 Apr 2027. Evidence pack lives at thoughts/shared/rd-pack-fy26/.
+
+  # ─── ATO annual returns ───
+
+  - id: ato-annual-fy25-26-sole-trader
+    title: ATO annual return FY25-26 (sole trader, Nicholas Marchesi)
+    type: ATO
+    entity: sole-trader
+    due_date: 2026-10-31
+    status: pending
+    lead_times_days: [60, 30, 7]
+    notes: |
+      Standard self-assessment. With tax agent extension can push
+      to ~May 2027. Covers Jul 2025 – Jun 2026 sole-trader activity.
+
+  - id: ato-annual-fy25-26-pty
+    title: ATO annual return FY25-26 (Pty Ltd partial year)
+    type: ATO
+    entity: pty-ltd
+    due_date: 2027-02-28
+    status: pending
+    lead_times_days: [60, 30, 7]
+    notes: |
+      Pty Ltd registered 2026-04-24, so FY25-26 covers only the
+      Apr-Jun 2026 stub. Full FY26-27 return due 2028.
+
+  # ─── ASIC (Pty Ltd company review) ───
+
+  - id: asic-annual-act-pty-1st
+    title: ASIC annual review — A Curious Tractor Pty Ltd (first)
+    type: ASIC
+    entity: pty-ltd
+    due_date: 2027-04-24
+    status: pending
+    lead_times_days: [30, 7]
+    notes: |
+      Registered 2026-04-24. Annual review due 2 months after each
+      anniversary. ASIC sends a Company Statement; verify and pay
+      the annual review fee.
+
+  # ─── Charity reporting (A Kind Tractor Ltd, dormant) ───
+
+  - id: acnc-annual-aiks-tractor
+    title: ACNC Annual Information Statement — A Kind Tractor Ltd
+    type: ACNC
+    entity: a-kind-tractor-ltd
+    due_date: 2026-12-31
+    status: pending
+    lead_times_days: [60, 14]
+    notes: |
+      A Kind Tractor Ltd (ACN 669 029 341) is a registered charity
+      but dormant + NOT DGR. Annual statement required even when
+      dormant. Lodge by 31 Dec for FY ending 30 Jun.
+
+  # ─── Sole trader → Pty Ltd cutover (ONE-OFF) ───
+
+  - id: sole-trader-pty-cutover
+    title: Sole trader → Pty Ltd cutover
+    type: ONE-OFF
+    entity: both
+    due_date: 2026-06-30
+    status: pending
+    lead_times_days: [60, 30, 14, 7, 1]
+    notes: |
+      All commercial activity must transfer from Nicholas Marchesi
+      sole trader (ABN 21 591 780 066) to A Curious Tractor Pty Ltd
+      (ACN 697 347 676) by 30 Jun 2026. Canonical checklist at
+      thoughts/shared/plans/act-entity-migration-checklist-2026-06-30.md
+      with ~50 line items: Xero new org, GHL re-keying, contract
+      novations, Stripe re-onboarding, etc.
+
+---
+
+# ACT Compliance Calendar
+
+This page is generated from frontmatter above. Edit the `obligations:` array to
+add/change items. The companion script `scripts/build-compliance-calendar.mjs`
+merges this list with `ghl_opportunities.acquittal_due_date` rows (grant
+acquittals — dynamic) into a unified calendar published at
+`/finance/command` (AT RISK TODAY pane) + Notion + Telegram.
+
+## Entities
+
+| Entity | Status | Notes |
+|---|---|---|
+| Nicholas Marchesi sole trader | Active until 2026-06-30 | ABN 21 591 780 066 |
+| A Curious Tractor Pty Ltd | Active from 2026-04-24 | ACN 697 347 676. Knight + Marchesi family trusts 50/50. |
+| A Kind Tractor Ltd | Dormant charity | ACN 669 029 341. NOT DGR. |
+
+## Lead-time conventions
+
+| `lead_times_days` value | Telegram alert |
+|---|---|
+| 60 | `[T-60] <title>` (R&D + ATO long lead time) |
+| 30 | `[T-30] <title>` (BAS standard) |
+| 14 | `[T-14] <title>` (acquittals, last calls) |
+| 7 | `[T-7] <title>` (final reminder) |
+| 1 | `[T-1] <title> DUE TOMORROW` |
+
+A single obligation can have multiple lead times. Alerts fire only when
+`days_until_due` matches a list entry EXACTLY (so you don't get nagged
+every day).
+
+## Status values
+
+| Status | Meaning |
+|---|---|
+| `pending` | Not yet filed. Counts toward AT RISK if any lead time matches today. |
+| `filed` | Lodged. Move `last_filed_at` to the filing date. Disappears from AT RISK pane. |
+| `superseded` | Replaced by a later obligation (e.g., cutover supersedes sole-trader life). Stays in record for audit but doesn't alert. |
+| `waived` | Confirmed not required (e.g., entity dissolved). Audit trail kept. |
+
+## Grant acquittals (dynamic, NOT in this file)
+
+Grant acquittals come from `ghl_opportunities.acquittal_due_date` and
+`acquittal_status`. The build script joins them with this static list
+at run-time. To see all current grant acquittals on `/finance/command`,
+they appear in the AT RISK TODAY pane automatically.
+
+When a grant is acquitted: set `acquittal_status = 'complete'` in GHL
+(or via `/finance/workbench`) — the next cron run removes it from AT RISK.
+
+## When to edit this file
+
+- New fixed obligation appears (e.g., new entity registered)
+- A statute-driven date changes (rare — ATO sometimes shifts BAS deadlines)
+- An obligation is filed: `status: filed` + `last_filed_at: YYYY-MM-DD`
+- Annual rollover: at start of each FY, add the new BAS quarters + reset rolling annual obligations
+
+## When NOT to edit
+
+- For grant acquittals (they're auto-pulled)
+- For super/PAYG monthly (we don't have employees yet — add when we do)
+- For one-offs that already passed (let them stay with `status: filed`)


### PR DESCRIPTION
## Summary

Closes the six AI-leverage gaps named in the 2026-05-16 money audit, plus a UX audit handoff for the next pass.

The user ask: *"make our Dext, Xero workflow better, easier, more efficient — the most AI-based system across all those platforms so we set everything up with Dext AI, Jax in Xero, and our Supabase etc so we know exactly where things are at — can review every week and stay on top of all finance."*

## What ships

### Six AI-leverage pieces

1. **`/finance/workbench` + 3 more pages** (`c212645`) — one unified table over bank_lines + xero_transactions + xero_invoices with filter-by-status. Plus `/dext-push-audit`, `/xero-page-copilot`, `/receipt-evidence`.

2. **Dext routing pack** (`21a5d3f`) — `config/dext-routing-sections.json` locks 12 project codes + Payment Methods + auto-publish policy. Plus 5 supporting scripts (generate routing pack, bank-line action queue, receipt-close-queue, approve-safe-evidence, audit-approved-links).

3. **AI Dext routing grader** (`44023ee`) — Sonnet 4.6 grades every untagged bank_line / receipt_email / xero_transaction with `{project_code, confidence, reason, risk_flags[]}`. Writes to new `finance_ai_routing_suggestions` table. `--apply` auto-applies high-conf (≥85%) unless code is ASK_USER or SL_REVIEW.

4. **Xero copilot wiring** (`d8175c4`) — POST `/api/finance/xero-page-copilot/execute` actually calls Xero API for `attach_evidence`, `find_match_bill`, `transfer`. CLI driver at `scripts/xero-copilot-execute.mjs` for bulk attach. Hard constraint respected: Xero API can't set IsReconciled=true; the click-OK step still needs the user, but everything before it is automated.

5. **Weekly narrative digest** (`f40a5e3`) — Sonnet 4.6 reads the money-command data + week deltas and writes "5 things to know this week" in Curtis voice. No AI tells. Scheduled Fri 3:15pm via cron.

6. **Pre-publish Dext grader** (`e7ea801`) — polls `finance_receipt_documents` every 15min Mon-Fri, grades each fresh OCR'd doc, surfaces in workbench before publish. Currently 6417 ungraded docs in backlog — poller catches up in ~3 days.

7. **Monday morning cron chain** (`a993357`) — single wrapper replaces 6 separate PM2 entries (5:30-9:10am). Failure isolation, one Telegram summary, markdown log.

### UX audit

8. **UX audit handoff + ready-to-wire hero** (`bc8561f`) — `thoughts/shared/handoffs/2026-05-16-money-audit/ux-audit.md` walks each of the 16 active finance routes against 5 questions (title test, first-frame test, one-job test, redundancy test, action test) and proposes end-state target of 11 routes grouped by job-to-do. Plus a `<TodayActionsHero />` component + GET `/api/finance/today-actions` API ready to wire (deferred).

### Plus

- Compliance calendar (`c3e0e03`) — At Risk Today pane on `/finance/command` pulling deadlines + risk
- Pass 2A handoff (`70d2475`)

## Verification

- ✅ `pnpm --filter @act/command-center build` passed
- ✅ `npx tsc --noEmit` exit 0
- ✅ Migrations applied to shared DB
- ✅ Smoke-tested each new script against live data
- ✅ Xero copilot CLI found 1 real candidate (Virgin Australia $385.79) in attach queue
- ✅ AI routing grader correctly: ACT-IN for Xero (82%), SL_REVIEW for Brisbane City Council (55%), ASK_USER for ambiguous travel (45%)
- ✅ Weekly narrative produced sharp Curtis-voice output naming Rotary Eclub 22mo overdue + Palm Island $96.8K

## Cron entries added

- `weekly-narrative` (Fri 3:15pm AEST, --telegram)
- `pre-publish-dext-grader` (every 15min, 8am-6pm, Mon-Fri, --telegram)
- `monday-morning-chain` (Mon 5:30am, registered commented-out, opt-in)

## Migration

- `20260516120000_finance_ai_routing.sql` — `finance_ai_routing_suggestions` table for AI grades

## Handoff artifacts

- `thoughts/shared/handoffs/2026-05-16-money-audit/current.md`
- `thoughts/shared/handoffs/2026-05-16-money-audit/decisions.md`
- `thoughts/shared/handoffs/2026-05-16-money-audit/inventory.md`
- `thoughts/shared/handoffs/2026-05-16-money-audit/ux-audit.md`

## Test plan

- [ ] Run `node scripts/ai-route-dext-doc.mjs --limit 20` and review suggestions
- [ ] Run `node scripts/xero-copilot-execute.mjs --limit 5` (dry run)
- [ ] Run `node scripts/narrate-weekly-digest.mjs --no-write` to see Curtis-voice output
- [ ] Enable `pre-publish-dext-grader` PM2 entry and watch backlog drain
- [ ] Decide on UX hero wiring (audit doc has the placement proposed)