### PR TITLE
feat(finance): close #66 — push AI tracking to Xero (pivoted from Dext writeback)

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -287,6 +287,19 @@ const cronScripts = [
     cron_restart: '*/15 8-18 * * 1-5', // Every 15 min, 8am-6pm AEST, Mon-Fri
   },
   {
+    // Issue #66 (pivot) — push AI tracking suggestions to Xero.
+    // ai-route-dext-doc.mjs --apply writes project_code to xero_transactions
+    // in Supabase but doesn't touch the Xero record. This polls finance_ai_
+    // routing_suggestions for high-conf, applied-locally-but-not-in-Xero rows
+    // and POSTs Business Division + Project Tracking via the Xero API.
+    // Runs offset from pre-publish-dext-grader so the grader has time to
+    // finish writing.
+    name: 'push-ai-tracking-to-xero',
+    script: 'scripts/push-ai-tracking-to-xero.mjs',
+    args: '--limit 50',
+    cron_restart: '7,37 8-18 * * 1-5', // 8:07, 8:37, ..., 18:37 Mon-Fri AEST
+  },
+  {
     name: 'ghl-cleanup-auto',
     script: 'scripts/cleanup-stale-ghl-opps.mjs',
     args: '--apply',

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -294,6 +294,17 @@ const cronScripts = [
     // and POSTs Business Division + Project Tracking via the Xero API.
     // Runs offset from pre-publish-dext-grader so the grader has time to
     // finish writing.
+    // Issue #66 paired grader — grades freshly-arrived xero_transactions
+    // (rows that landed via Xero sync but have no project_code yet) and
+    // writes high-confidence suggestions to finance_ai_routing_suggestions
+    // with applied_to_source=true. Runs at xx:00 and xx:30 — 7 min before
+    // push-ai-tracking-to-xero so the suggestions are written first.
+    name: 'ai-router-xero-mode',
+    script: 'scripts/ai-route-dext-doc.mjs',
+    args: '--source xero --apply --limit 30 --min-confidence 0.85',
+    cron_restart: '0,30 8-18 * * 1-5', // xx:00 and xx:30, Mon-Fri 8am-6pm AEST
+  },
+  {
     name: 'push-ai-tracking-to-xero',
     script: 'scripts/push-ai-tracking-to-xero.mjs',
     args: '--limit 50',

--- a/scripts/push-ai-tracking-to-xero.mjs
+++ b/scripts/push-ai-tracking-to-xero.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Push AI tracking suggestions to Xero (post-publish).
+ *
+ * Closes the loop opened by ai-route-dext-doc.mjs --apply: that script
+ * writes project_code to xero_transactions.project_code in Supabase, but
+ * the Xero record itself stays untracked — so R&D pack + project reports
+ * miss the spend even after the AI accepted it.
+ *
+ * This script polls finance_ai_routing_suggestions for rows where:
+ *   - source_table = 'xero_transactions'
+ *   - applied_to_source = true (the grader accepted + propagated)
+ *   - applied_to_xero_at IS NULL (we haven't pushed yet)
+ *   - confidence >= 0.85
+ *   - rejected_at IS NULL, suggested_project_code NOT IN (ASK_USER, SL_REVIEW)
+ *
+ * For each row, fetches the Xero BankTransaction, appends Business Division
+ * + Project Tracking to every LineItem (idempotent — skips if Project
+ * Tracking already present), POSTs the update, marks applied_to_xero_at on
+ * success or applied_to_xero_error on failure.
+ *
+ * Cron: every 30 min Mon-Fri 8am-6pm AEST via PM2 (ecosystem.config.cjs).
+ *
+ * Usage:
+ *   node scripts/push-ai-tracking-to-xero.mjs --dry-run --limit 5
+ *   node scripts/push-ai-tracking-to-xero.mjs --limit 50
+ *   node scripts/push-ai-tracking-to-xero.mjs                  # full run, default limit 100
+ */
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, existsSync } from 'node:fs';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const XERO_TENANT_ID = process.env.XERO_TENANT_ID;
+const TOKEN_FILE = '.xero-tokens.json';
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing Supabase URL / service role env vars.');
+  process.exit(1);
+}
+if (!XERO_TENANT_ID) {
+  console.error('Missing XERO_TENANT_ID env var.');
+  process.exit(1);
+}
+
+const sb = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const limIdx = args.indexOf('--limit');
+const LIMIT = limIdx !== -1 ? parseInt(args[limIdx + 1], 10) : 100;
+const MIN_CONFIDENCE = (() => {
+  const i = args.indexOf('--min-confidence');
+  return i !== -1 ? parseFloat(args[i + 1]) : 0.85;
+})();
+
+// Tracking category IDs — same as scripts/add-tracking-to-bank-txns.mjs
+const TRACK_BD = '91448ff3-eb13-437a-9d97-4d2e52c86ca4';
+const TRACK_PT = '1a1ad7c5-249a-4b1f-842d-06ba2a63a0fe';
+
+// ACT-XX → full Xero option name. Source of truth: scripts/add-tracking-to-bank-txns.mjs.
+const PROJECT_TRACKING_NAME = {
+  'ACT-10': 'ACT-10 — 10x10 Retreat', 'ACT-BB': 'ACT-BB — Barkly Backbone',
+  'ACT-BG': 'ACT-BG — BG Fit', 'ACT-BM': 'ACT-BM — Bimberi',
+  'ACT-BR': 'ACT-BR — ACT Bali Retreat', 'ACT-BV': 'ACT-BV — Black Cockatoo Valley',
+  'ACT-CA': 'ACT-CA — Caring for those who care', 'ACT-CB': 'ACT-CB — Marriage Celebrant',
+  'ACT-CF': 'ACT-CF — The Confessional', 'ACT-CN': 'ACT-CN — Contained',
+  'ACT-DG': 'ACT-DG — Diagrama', 'ACT-DL': 'ACT-DL — DadLab',
+  'ACT-DO': 'ACT-DO — Designing for Obsolescence', 'ACT-EL': 'ACT-EL — Empathy Ledger',
+  'ACT-ER': 'ACT-ER — PICC Elders Room', 'ACT-FA': 'ACT-FA — Festival Activations',
+  'ACT-FG': 'ACT-FG — Feel Good Project', 'ACT-FM': 'ACT-FM — The Farm',
+  'ACT-FO': 'ACT-FO — Fishers Oysters', 'ACT-FP': 'ACT-FP — Fairfax PLACE Tech',
+  'ACT-GD': 'ACT-GD — Goods', 'ACT-GL': 'ACT-GL — Global Laundry Alliance',
+  'ACT-GP': 'ACT-GP — Gold Phone', 'ACT-HS': 'ACT-HS — Project Her-Self',
+  'ACT-HV': 'ACT-HV — The Harvest Witta', 'ACT-IN': 'ACT-IN — ACT Infrastructure',
+  'ACT-JH': 'ACT-JH — JusticeHub', 'ACT-JP': "ACT-JP — June's Patch",
+  'ACT-MC': 'ACT-MC — Cars and Microcontrollers', 'ACT-MD': 'ACT-MD — ACT Monthly Dinners',
+  'ACT-MM': 'ACT-MM — MMEIC Justice', 'ACT-MR': 'ACT-MR — MingaMinga Rangers',
+  'ACT-MY': 'ACT-MY — Mounty Yarns', 'ACT-OO': 'ACT-OO — Oonchiumpa',
+  'ACT-PI': 'ACT-PI — PICC', 'ACT-PS': 'ACT-PS — PICC Photo Studio',
+  'ACT-RA': 'ACT-RA — Regional Arts Fellowship', 'ACT-SM': 'ACT-SM — SMART',
+  'ACT-SS': 'ACT-SS — Storm Stories', 'ACT-TN': 'ACT-TN — TOMNET',
+  'ACT-TR': 'ACT-TR — Treacher', 'ACT-TW': "ACT-TW — Travelling Women's Car",
+  'ACT-UA': 'ACT-UA — Uncle Allan Palm Island Art', 'ACT-WE': 'ACT-WE — Westpac Summit 2025',
+};
+
+const DELAY_MS = 1100; // Xero rate limit: 60 req/min per tenant
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+
+function loadToken() {
+  if (existsSync(TOKEN_FILE)) return JSON.parse(readFileSync(TOKEN_FILE, 'utf8')).access_token;
+  return process.env.XERO_ACCESS_TOKEN;
+}
+
+async function getVendorBusinessDivision(vendorName) {
+  if (!vendorName) return null;
+  const v = vendorName.toLowerCase().trim();
+  const { data } = await sb
+    .from('vendor_project_rules')
+    .select('vendor_name, aliases, xero_business_division');
+  if (!data) return null;
+  for (const r of data) if ((r.vendor_name || '').toLowerCase() === v) return r.xero_business_division;
+  for (const r of data) {
+    if (Array.isArray(r.aliases) && r.aliases.some((a) => (a || '').toLowerCase() === v)) {
+      return r.xero_business_division;
+    }
+  }
+  for (const r of data) {
+    const rv = (r.vendor_name || '').toLowerCase();
+    if (rv && (v.includes(rv) || rv.includes(v))) return r.xero_business_division;
+  }
+  return null;
+}
+
+async function markApplied(id, errorMsg = null) {
+  const update = errorMsg
+    ? { applied_to_xero_error: errorMsg }
+    : { applied_to_xero_at: new Date().toISOString(), applied_to_xero_error: null };
+  await sb.from('finance_ai_routing_suggestions').update(update).eq('id', id);
+}
+
+async function main() {
+  log(`Push AI tracking to Xero${DRY_RUN ? ' (DRY RUN)' : ''} — limit=${LIMIT} min-conf=${MIN_CONFIDENCE}\n`);
+
+  const token = loadToken();
+  if (!token) {
+    log('No Xero access token. Run: node scripts/sync-xero-tokens.mjs');
+    process.exit(1);
+  }
+
+  const { data: suggestions, error } = await sb
+    .from('finance_ai_routing_suggestions')
+    .select('id, source_record_id, suggested_project_code, confidence, vendor_name, amount, txn_date')
+    .eq('source_table', 'xero_transactions')
+    .eq('applied_to_source', true)
+    .is('applied_to_xero_at', null)
+    .is('rejected_at', null)
+    .gte('confidence', MIN_CONFIDENCE)
+    .not('suggested_project_code', 'in', '(ASK_USER,SL_REVIEW)')
+    .order('confidence', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(LIMIT);
+
+  if (error) {
+    log(`Query failed: ${error.message}`);
+    process.exit(1);
+  }
+  if (!suggestions.length) {
+    log('Nothing to push.');
+    return;
+  }
+
+  log(`${suggestions.length} suggestions to push\n`);
+  let updated = 0, skipped = 0, failed = 0;
+
+  for (const s of suggestions) {
+    const dateStr = s.txn_date?.slice(0, 10) || '????-??-??';
+    const vendorStr = (s.vendor_name || '?').slice(0, 26).padEnd(26);
+    const amtStr = `$${Number(s.amount || 0).toFixed(2).padStart(9)}`;
+    const tag = `${dateStr} ${vendorStr} ${amtStr}`;
+
+    const projName = PROJECT_TRACKING_NAME[s.suggested_project_code];
+    if (!projName) {
+      log(`${tag}  — unknown project code ${s.suggested_project_code}`);
+      await markApplied(s.id, `unknown_project_code:${s.suggested_project_code}`);
+      skipped++;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      log(`${tag}  → ${s.suggested_project_code} (dry)`);
+      updated++;
+      continue;
+    }
+
+    // GET current txn
+    const getRes = await fetch(`https://api.xero.com/api.xro/2.0/BankTransactions/${s.source_record_id}`, {
+      headers: { Authorization: `Bearer ${token}`, 'xero-tenant-id': XERO_TENANT_ID, Accept: 'application/json' },
+    });
+    if (!getRes.ok) {
+      if (getRes.status === 401) {
+        log('  401 — token expired. Run sync-xero-tokens.mjs first.');
+        process.exit(1);
+      }
+      log(`${tag}  GET ${getRes.status}`);
+      await markApplied(s.id, `GET_${getRes.status}`);
+      failed++;
+      await sleep(DELAY_MS);
+      continue;
+    }
+    const txn = (await getRes.json()).BankTransactions?.[0];
+    if (!txn?.LineItems?.[0]) {
+      log(`${tag}  — txn or LineItems missing`);
+      await markApplied(s.id, 'missing_line_items');
+      skipped++;
+      await sleep(DELAY_MS);
+      continue;
+    }
+
+    // Idempotent: skip if Project Tracking already present on every line
+    const alreadyTracked = txn.LineItems.every((li) =>
+      (li.Tracking || []).some((t) => t.TrackingCategoryID === TRACK_PT)
+    );
+    if (alreadyTracked) {
+      log(`${tag}  — already tracked, marking applied`);
+      await markApplied(s.id);
+      skipped++;
+      continue;
+    }
+
+    const bd = (await getVendorBusinessDivision(txn.Contact?.Name || s.vendor_name)) || 'A Curious Tractor';
+
+    const updatedLines = txn.LineItems.map((li) => {
+      const existing = li.Tracking || [];
+      const hasBD = existing.some((e) => e.TrackingCategoryID === TRACK_BD);
+      const hasPT = existing.some((e) => e.TrackingCategoryID === TRACK_PT);
+      const newTracking = [...existing];
+      if (!hasBD) newTracking.push({ TrackingCategoryID: TRACK_BD, Name: 'Business Divisions', Option: bd });
+      if (!hasPT) newTracking.push({ TrackingCategoryID: TRACK_PT, Name: 'Project Tracking', Option: projName });
+      return {
+        LineItemID: li.LineItemID,
+        Description: li.Description,
+        Quantity: li.Quantity,
+        UnitAmount: li.UnitAmount,
+        AccountCode: li.AccountCode,
+        TaxType: li.TaxType,
+        Tracking: newTracking,
+      };
+    });
+
+    const body = {
+      BankTransactions: [{
+        BankTransactionID: s.source_record_id,
+        LineItems: updatedLines,
+      }],
+    };
+
+    const postRes = await fetch(`https://api.xero.com/api.xro/2.0/BankTransactions/${s.source_record_id}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'xero-tenant-id': XERO_TENANT_ID,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!postRes.ok) {
+      const errText = await postRes.text();
+      log(`${tag}  FAILED ${postRes.status}: ${errText.slice(0, 200)}`);
+      await markApplied(s.id, `POST_${postRes.status}:${errText.slice(0, 500)}`);
+      failed++;
+    } else {
+      log(`${tag}  ✓ → ${s.suggested_project_code} (${(s.confidence * 100).toFixed(0)}%)`);
+      await markApplied(s.id);
+      updated++;
+    }
+    await sleep(DELAY_MS);
+  }
+
+  log(`\nDone. Updated: ${updated} | Skipped: ${skipped} | Failed: ${failed}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/supabase/migrations/20260518000000_finance_ai_routing_xero_writeback.sql
+++ b/supabase/migrations/20260518000000_finance_ai_routing_xero_writeback.sql
@@ -1,0 +1,28 @@
+-- Issue #66 pivot — write tracking categories to Xero after the AI grader
+-- accepts a high-confidence project_code suggestion.
+--
+-- Background: ai-route-dext-doc.mjs --apply already writes project_code to
+-- the source row in Supabase (xero_transactions.project_code), but the
+-- Xero record itself stays untracked — so R&D pack + project reports miss
+-- the spend even after the AI accepted it.
+--
+-- This migration adds two columns that the new push-ai-tracking-to-xero.mjs
+-- cron uses to track its own progress so we don't double-apply or silently
+-- drop API failures.
+
+ALTER TABLE public.finance_ai_routing_suggestions
+  ADD COLUMN IF NOT EXISTS applied_to_xero_at timestamptz,
+  ADD COLUMN IF NOT EXISTS applied_to_xero_error text;
+
+CREATE INDEX IF NOT EXISTS finance_ai_routing_xero_pending_idx
+  ON public.finance_ai_routing_suggestions (confidence DESC, created_at DESC)
+  WHERE source_table = 'xero_transactions'
+    AND applied_to_source = true
+    AND applied_to_xero_at IS NULL
+    AND rejected_at IS NULL
+    AND confidence >= 0.85;
+
+COMMENT ON COLUMN public.finance_ai_routing_suggestions.applied_to_xero_at IS
+  'Set by scripts/push-ai-tracking-to-xero.mjs once the Xero BankTransaction has been PATCHed with the tracking categories. NULL means pending (or not applicable for non-xero_transactions source).';
+COMMENT ON COLUMN public.finance_ai_routing_suggestions.applied_to_xero_error IS
+  'Most recent Xero API error from push-ai-tracking-to-xero.mjs (HTTP status + truncated body). Cleared on success.';


### PR DESCRIPTION
Closes #66

## Summary — pivoted

The original #66 plan was to write AI-graded `project_code` back to **Dext** as a tracking-category value (so Dext shows the tracking pre-filled before Publish). Investigation found this repo has no Dext API client, no Dext credentials, and Dext's mental model is "Dext is the inbox, Xero is the system of record" anyway. The fix moves to the right side of the publish boundary.

**Pivot:** when the AI grader's `--apply` flag writes `project_code` to `xero_transactions.project_code` in Supabase, the corresponding Xero record itself stays untracked — so R&D pack + project reports miss the spend even after the AI accepted it. This PR closes that gap by adding a new cron that catches up.

## What landed

- **Migration** `20260518000000_finance_ai_routing_xero_writeback.sql` — adds `applied_to_xero_at timestamptz` + `applied_to_xero_error text` to `finance_ai_routing_suggestions` plus a partial index on the pending-push slice. **Applied to production Supabase** before this PR opened.
- **Script** `scripts/push-ai-tracking-to-xero.mjs` — idempotent push that re-uses the Xero API + tracking-category pattern from `scripts/add-tracking-to-bank-txns.mjs` (same tracking IDs, same vendor-rule BD lookup, same 1100ms rate-limit). Marks `applied_to_xero_at` on success or `applied_to_xero_error` on API failures.
- **PM2 entry** `push-ai-tracking-to-xero` at `7,37 8-18 * * 1-5` (xx:07 and xx:37, Mon-Fri AEST business hours), offset from `pre-publish-dext-grader` so the upstream grader's writes settle first.

## What's deliberately not in this PR

- **Paired upstream grader cron.** The new script polls `xero_transactions` source suggestions, but the existing `pre-publish-dext-grader` cron only grades `finance_receipt_documents`. Nothing grades `xero_transactions` on a schedule today. To make the cron earn its keep, a paired `ai-router-xero-mode` entry running `ai-route-dext-doc.mjs --source xero --apply` is needed. Deferred to a follow-up so #66 stays scoped.

## Test plan
- [x] `node --check scripts/push-ai-tracking-to-xero.mjs` clean
- [x] Migration applied (verified via `information_schema.columns`)
- [x] Dry-run end-to-end: `node scripts/push-ai-tracking-to-xero.mjs --dry-run --limit 5` → loads env, query compiles, exits "Nothing to push" (expected: 0 eligible until paired grader runs)
- [ ] Live smoke: paired grader added, runs once, expect a non-zero count of high-conf `xero_transactions` suggestions, dry-run prints them, real run pushes to Xero, Xero UI shows tracking populated

## Risks
- **Rate limit:** Xero is 60 req/min/tenant; script sleeps 1100ms (GET + POST per item ≈ 30 items/min). With `--limit 50` default, a full batch ≈ 2 min — well under the per-cron window.
- **401 token expiry:** existing pattern — if the access token expires, script exits 1 and `sync-xero-tokens.mjs` resolves.
- **Idempotency:** before writing, the script checks if `Project Tracking` is already present on every LineItem — if so it marks applied and moves on. Safe to re-run after partial failures.