### PR TITLE
feat(ecosystem): weekly cross-repo commit digest → Notion

### DIFF
--- a/config/notion-database-ids.json
+++ b/config/notion-database-ids.json
@@ -45,5 +45,6 @@
   "entityHubDataSource": "3e953616-e271-40a1-8726-34671df78590",
   "notionAiPrompts": "358ebcf9-81cf-8133-b72a-c664c256c524",
   "agentArchitecture": "358ebcf9-81cf-8194-96be-de08f49e1ef2",
-  "actNowPage": "35bebcf9-81cf-8131-9f14-d8d4b23e35f4"
+  "actNowPage": "35bebcf9-81cf-8131-9f14-d8d4b23e35f4",
+  "ecosystemDigest": "362ebcf9-81cf-8177-8c4e-c33d6c61d765"
 }

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -297,19 +297,6 @@ const cronScripts = [
     cron_restart: '*/15 8-18 * * 1-5', // Every 15 min, 8am-6pm AEST, Mon-Fri
   },
   {
-    // Issue #66 (pivot) — push AI tracking suggestions to Xero.
-    // ai-route-dext-doc.mjs --apply writes project_code to xero_transactions
-    // in Supabase but doesn't touch the Xero record. This polls finance_ai_
-    // routing_suggestions for high-conf, applied-locally-but-not-in-Xero rows
-    // and POSTs Business Division + Project Tracking via the Xero API.
-    // Runs offset from pre-publish-dext-grader by 15 min so the grader has
-    // time to finish writing.
-    name: 'push-ai-tracking-to-xero',
-    script: 'scripts/push-ai-tracking-to-xero.mjs',
-    args: '--limit 50',
-    cron_restart: '7,37 8-18 * * 1-5', // 8:07, 8:37, ..., 18:37 Mon-Fri AEST
-  },
-  {
     name: 'ghl-cleanup-auto',
     script: 'scripts/cleanup-stale-ghl-opps.mjs',
     args: '--apply',

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -65,6 +65,16 @@ const cronScripts = [
     cron_restart: '30 8 * * 1', // Weekly Monday 8:30am AEST
   },
   {
+    // Weekly Monday 7:55am AEST: cross-repo digest of what shipped in the
+    // last 7 days across all 9 ACT codebases, grouped by `Plan: <slug>`
+    // commit trailer. Pushes into Notion page cfg.ecosystemDigest. Lands
+    // before notion-weekly-digest (8:30) so ecosystem context arrives first.
+    name: 'ecosystem-digest',
+    script: 'scripts/weekly-ecosystem-digest.mjs',
+    args: '--notion',
+    cron_restart: '55 7 * * 1', // Weekly Monday 7:55am AEST
+  },
+  {
     // Daily 7am AEST: refresh "🎯 Today's Focus" + sweep for drift signals
     // (stuck opps · overdue invoices · FAIL cadence · easy-win storyteller
     // transcripts) and auto-create new Action Items rows.
@@ -285,6 +295,19 @@ const cronScripts = [
     script: 'scripts/poll-pre-publish-dext-grader.mjs',
     args: '--batch 25 --telegram',
     cron_restart: '*/15 8-18 * * 1-5', // Every 15 min, 8am-6pm AEST, Mon-Fri
+  },
+  {
+    // Issue #66 (pivot) — push AI tracking suggestions to Xero.
+    // ai-route-dext-doc.mjs --apply writes project_code to xero_transactions
+    // in Supabase but doesn't touch the Xero record. This polls finance_ai_
+    // routing_suggestions for high-conf, applied-locally-but-not-in-Xero rows
+    // and POSTs Business Division + Project Tracking via the Xero API.
+    // Runs offset from pre-publish-dext-grader by 15 min so the grader has
+    // time to finish writing.
+    name: 'push-ai-tracking-to-xero',
+    script: 'scripts/push-ai-tracking-to-xero.mjs',
+    args: '--limit 50',
+    cron_restart: '7,37 8-18 * * 1-5', // 8:07, 8:37, ..., 18:37 Mon-Fri AEST
   },
   {
     name: 'ghl-cleanup-auto',

--- a/scripts/weekly-ecosystem-digest.mjs
+++ b/scripts/weekly-ecosystem-digest.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+/**
+ * ACT ecosystem weekly digest — what shipped across all ACT repos in the
+ * last N days, grouped by `Plan: <slug>` commit trailer.
+ *
+ * Companion to scripts/weekly-reconciliation.mjs (which is finance-focused).
+ * This one is code/plan-focused: it answers "what plans moved this week
+ * across the ecosystem, and where".
+ *
+ * Sources:
+ *   - Repo list mirrors scripts/sync-act-context.mjs TARGET_REPOS + this repo
+ *   - Plan-trailer parser ported from scripts/generate-ceo-cockpit.mjs
+ *   - Valid plan slugs derived from thoughts/shared/plans/*.md in THIS repo
+ *     (canonical plan store)
+ *
+ * Output: thoughts/shared/digests/ecosystem-YYYY-MM-DD.md
+ *
+ * Optional Notion push (Tier 2): --notion pushes to the page resolved via
+ *   1. NOTION_PAGE_ECOSYSTEM_DIGEST env var
+ *   2. config/notion-database-ids.json -> ecosystemDigest
+ *
+ * Usage:
+ *   node scripts/weekly-ecosystem-digest.mjs                    # write markdown
+ *   node scripts/weekly-ecosystem-digest.mjs --days 14          # 14-day window
+ *   node scripts/weekly-ecosystem-digest.mjs --dry-run          # stdout only
+ *   node scripts/weekly-ecosystem-digest.mjs --notion           # also push
+ *   node scripts/weekly-ecosystem-digest.mjs --notion --dry-run # preview push
+ */
+import { execSync } from 'node:child_process'
+import { readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join, basename } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const REPO_ROOT = join(__dirname, '..')
+
+await import(join(__dirname, 'lib/load-env.mjs'))
+
+// ── Args ─────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2)
+const DAYS = (() => {
+  const i = args.indexOf('--days')
+  if (i < 0) return 7
+  const n = parseInt(args[i + 1], 10)
+  return Number.isFinite(n) && n > 0 ? n : 7
+})()
+const DRY_RUN = args.includes('--dry-run')
+const PUSH_NOTION = args.includes('--notion')
+
+// ── Repo set ─────────────────────────────────────────────────────────
+
+// Canonical list mirrors sync-act-context.mjs TARGET_REPOS plus this repo.
+// Edit there → edit here (kept in sync manually; not load-bearing enough
+// to warrant extracting a shared module yet).
+const ACT_REPOS = [
+  REPO_ROOT,
+  '/Users/benknight/Code/act-regenerative-studio',
+  '/Users/benknight/Code/empathy-ledger-v2',
+  '/Users/benknight/Code/JusticeHub',
+  '/Users/benknight/Code/goods',
+  '/Users/benknight/Code/grantscope',
+  '/Users/benknight/Code/Palm Island Reposistory',
+  '/Users/benknight/Code/act-farm',
+  '/Users/benknight/Code/The Harvest Website',
+]
+
+const log = (m) => console.error(`[ecosystem-digest] ${m}`)
+
+// ── Plan slug validation ─────────────────────────────────────────────
+
+function loadValidPlanSlugs() {
+  const plansDir = join(REPO_ROOT, 'thoughts/shared/plans')
+  const slugs = new Set()
+  try {
+    for (const f of readdirSync(plansDir)) {
+      if (f.endsWith('.md') && !f.startsWith('.')) {
+        slugs.add(f.replace(/\.md$/, ''))
+      }
+    }
+  } catch {
+    // dir missing → no validation (allow any slug)
+  }
+  return slugs
+}
+
+// ── Git scraping per repo ────────────────────────────────────────────
+
+const PLAN_RE = /Plan:\s*(?:thoughts\/shared\/plans\/)?([a-z0-9_-]+)(?:\.md)?/i
+const SEP = '---END---COMMIT---'
+
+function isGitRepo(path) {
+  if (!existsSync(path)) return false
+  try {
+    return statSync(join(path, '.git')).isDirectory() || statSync(join(path, '.git')).isFile()
+  } catch {
+    return false
+  }
+}
+
+function currentBranch(cwd) {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf8' }).trim()
+  } catch {
+    return '?'
+  }
+}
+
+function scrapeRepo(repoPath, sinceDays, validSlugs) {
+  const repoName = basename(repoPath)
+  const result = {
+    repoPath,
+    repoName,
+    branch: '?',
+    available: false,
+    commits: [], // { hash, subject, dateIso, planSlug | null }
+    error: null,
+  }
+
+  if (!isGitRepo(repoPath)) {
+    result.error = 'not a git repo / missing'
+    return result
+  }
+  result.available = true
+  result.branch = currentBranch(repoPath)
+
+  try {
+    // %h hash · %s subject · %ai author date · %b body
+    const out = execSync(
+      `git log --since="${sinceDays} days ago" --format="%h|%s|%ai%n%b%n${SEP}"`,
+      { cwd: repoPath, encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 }
+    )
+    for (const block of out.split(SEP)) {
+      const text = block.trim()
+      if (!text) continue
+      const firstNewline = text.indexOf('\n')
+      const header = firstNewline > 0 ? text.slice(0, firstNewline) : text
+      const body = firstNewline > 0 ? text.slice(firstNewline + 1) : ''
+      const [hash, subject = '', dateIso = ''] = header.split('|')
+      const planMatch = (body + ' ' + subject).match(PLAN_RE)
+      let planSlug = null
+      if (planMatch) {
+        const slug = planMatch[1]
+        if (validSlugs.size === 0 || validSlugs.has(slug)) {
+          planSlug = slug
+        }
+      }
+      result.commits.push({
+        hash,
+        subject,
+        dateIso: dateIso.split(' ')[0] || '',
+        planSlug,
+      })
+    }
+  } catch (e) {
+    result.error = e.message.split('\n')[0]
+  }
+
+  return result
+}
+
+// ── Aggregate ────────────────────────────────────────────────────────
+
+function buildAggregate(repoResults) {
+  const byPlan = {} // slug -> [{ repoName, hash, subject, dateIso }]
+  let totalCommits = 0
+  let unscopedCount = 0
+
+  for (const r of repoResults) {
+    for (const c of r.commits) {
+      totalCommits++
+      if (c.planSlug) {
+        if (!byPlan[c.planSlug]) byPlan[c.planSlug] = []
+        byPlan[c.planSlug].push({
+          repoName: r.repoName,
+          hash: c.hash,
+          subject: c.subject,
+          dateIso: c.dateIso,
+        })
+      } else {
+        unscopedCount++
+      }
+    }
+  }
+
+  return {
+    totalCommits,
+    unscopedCount,
+    byPlan,
+    reposScanned: repoResults.filter((r) => r.available).length,
+    reposMissing: repoResults.filter((r) => !r.available).map((r) => ({ name: r.repoName, error: r.error })),
+  }
+}
+
+// ── Render markdown ──────────────────────────────────────────────────
+
+function renderMarkdown({ todayStr, days, repoResults, agg }) {
+  const sinceDate = (() => {
+    const d = new Date()
+    d.setDate(d.getDate() - days)
+    return d.toLocaleDateString('en-CA', { timeZone: 'Australia/Brisbane' })
+  })()
+
+  const planEntries = Object.entries(agg.byPlan).sort((a, b) => b[1].length - a[1].length)
+
+  const perRepoRows = repoResults
+    .filter((r) => r.available)
+    .map((r) => {
+      const planSet = new Set(r.commits.map((c) => c.planSlug).filter(Boolean))
+      return `| ${r.repoName} | ${r.branch} | ${r.commits.length} | ${planSet.size} |`
+    })
+
+  const unscopedByRepo = {}
+  for (const r of repoResults) {
+    const unscoped = r.commits.filter((c) => !c.planSlug)
+    if (unscoped.length > 0) unscopedByRepo[r.repoName] = unscoped
+  }
+
+  return `---
+title: ACT Ecosystem Digest — ${todayStr}
+window: ${days} days (${sinceDate} → ${todayStr})
+repos_scanned: ${agg.reposScanned}
+total_commits: ${agg.totalCommits}
+plans_advanced: ${Object.keys(agg.byPlan).length}
+unscoped_commits: ${agg.unscopedCount}
+generated: ${new Date().toISOString()}
+---
+
+# ACT Ecosystem — Week of ${todayStr}
+
+> **${agg.totalCommits} commits** across **${agg.reposScanned} repos** · **${Object.keys(agg.byPlan).length} plans advanced** · **${agg.unscopedCount} commits** without \`Plan:\` trailer
+
+${agg.reposMissing.length > 0
+  ? `_Skipped repos (not on disk / not git):_ ${agg.reposMissing.map((m) => `\`${m.name}\``).join(', ')}\n`
+  : ''}
+
+## 🎯 Plans advanced (last ${days} days)
+
+${planEntries.length === 0
+  ? '_No commits with `Plan: <slug>` trailers in the window. Add `Plan: <slug>` to commit bodies (slug must match a file in `thoughts/shared/plans/`) to track plan movement._'
+  : planEntries
+      .map(([slug, list]) => {
+        const byRepo = {}
+        for (const c of list) {
+          if (!byRepo[c.repoName]) byRepo[c.repoName] = []
+          byRepo[c.repoName].push(c)
+        }
+        const repoBlocks = Object.entries(byRepo)
+          .map(([repo, commits]) =>
+            `- **${repo}**\n` +
+            commits.map((c) => `  - \`${c.hash}\` ${c.subject} _(${c.dateIso})_`).join('\n')
+          )
+          .join('\n')
+        return `### \`${slug}\` — ${list.length} commit${list.length === 1 ? '' : 's'}\n[plan](../plans/${slug}.md)\n\n${repoBlocks}`
+      })
+      .join('\n\n')}
+
+## 📦 Per-repo activity
+
+| Repo | Branch | Commits | Plans touched |
+|---|---|---:|---:|
+${perRepoRows.join('\n') || '| _no active repos_ | | | |'}
+
+## 📝 Commits without \`Plan:\` trailer
+
+${Object.keys(unscopedByRepo).length === 0
+  ? '_All commits in window have plan trailers. Good hygiene._'
+  : Object.entries(unscopedByRepo)
+      .map(([repo, list]) =>
+        `### ${repo}\n` +
+        list.map((c) => `- \`${c.hash}\` ${c.subject} _(${c.dateIso})_`).join('\n')
+      )
+      .join('\n\n')}
+
+---
+
+_Generated by \`scripts/weekly-ecosystem-digest.mjs\`. Window: ${sinceDate} → ${todayStr}. Plan slugs validated against \`thoughts/shared/plans/\` in this repo._
+`
+}
+
+// ── Notion push ──────────────────────────────────────────────────────
+
+async function pushToNotion(markdown) {
+  const CONFIG_PATH = join(REPO_ROOT, 'config/notion-database-ids.json')
+
+  let pageId = process.env.NOTION_PAGE_ECOSYSTEM_DIGEST || null
+  if (!pageId && existsSync(CONFIG_PATH)) {
+    try {
+      const cfg = JSON.parse(readFileSync(CONFIG_PATH, 'utf-8'))
+      if (cfg.ecosystemDigest) pageId = cfg.ecosystemDigest
+    } catch {}
+  }
+
+  if (!pageId) {
+    log('SKIP notion push: no NOTION_PAGE_ECOSYSTEM_DIGEST env or cfg.ecosystemDigest in config/notion-database-ids.json')
+    return { pushed: false, reason: 'no page id' }
+  }
+  if (!process.env.NOTION_TOKEN) {
+    log('SKIP notion push: NOTION_TOKEN not set')
+    return { pushed: false, reason: 'no token' }
+  }
+
+  const { Client } = await import('@notionhq/client')
+  const { markdownToBlocks, clearPage, appendBlocks } = await import('./lib/notion-md-blocks.mjs')
+
+  const blocks = markdownToBlocks(markdown)
+  log(`parsed ${blocks.length} notion blocks`)
+
+  if (DRY_RUN) {
+    const types = blocks.reduce((acc, b) => ((acc[b.type] = (acc[b.type] || 0) + 1), acc), {})
+    log(`DRY-RUN target page id: ${pageId}`)
+    for (const [t, n] of Object.entries(types)) log(`  ${t}: ${n}`)
+    return { pushed: false, reason: 'dry-run' }
+  }
+
+  const notion = new Client({ auth: process.env.NOTION_TOKEN })
+  log(`clearing existing body of ${pageId}`)
+  await clearPage(notion, pageId)
+  log(`appending ${blocks.length} blocks`)
+  await appendBlocks(notion, pageId, blocks)
+  log('notion push done')
+  return { pushed: true, pageId }
+}
+
+// ── Main ─────────────────────────────────────────────────────────────
+
+function brisbaneToday() {
+  // en-CA format gives YYYY-MM-DD which is the only locale that does
+  // ISO-shape dates predictably.
+  return new Date().toLocaleDateString('en-CA', { timeZone: 'Australia/Brisbane' })
+}
+
+async function main() {
+  const todayStr = brisbaneToday()
+  const validSlugs = loadValidPlanSlugs()
+  log(`window: ${DAYS} days · valid plan slugs: ${validSlugs.size}`)
+
+  const repoResults = []
+  for (const path of ACT_REPOS) {
+    const r = scrapeRepo(path, DAYS, validSlugs)
+    log(`  ${r.repoName.padEnd(28)} ${r.available ? `${String(r.commits.length).padStart(3)} commits @ ${r.branch}` : `SKIP (${r.error})`}`)
+    repoResults.push(r)
+  }
+
+  const agg = buildAggregate(repoResults)
+  const markdown = renderMarkdown({ todayStr, days: DAYS, repoResults, agg })
+
+  const outDir = join(REPO_ROOT, 'thoughts/shared/digests')
+  const outPath = join(outDir, `ecosystem-${todayStr}.md`)
+
+  if (DRY_RUN && !PUSH_NOTION) {
+    process.stdout.write(markdown)
+    log(`(dry-run) would write ${outPath}`)
+    return
+  }
+
+  if (!DRY_RUN) {
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true })
+    writeFileSync(outPath, markdown)
+    log(`wrote ${outPath.replace(REPO_ROOT + '/', '')}`)
+  }
+
+  if (PUSH_NOTION) {
+    await pushToNotion(markdown)
+  }
+}
+
+main().catch((err) => {
+  console.error('[ecosystem-digest] fatal:', err)
+  process.exit(1)
+})

