### PR TITLE
feat(cron): #66 paired grader — ai-router-xero-mode for the writeback chain

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -294,6 +294,17 @@ const cronScripts = [
     // and POSTs Business Division + Project Tracking via the Xero API.
     // Runs offset from pre-publish-dext-grader so the grader has time to
     // finish writing.
+    // Issue #66 paired grader — grades freshly-arrived xero_transactions
+    // (rows that landed via Xero sync but have no project_code yet) and
+    // writes high-confidence suggestions to finance_ai_routing_suggestions
+    // with applied_to_source=true. Runs at xx:00 and xx:30 — 7 min before
+    // push-ai-tracking-to-xero so the suggestions are written first.
+    name: 'ai-router-xero-mode',
+    script: 'scripts/ai-route-dext-doc.mjs',
+    args: '--source xero --apply --limit 30 --min-confidence 0.85',
+    cron_restart: '0,30 8-18 * * 1-5', // xx:00 and xx:30, Mon-Fri 8am-6pm AEST
+  },
+  {
     name: 'push-ai-tracking-to-xero',
     script: 'scripts/push-ai-tracking-to-xero.mjs',
     args: '--limit 50',


### PR DESCRIPTION
Follow-up to #74. Adds the missing upstream cron so the writeback chain has data to push.

## What

A new PM2 entry `ai-router-xero-mode` that runs `scripts/ai-route-dext-doc.mjs --source xero --apply` every 30 min during weekday business hours (xx:00 and xx:30, 8am-6pm AEST Mon-Fri).

## Why this PR is separate

PR #74 stays scoped to "the writeback half". This PR is "the grader half". Reviewers can verify each independently: the writeback writes correct API calls; the grader writes correct suggestions. They share no code — only the shared cron schedule (`0,30` then `7,37` = 7-min handoff).

## Cron schedule

```
ai-router-xero-mode       xx:00, xx:30  Mon-Fri 8am-6pm AEST   (grader)
push-ai-tracking-to-xero  xx:07, xx:37  Mon-Fri 8am-6pm AEST   (push, from PR #74)
```

The 7-min offset gives the grader time to write suggestions before the push polls. Worst case if a grader run overflows the window, the push finds nothing fresh that cycle and picks up 30 min later — no data lost.

## Smoke test (2026-05-17)

```
$ node scripts/ai-route-dext-doc.mjs --source xero --limit 3
Model: claude-sonnet-4-6  •  Source: xero  •  Limit: 3
Apply mode: no (suggestions only)
Found 0 unrouted rows.
```

All 1749 `xero_transactions` since 2025-07-01 are already routed — the BAS prep work cleared the backlog. New untagged txns from upcoming Xero syncs will flow through this chain.

## Merge order

This PR should merge **into PR #74's branch first** (base = `feat/issue-66-ai-tracking-to-dext`). Then PR #74 → main carries both halves together. If reviewers prefer the opposite order, the base can be re-targeted to main and ordered explicitly.

## Test plan
- [x] Cron entry parses via `node -e "require('./ecosystem.config.cjs')"`
- [x] Manual dry-run of the underlying grader exits cleanly on empty queue
- [ ] After merge + PM2 reload, first business-hour tick logs "Found N unrouted rows" with N > 0 once new txns arrive from Xero sync
- [ ] First high-confidence suggestion lands in `finance_ai_routing_suggestions` with `applied_to_source = true`
- [ ] Following push tick reads the suggestion, PATCHes Xero, marks `applied_to_xero_at`

## Post-merge ops (Tier 2)

`pm2 start ecosystem.config.cjs --only ai-router-xero-mode,push-ai-tracking-to-xero && pm2 save` — register both crons. Existing pm2 processes are unaffected.