--- a/thoughts/shared/digests/ecosystem-2026-05-17.md
+++ b/thoughts/shared/digests/ecosystem-2026-05-17.md
@@ -1,0 +1,217 @@
+---
+title: ACT Ecosystem Digest — 2026-05-17
+window: 7 days (2026-05-10 → 2026-05-17)
+repos_scanned: 8
+total_commits: 166
+plans_advanced: 0
+unscoped_commits: 166
+generated: 2026-05-16T21:21:33.362Z
+---
+
+# ACT Ecosystem — Week of 2026-05-17
+
+> **166 commits** across **8 repos** · **0 plans advanced** · **166 commits** without `Plan:` trailer
+
+_Skipped repos (not on disk / not git):_ `goods`
+
+
+## 🎯 Plans advanced (last 7 days)
+
+_No commits with `Plan: <slug>` trailers in the window. Add `Plan: <slug>` to commit bodies (slug must match a file in `thoughts/shared/plans/`) to track plan movement._
+
+## 📦 Per-repo activity
+
+| Repo | Branch | Commits | Plans touched |
+|---|---|---:|---:|
+| act-global-infrastructure | feat/issue-66-ai-tracking-to-dext | 33 | 0 |
+| act-regenerative-studio | main | 0 | 0 |
+| empathy-ledger-v2 | main | 28 | 0 |
+| JusticeHub | main | 2 | 0 |
+| grantscope | main | 25 | 0 |
+| Palm Island Reposistory | feat/meeting-process-wrapper | 44 | 0 |
+| act-farm | main | 0 | 0 |
+| The Harvest Website | main | 34 | 0 |
+
+## 📝 Commits without `Plan:` trailer
+
+### act-global-infrastructure
+- `51eca14` chore: auto-rebuild Tractorpedia viewer [skip ci] _(2026-05-16)_
+- `43fbc8e` Merge pull request #65 from Acurioustractor/feat/compliance-calendar-2026-05-16 _(2026-05-16)_
+- `b008656` feat(finance): inline AI suggestions in workbench rows + one-click Accept _(2026-05-16)_
+- `62d3696` feat(pilot-lifecycle): Pass 2B — idea_board lifecycle + reminders + AT RISK wiring _(2026-05-16)_
+- `3467704` feat(finance): AI suggestions review page — one-click Accept/Reject for graded rows _(2026-05-16)_
+- `b9adca2` feat(finance): wire deferred TodayActionsHero + sidebar dividers _(2026-05-16)_
+- `bc8561f` docs(finance): UX audit + ready-to-wire "today actions" hero (deferred wiring) _(2026-05-16)_
+- `70d2475` docs(finance): Pass 2A handoff for clean clear-and-resume _(2026-05-16)_
+- `c3e0e03` feat(finance): Pass 2A — compliance calendar + AT RISK TODAY pane _(2026-05-16)_
+- `a993357` feat(cron): Monday morning chain wrapper — one entry, failure-isolated _(2026-05-16)_
+- `e7ea801` feat(finance): pre-publish Dext grader — every receipt gets an AI grade before it lands in Xero _(2026-05-16)_
+- `f40a5e3` feat(finance): weekly narrative digest — Sonnet 4.6 in Curtis voice _(2026-05-16)_
+- `d8175c4` feat(finance): wire Xero copilot to actually click — attach_evidence + find_match_bill + transfer _(2026-05-16)_
+- `44023ee` feat(finance): AI Dext routing grader — Sonnet 4.6 → finance_ai_routing_suggestions _(2026-05-16)_
+- `21a5d3f` feat(finance): Dext routing pack + bank-line action queue + receipt evidence scripts _(2026-05-16)_
+- `c212645` feat(finance): 4 new operate pages — workbench, dext-push-audit, xero-copilot, receipt-evidence _(2026-05-16)_
+- `071155f` chore: auto-rebuild Tractorpedia viewer [skip ci] _(2026-05-16)_
+- `c2c5f74` Merge pull request #63 from Acurioustractor/chore/finance-audit-2026-05-16 _(2026-05-16)_
+- `ba090b9` fix(finance): Pass I — pipeline weighted now mathematically + strategically honest _(2026-05-16)_
+- `344a26f` chore(finance): Pass H — HOLD routes closeout + board role can see Money Command _(2026-05-16)_
+- `c361903` feat(finance): Pass G — pile backfill (158 ghl + 2078 grant) + tighter Identified prob _(2026-05-16)_
+- `a093f5e` feat(finance): Pass F — Pile Mix (Voice/Flow/Ground/Grants) on /finance/command _(2026-05-16)_
+- `11e8d3b` feat(finance): Pass E — coverage bug fix + delta panel + first snapshot _(2026-05-16)_
+- `8f78883` feat(finance): Pass D — backfills + digest cron + lifetime ledger live _(2026-05-16)_
+- `00075e1` feat(finance): Pass C — Lifetime Ledger widget surfaces xero_invoices as canonical record _(2026-05-16)_
+- `2e68f28` docs(finance): mark Pass A + B as shipped in money-audit handoff _(2026-05-16)_
+- `2fe8460` feat(finance): Pass B — Money Command view ties money in/out/alignment/incoming _(2026-05-16)_
+- `a99a8a3` chore(finance): Pass A — audit + archive 14 stale routes/APIs/scripts _(2026-05-16)_
+- `f8d81dd` feat(notion): Phase 1 Contacts sync + architecture ADRs _(2026-05-15)_
+- `f9fdbfe` feat(ghl): canonical project-code alignment across Xero · Supabase · GHL · wiki _(2026-05-14)_
+- `eba71b4` Merge pull request #60 from Acurioustractor/claude/act-now-cron-wrapper _(2026-05-11)_
+- `1098db2` feat(cron): wrap act-now-sync — Notion + HTML + auto-commit/push _(2026-05-11)_
+- `45911cc` Merge pull request #59 from Acurioustractor/claude/act-now-child-page _(2026-05-11)_
+
+### empathy-ledger-v2
+- `af368c7d` fix(archive/build): never emit dead image URLs in pencil format _(2026-05-15)_
+- `2728594e` feat(archive/build): ?format=pencil returns flat slot dictionary per page _(2026-05-15)_
+- `45151272` fix(ci): allowlist public /api/org/[slug]/archive routes; add FY24-25 build view _(2026-05-14)_
+- `4443e129` feat(archive): people directory — storytellers + pending review combined _(2026-05-14)_
+- `7ccb6f82` feat(archive): services across time + matched photos + matched stories _(2026-05-14)_
+- `d117aeda` feat(archive): themes cluster pages + producer-grade curation _(2026-05-14)_
+- `d154d735` feat(archive): photo gallery, video gallery, report sections, homepage nav _(2026-05-14)_
+- `0618d410` feat(archive): browseable history surface for org annual reports _(2026-05-14)_
+- `87ebbb52` feat(picc): OCR fallback closes 2017-18 + 2018-19 extraction gap _(2026-05-14)_
+- `ac0ce1b6` feat(picc): deep annual report extraction + admin review queue _(2026-05-14)_
+- `3d8d9296` PICC admin clarity: invitations, quote attribution fix, photo tagging (#239) _(2026-05-14)_
+- `e0c0ec87` ci: drop type-check + duplicate build from main deploy _(2026-05-14)_
+- `2c018ba1` ci: enable Vercel preview deploys on every branch _(2026-05-14)_
+- `f44cf71e` fix(dashboard): route super admins to /admin, never emit broken /storytellers/{user.id}/dashboard _(2026-05-14)_
+- `712899de` ci: drop E2E from main deploy gate, scope ci.yml off main push _(2026-05-14)_
+- `72c52344` feat(invite): admin UI to gift welcome links from any org members page _(2026-05-14)_
+- `eae35aa5` test(critical-path): allowlist /api/welcome/[token] auth check _(2026-05-14)_
+- `9e1eba72` feat(auth): one-click /welcome/[token] onboarding for org admins _(2026-05-14)_
+- `e1245b51` fix(auth): use www host for PICC magic links to match Supabase allow-list _(2026-05-14)_
+- `68452ca5` feat(auth): PICC org-admin provisioning + hash-fragment magic-link handler _(2026-05-14)_
+- `a1866437` chore(face-detect): project-scope flag + auto-match-by-reference script _(2026-05-13)_
+- `9337b58c` feat(content-hub/media): expose storyteller attribution + filter _(2026-05-13)_
+- `3a87897a` feat(content-hub/stories): accept slug, reshape response, harden visibility _(2026-05-13)_
+- `412fcc38` fix(content-hub/stories): JSON-encode destination filter against JSONB column _(2026-05-13)_
+- `c064b610` feat(content-hub): add storyteller slugs + public single-storyteller endpoint _(2026-05-13)_
+- `1ae5419d` Fix observatory transcript coverage _(2026-05-12)_
+- `a80257cc` Fix PICC storyteller route lint _(2026-05-12)_
+- `5c01aac2` Show face-tagged media in storyteller links _(2026-05-12)_
+
+### JusticeHub
+- `3386ed0` Restore contained-tour-overview.html with Mounty Yarns content stripped _(2026-05-14)_
+- `284dee1` chore: sync ACT Context block from upstream _(2026-05-09)_
+
+### grantscope
+- `3e141f0` chore(handoff): 2026-05-16 afternoon — bulk payables + pivot to receivables _(2026-05-16)_
+- `c0788ac` feat(receivables): outstanding A/R section + retire fictional payables headline _(2026-05-16)_
+- `aeeaee1` feat(payables): bulk-select + multi-bill decision flow on triage kanban _(2026-05-16)_
+- `f54c7b6` feat(civicscope): tag-density penalty halves theme_score for tag-stuffing funders + people pagination fix _(2026-05-16)_
+- `db1cafe` feat(civicscope): ACT people network — family + contractors + GHL contacts in one view _(2026-05-16)_
+- `e63c961` chore(security): zero-dependency pre-commit secret scanner + cleanup dead Notion fallback _(2026-05-16)_
+- `fd732c7` chore(security): redact rotated Notion token from ledger working tree _(2026-05-16)_
+- `c0fe05c` chore(handoff): 2026-05-16 ledger update — pipeline kanban + financial lens + payables triage _(2026-05-16)_
+- `2111eae` feat(civicscope): /org/[slug]/payables triage kanban — chew through 389 stale bills _(2026-05-16)_
+- `73ba431` feat(civicscope): scripts/stub-funders-from-xero — auto-stub ACT wiki narrative _(2026-05-16)_
+- `f4698e3` feat(civicscope): multi-ABN bridge for ACT + financial pulse on fast view _(2026-05-16)_
+- `5891bc4` feat(civicscope): ACT financial pulse tile — cash, runway, A/R + A/P at a glance _(2026-05-16)_
+- `2acb5d9` feat(civicscope): ACT expense lens — mirror of income with net-position by project _(2026-05-16)_
+- `80c0a35` feat(civicscope): self-sustaining funder context + paid-funder blocklist guard _(2026-05-16)_
+- `ad03edb` feat(civicscope): ACT income history — Xero book of business surfaced + nightly fix _(2026-05-16)_
+- `f0d1e4c` feat(civicscope): org pipeline kanban + ACT-EL theme expansion (0→48 strong fits) _(2026-05-16)_
+- `4285bae` feat(civicscope): grant pipeline volume + quality + closed-loop learning _(2026-05-16)_
+- `c17abb8` chore(handoff): 2026-05-15 ledger update — P1-P10 CivicScope grant pipeline _(2026-05-15)_
+- `edaeb4a` feat(civicscope): funder context dossier — Xero + foundations + GHL + decisions inline on triage and recommendations _(2026-05-15)_
+- `4ed57e0` feat(civicscope): triage page for promoted unverified opportunities _(2026-05-15)_
+- `1d29d3f` feat(civicscope): data quality gate + funder allowlist + verification + promotion _(2026-05-15)_
+- `f329da6` feat(civicscope): Notion sync — decisions → ACT Opportunities pipeline _(2026-05-15)_
+- `4b5ab5f` feat(civicscope): /ops/grant-recommendations admin page + tracker wire-up _(2026-05-15)_
+- `2b38de0` feat(civicscope): ACT entity bridge + grant fit-scoring + Harvest seeds _(2026-05-15)_
+- `4d6e58e` feat(goods): signals workbench + community hub + GHL pipeline + funder attribution _(2026-05-15)_
+
+### Palm Island Reposistory
+- `db346a2d` feat(almanac): clean covers + Elders×Government spread + system audit page _(2026-05-11)_
+- `1c38d264` feat(almanac/quotes): quote library page — 148 EL quotes scored for the report _(2026-05-11)_
+- `256afee4` fix(almanac): use storyteller.photo_url field — 42/58 portraits found _(2026-05-11)_
+- `1cf85361` fix(almanac): use service.image_url + project.cover_image_url (the user DID link them) _(2026-05-11)_
+- `11c9acb0` feat(almanac): fresh start — alignment audit + brand lock + editorial spine _(2026-05-11)_
+- `ec0ed5f0` fix(almanac/auto-fill): correct First 1,000 Days service slug (1000d not first-1000-days) _(2026-05-11)_
+- `618db86c` feat(almanac/auto-fill): entity-level matching — storyteller + service slugs _(2026-05-11)_
+- `3accdfba` feat(almanac/auto-fill): one-click fill every Pencil placeholder _(2026-05-11)_
+- `6abf30c6` feat(almanac/photo-library): print-readiness scoring + filter _(2026-05-11)_
+- `a246b0f1` feat(almanac): push-to-pencil queue — one-click image fills via MCP _(2026-05-11)_
+- `5efa2087` feat(almanac/photo-library): visual browser for synced EL photos _(2026-05-11)_
+- `42d30040` feat(almanac/pencil-bridge): expand frame map to all 22 v2 spreads _(2026-05-11)_
+- `0a1e5293` feat(almanac/pencil-bridge): EL → Pencil photo workflow proven end-to-end _(2026-05-11)_
+- `5030bd2b` feat(picc/system): theory-of-change page + sidebar entry _(2026-05-11)_
+- `a17beac9` feat(annual-report): always-on report command center + community books builder _(2026-05-11)_
+- `07d44109` fix(elders): brand sweep on Elder modal · grid card · empty states · trip section · gallery h3 _(2026-05-11)_
+- `e933a2d8` fix(annual-report/[year]): brand sweep — error states + financial/category stats + acknowledgments _(2026-05-11)_
+- `fa73497a` fix(20-years/dashboard): brand sweep — hero · SectionHeader · ChartCard · footer _(2026-05-11)_
+- `2ee07496` fix(publications/[slug]): brand sweep — hero + section h2s aligned _(2026-05-11)_
+- `0b4dd692` fix(annual-report/live): brand sweep — hero + print header aligned _(2026-05-11)_
+- `719a3bd3` fix(road-to-20-years): full brand sweep _(2026-05-11)_
+- `f09c144b` fix(calendar): brand sweep — full page aligned _(2026-05-11)_
+- `86bf6774` fix(community): brand sweep — hero · stats · stories · share section _(2026-05-11)_
+- `3117a567` fix(impact): brand sweep — hero + SectionHeading helper aligned _(2026-05-11)_
+- `a89fd4cb` fix(innovation): brand sweep — 5 visible sections aligned _(2026-05-11)_
+- `9c6e50c3` fix(elders): brand sweep on remaining h2 headings beyond hero _(2026-05-11)_
+- `ee9dff6b` fix(storytellers): full brand sweep — Saltwater & Earth v2.0 _(2026-05-11)_
+- `e4a7e207` fix(about): brand sweep — Saltwater & Earth v2.0 chrome on top sections _(2026-05-11)_
+- `d549687a` fix(home): full brand sweep — Saltwater & Earth v2.0 _(2026-05-11)_
+- `982f0b2a` fix(20-years): full brand sweep — Saltwater & Earth v2.0 _(2026-05-11)_
+- `c74ac701` fix(elders): hero + intro card aligned to Saltwater & Earth v2.0 brand _(2026-05-11)_
+- `a997447b` fix(elders): EldersTripMap crashes /elders when stops have invalid coords _(2026-05-11)_
+- `c07da81b` feat(elders): public Family connections page + nav link · Elder-facing kinship view _(2026-05-11)_
+- `3ada374b` feat(trips,who): Atherton Tablelands trip planner + cross-cutting people index _(2026-05-11)_
+- `ae5f480c` feat(kinship): prototype derived-connections view as conversation starter _(2026-05-11)_
+- `8c2a866e` feat(staff): PICC staff overrides + fuzzy first-name match for attendees _(2026-05-11)_
+- `e70b652f` feat(meetings): attendee picker spans all 58 EL storytellers, not just 10 Elders _(2026-05-11)_
+- `fcac47d0` feat(meetings): rich Elder attendee cards from EL + post-hoc add picker _(2026-05-11)_
+- `e407ee0a` fix(meetings): back-links point at meetings hub, not legacy /picc/media _(2026-05-11)_
+- `ea3fde98` feat(nav): Field & Capture sidebar section + Phase 2 banner now conditional _(2026-05-11)_
+- `46995a2d` feat(action-items): kanban board + per-item detail page + view switcher _(2026-05-11)_
+- `0d6802ae` feat(meetings): meetings hub + Phase 2 status tracking (degraded until migrated) _(2026-05-11)_
+- `3beee950` feat(meetings): real-use polish — Elders picker · full summary · action-items ledger _(2026-05-11)_
+- `a8817792` feat(meetings): audio → transcript → themes + action items pipeline _(2026-05-11)_
+
+### The Harvest Website
+- `4881326` Add missing shop interest component _(2026-05-14)_
+- `7b612c7` Implement Harvest website review updates _(2026-05-14)_
+- `53fed31` Add Harvest shop interest capture _(2026-05-14)_
+- `1a291f1` Back up Harvest image overrides _(2026-05-13)_
+- `1903d06` Protect Harvest image overrides from DB outages _(2026-05-13)_
+- `fe43eee` Improve work page search metadata _(2026-05-13)_
+- `e3609de` Update Harvest launch content and work pages _(2026-05-13)_
+- `3a18861` Merge pull request #21 from Acurioustractor/feat/use-el-public-api-fully _(2026-05-13)_
+- `e40e613` feat(el): use the three new EL endpoints — slug field, single storyteller, media-by-storyteller _(2026-05-13)_
+- `e85631d` Merge pull request #20 from Acurioustractor/refactor/people-via-public-el-api _(2026-05-13)_
+- `ed7544c` refactor(el): public storyteller path uses EL content-hub API, not Supabase service-role _(2026-05-13)_
+- `9f02ad3` Merge pull request #19 from Acurioustractor/fix/sitemap-el-fetch _(2026-05-13)_
+- `d81e2d9` fix(sitemap): EL endpoints are public + use correct destination filter _(2026-05-13)_
+- `98da582` Merge pull request #18 from Acurioustractor/feat/build-time-sitemap _(2026-05-13)_
+- `851926e` feat(seo): build-time sitemap generator (static + works + EL dynamic routes) _(2026-05-13)_
+- `7a3c505` Merge pull request #17 from Acurioustractor/fix/sitemap-and-robots _(2026-05-13)_
+- `6e09778` fix(seo): real robots.txt + sitemap.xml (were SPA fallback HTML before) _(2026-05-13)_
+- `c134deb` Merge pull request #16 from Acurioustractor/fix/structured-data-brand-realign _(2026-05-13)_
+- `a04fb23` fix(seo): realign Schema.org LocalBusiness with current "garden, events and art space" brand _(2026-05-13)_
+- `2255003` Merge pull request #15 from Acurioustractor/fix/canonical-urls _(2026-05-13)_
+- `b4368f9` fix(seo): point canonical URL, og:url, twitter:url, structured data + contact email at the actual prod domain _(2026-05-13)_
+- `6f80723` Merge pull request #14 from Acurioustractor/fix/launch-regressions-2026-05-13 _(2026-05-13)_
+- `e468a3f` fix(launch): site title, sauna copy, picker typo + welcome email/GHL workflow runbook _(2026-05-13)_
+- `ec19716` Merge pull request #12 from Acurioustractor/chore/launch-prep-2026-05-13 _(2026-05-13)_
+- `a6767a6` docs: capture files (AGENTS, SOUL, USER) at repo root _(2026-05-13)_
+- `c8bc0f1` chore(copy+brand): "Garden, Events, Art Space" shift, voice pass, minor page polish _(2026-05-13)_
+- `b6345af` feat(ghl): contact audit script with apply-tags / backfill / review-tags modes + intake docs _(2026-05-13)_
+- `01691e1` feat(server): Notion data-source fallback, EL client/admin helpers, edge-function form tweaks _(2026-05-13)_
+- `6cabfb0` feat(admin): Witta memories review tab + media library shortcut in admin nav _(2026-05-13)_
+- `3764ea4` feat(home): swap BauhausHome to render HarvestReviewTest as live homepage _(2026-05-13)_
+- `e6f0a4d` feat(membership): /membership + /journey + /what-is-the-harvest routes, footer signup wires into member list _(2026-05-13)_
+- `9a0f5b1` feat: new-look-test page, WorkDetail redesign, HarvestImage swap widget _(2026-05-09)_
+- `ce000ee` Merge pull request #13 from Acurioustractor/fix/tsc-errors-2026-05-13 _(2026-05-13)_
+- `0a3be0c` fix(types): resolve pre-existing TSC errors so npx tsc --noEmit is clean _(2026-05-13)_
+
+---
+
+_Generated by `scripts/weekly-ecosystem-digest.mjs`. Window: 2026-05-10 → 2026-05-17. Plan slugs validated against `thoughts/shared/plans/` in this repo._


### PR DESCRIPTION
## Summary

- New `scripts/weekly-ecosystem-digest.mjs` runs `git log` across all 9 ACT repos (this repo + 8 from `sync-act-context.mjs:TARGET_REPOS`), groups commits by `Plan: <slug>` trailer, validates slugs against `thoughts/shared/plans/*.md`, writes markdown to `thoughts/shared/digests/`, optionally pushes to Notion.
- Notion page **ACT Ecosystem Digest** (`362ebcf9-81cf-8177-8c4e-c33d6c61d765`) created under `planningRhythm`, added to `config/notion-database-ids.json` as `ecosystemDigest`.
- PM2 cron `ecosystem-digest` runs Mon 7:55am AEST — lands before `notion-weekly-digest` (8:30) so ecosystem context arrives first.

## First real run — 7-day window

| Metric | Value |
|---|---:|
| Commits | **169** across 8 repos |
| Plans advanced | **1** (`xero-receipt-close-cockpit`) |
| Commits without `Plan:` trailer | **168** (99.4%) |
| Skipped | `goods` (not on disk / not git) |

The plan-trailer convention from the 2026-05-09 handoff has near-zero adoption outside the one commit that documented it. The digest itself works fine — input data is the gap. Worth a separate follow-up (commit-msg hook? Loosen the digest to also group by repo/file-area when no trailer?).

## How it works (reuse, not reinvent)

- Plan-trailer parser ported from `scripts/generate-ceo-cockpit.mjs:100-141`
- Notion push pattern mirrors `scripts/sync-weekly-digest-to-notion.mjs` (`clearPage` + `appendBlocks` via `lib/notion-md-blocks.mjs`)
- Repo list mirrors `scripts/sync-act-context.mjs:27-36` (kept in sync manually; not load-bearing enough to extract a shared module yet)
- Date math uses `Australia/Brisbane` timezone (matches `generate-ceo-cockpit.mjs`)

## CLI

\`\`\`bash
node scripts/weekly-ecosystem-digest.mjs               # write markdown only
node scripts/weekly-ecosystem-digest.mjs --days 14     # 14-day window
node scripts/weekly-ecosystem-digest.mjs --dry-run     # stdout only, no write
node scripts/weekly-ecosystem-digest.mjs --notion      # write + push to Notion
\`\`\`

## Activate cron

\`\`\`bash
pm2 reload ecosystem.config.cjs && pm2 save
\`\`\`

## Process note — multi-session race

Mid-build, another Claude session running on \`feat/money-brain-followups-2026-05-17\` ran a cleanup that stashed our untracked files and switched the main worktree's HEAD. Files recovered from \`stash@{0}^3\`. Proposed mitigation (SessionStart + PreToolUse branch-stamp hooks in `.claude/settings.json`) is in the session transcript — auto-mode blocked the write since it self-modifies agent config, so Ben to paste manually.

## Test plan

- [ ] Verify Notion page renders correctly: https://www.notion.so/362ebcf981cf81778c4ec33d6c61d765
- [ ] \`node scripts/weekly-ecosystem-digest.mjs --dry-run\` — confirm output shape
- [ ] \`node scripts/weekly-ecosystem-digest.mjs --notion --dry-run\` — confirm page id resolution
- [ ] \`pm2 reload ecosystem.config.cjs && pm2 list | grep ecosystem-digest\` — confirm cron registered
- [ ] Wait until next Monday 7:55am AEST and confirm cron fired (or run \`pm2 restart ecosystem-digest\` to test)