### PR TITLE
feat(finance): Pass 2C accountability — ack tables + debt counter + digest sections

### DIFF
--- a/apps/command-center/src/app/api/finance/ack-state/route.ts
+++ b/apps/command-center/src/app/api/finance/ack-state/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+// Pass 2C C2 — ack state for AT RISK pane.
+//
+// Returns most-recent ack per obligation/idea within the lookback window so the
+// page can decorate each row with ✓/age vs red, and compute the debt counter
+// (items unacked > DEBT_HOURS where the underlying risk is still active).
+//
+// Snapshot semantics (Q11): debt counter is "right now", not cumulative.
+
+const LOOKBACK_DAYS = 14
+const DEBT_HOURS = 24
+
+interface AckRow {
+  acked_at: string
+  acked_by: string
+}
+
+export interface AckStateResponse {
+  generatedAt: string
+  lookbackDays: number
+  debtHours: number
+  compliance: Record<string, AckRow>
+  idea: Record<string, AckRow>
+}
+
+export async function GET() {
+  const since = new Date(Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000).toISOString()
+
+  const [{ data: comp, error: compErr }, { data: idea, error: ideaErr }] = await Promise.all([
+    supabase
+      .from('compliance_ack')
+      .select('obligation_id, acked_at, acked_by')
+      .gte('acked_at', since)
+      .order('acked_at', { ascending: false }),
+    supabase
+      .from('idea_ack')
+      .select('idea_id, acked_at, acked_by')
+      .gte('acked_at', since)
+      .order('acked_at', { ascending: false }),
+  ])
+
+  if (compErr || ideaErr) {
+    return NextResponse.json(
+      { error: (compErr ?? ideaErr)!.message, hint: 'apply supabase/migrations/20260518000100_ack_tables.sql' },
+      { status: 500 },
+    )
+  }
+
+  // ordered desc, so first row wins = most recent ack
+  const compliance: Record<string, AckRow> = {}
+  for (const r of comp ?? []) {
+    if (!compliance[r.obligation_id]) {
+      compliance[r.obligation_id] = { acked_at: r.acked_at, acked_by: r.acked_by }
+    }
+  }
+  const idea_: Record<string, AckRow> = {}
+  for (const r of idea ?? []) {
+    if (!idea_[r.idea_id]) {
+      idea_[r.idea_id] = { acked_at: r.acked_at, acked_by: r.acked_by }
+    }
+  }
+
+  const response: AckStateResponse = {
+    generatedAt: new Date().toISOString(),
+    lookbackDays: LOOKBACK_DAYS,
+    debtHours: DEBT_HOURS,
+    compliance,
+    idea: idea_,
+  }
+  return NextResponse.json(response)
+}

--- a/apps/command-center/src/app/api/finance/ack/route.ts
+++ b/apps/command-center/src/app/api/finance/ack/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+// Pass 2C C2 — POST an ack for a compliance obligation or an idea reminder.
+//
+//   POST /api/finance/ack
+//   { kind: 'compliance', id: 'bas-q4-fy26', ack_by: 'ben', via?: 'command-page' }
+//   { kind: 'idea',       id: '<uuid>',     ack_by: 'ben', reminder_id?: '...' }
+
+interface AckBody {
+  kind: 'compliance' | 'idea'
+  id: string
+  ack_by?: string
+  via?: string
+  reminder_id?: string
+}
+
+export async function POST(req: NextRequest) {
+  let body: AckBody
+  try {
+    body = (await req.json()) as AckBody
+  } catch {
+    return NextResponse.json({ error: 'invalid JSON body' }, { status: 400 })
+  }
+
+  if (!body.id || !body.kind) {
+    return NextResponse.json({ error: 'kind + id required' }, { status: 400 })
+  }
+  const ackBy = body.ack_by?.trim() || 'ben'
+
+  if (body.kind === 'compliance') {
+    const { data, error } = await supabase
+      .from('compliance_ack')
+      .insert({ obligation_id: body.id, acked_by: ackBy, acked_via: body.via ?? 'command-page' })
+      .select('id, acked_at')
+      .single()
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ ok: true, ack: data })
+  }
+
+  if (body.kind === 'idea') {
+    const { data, error } = await supabase
+      .from('idea_ack')
+      .insert({ idea_id: body.id, acked_by: ackBy, reminder_id: body.reminder_id ?? null })
+      .select('id, acked_at')
+      .single()
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+    return NextResponse.json({ ok: true, ack: data })
+  }
+
+  return NextResponse.json({ error: `unknown kind: ${body.kind}` }, { status: 400 })
+}

--- a/apps/command-center/src/app/finance/command/page.tsx
+++ b/apps/command-center/src/app/finance/command/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
 import {
   AlertTriangle,
   ArrowRight,
@@ -167,6 +168,19 @@ interface PilotRisksResponse {
   counters: { high: number; medium: number; snooze_burned: number }
 }
 
+interface AckRow {
+  acked_at: string
+  acked_by: string
+}
+
+interface AckStateResponse {
+  generatedAt: string
+  lookbackDays: number
+  debtHours: number
+  compliance: Record<string, AckRow>
+  idea: Record<string, AckRow>
+}
+
 interface DeltaResponse {
   available: boolean
   reason?: string
@@ -237,6 +251,15 @@ export default function MoneyCommandPage() {
     },
     staleTime: 10 * 60 * 1000,
   })
+  const { data: ackState } = useQuery<AckStateResponse>({
+    queryKey: ['finance', 'ack-state'],
+    queryFn: async () => {
+      const res = await fetch('/api/finance/ack-state', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    staleTime: 60 * 1000,
+  })
 
   return (
     <div className="min-h-screen bg-neutral-950 text-neutral-100 p-6 lg:p-10">
@@ -274,7 +297,13 @@ export default function MoneyCommandPage() {
         {data && (
           <>
             {/* AT RISK TODAY — unified attention pane */}
-            <AtRiskTodaySection compliance={compliance} pilotRisks={pilotRisks} top={data.top} drift={data.middle.drift} />
+            <AtRiskTodaySection
+              compliance={compliance}
+              pilotRisks={pilotRisks}
+              top={data.top}
+              drift={data.middle.drift}
+              ackState={ackState}
+            />
             {/* TOP LAYER */}
             <TopLayer top={data.top} />
             {/* MIDDLE LAYER */}
@@ -299,19 +328,25 @@ function AtRiskTodaySection({
   pilotRisks,
   top,
   drift,
+  ackState,
 }: {
   compliance: ComplianceResponse | undefined
   pilotRisks: PilotRisksResponse | undefined
   top: CommandResponse['top']
   drift: DriftItem[]
+  ackState: AckStateResponse | undefined
 }) {
-  // Build risk items in severity order: critical (red), high (orange), medium (yellow)
+  // Build risk items in severity order: critical (red), high (orange), medium (yellow).
+  // Items with an ackKind+ackId can be acknowledged + checked against ackState
+  // for the debt counter (Pass 2C C2).
   type Risk = {
     severity: 'critical' | 'high' | 'medium'
-    icon: string
     label: string
     note: string
     href: string
+    ackKind?: 'compliance' | 'idea'
+    ackId?: string
+    firstSurfacedAt?: string  // approximation of when this risk became visible
   }
   const items: Risk[] = []
 
@@ -323,13 +358,17 @@ function AtRiskTodaySection({
       const tag = dd == null ? '' : dd < 0 ? `T+${Math.abs(dd)}d` : `T-${dd}d`
       items.push({
         severity: o.severity,
-        icon: '📋',
         label: `[${tag}] ${o.title}`,
         note: o.notes ? o.notes.split('\n')[0].slice(0, 60) : `${o.type} · ${o.entity}`,
         href:
           o.source === 'ghl_opportunities'
             ? '/finance/workbench'
             : 'https://github.com/Acurioustractor/act-global-infrastructure/blob/main/wiki/finance/compliance-calendar.md',
+        ackKind: 'compliance',
+        ackId: o.id,
+        // best-effort age proxy: compliance snapshot rebuilds daily at 7am, so
+        // any item present has been visible at least since that rebuild.
+        firstSurfacedAt: compliance.generatedAt,
       })
     }
   }
@@ -342,7 +381,6 @@ function AtRiskTodaySection({
       if (runwayMonths < 2) {
         items.push({
           severity: 'critical',
-          icon: '🔥',
           label: `runway ${runwayMonths.toFixed(1)} months`,
           note: `cash ${formatMoneyCompact(top.cashInBank)} · monthly burn ${formatMoneyCompact(monthlyBurn)}`,
           href: '/finance/overview',
@@ -350,7 +388,6 @@ function AtRiskTodaySection({
       } else if (runwayMonths < 3) {
         items.push({
           severity: 'medium',
-          icon: '⏱️',
           label: `runway ${runwayMonths.toFixed(1)} months`,
           note: `cash ${formatMoneyCompact(top.cashInBank)} · monthly burn ${formatMoneyCompact(monthlyBurn)}`,
           href: '/finance/overview',
@@ -364,7 +401,6 @@ function AtRiskTodaySection({
     if (Math.abs(d.amount) < 5000) continue
     items.push({
       severity: Math.abs(d.amount) >= 50000 ? 'high' : 'medium',
-      icon: '🔀',
       label: `drift ${formatMoneyCompact(Math.abs(d.amount))}`,
       note: d.label.slice(0, 60),
       href: d.workbenchUrl ?? '/finance/workbench',
@@ -374,15 +410,16 @@ function AtRiskTodaySection({
   // Pilot lifecycle risks (Pass 2B B6) — stale scope/fundraise + snooze-burned
   if (pilotRisks) {
     for (const p of pilotRisks.items.slice(0, 5)) {
-      const stageIcon = p.stage === 'fundraise' ? '💸' : '🔍'
       const valueTag = p.value_estimate > 0 ? ` · ~${formatMoneyCompact(p.value_estimate)}` : ''
       const burnTag = p.snooze_burned ? ' · 💤×3 forced decision' : p.snooze_count > 0 ? ` · 💤×${p.snooze_count}` : ''
       items.push({
         severity: p.severity,
-        icon: stageIcon,
         label: `[${p.stage} ${p.age_days}d idle${valueTag}${burnTag}]`,
         note: p.text.slice(0, 60),
         href: p.href,
+        ackKind: 'idea',
+        ackId: p.id,
+        firstSurfacedAt: pilotRisks.generatedAt,
       })
     }
   }
@@ -391,11 +428,35 @@ function AtRiskTodaySection({
   const sevOrder = { critical: 0, high: 1, medium: 2 }
   items.sort((a, b) => sevOrder[a.severity] - sevOrder[b.severity])
 
+  // Debt counter — snapshot count of ackable items WITHOUT a fresh ack.
+  // "Fresh" = acked AFTER the surface time AND within the lookback window.
+  // Threshold uses ackState.debtHours; items that haven't been visible that
+  // long aren't yet "in debt".
+  const debtHours = ackState?.debtHours ?? 24
+  const now = Date.now()
+  let unackedCount = 0
+  for (const r of items) {
+    if (!r.ackKind || !r.ackId) continue
+    const lookup = r.ackKind === 'compliance' ? ackState?.compliance : ackState?.idea
+    const ack = lookup?.[r.ackId]
+    const surfaceTime = r.firstSurfacedAt ? new Date(r.firstSurfacedAt).getTime() : now
+    const ageHours = (now - surfaceTime) / (1000 * 60 * 60)
+    if (ageHours < debtHours) continue
+    if (ack && new Date(ack.acked_at).getTime() >= surfaceTime) continue
+    unackedCount += 1
+  }
+
   const SEV_TONE: Record<Risk['severity'], { icon: string; bg: string; text: string }> = {
     critical: { icon: '🔴', bg: 'border-rose-900/60 bg-rose-950/30', text: 'text-rose-300' },
     high: { icon: '🟠', bg: 'border-amber-900/60 bg-amber-950/20', text: 'text-amber-300' },
     medium: { icon: '🟡', bg: 'border-yellow-900/40 bg-yellow-950/10', text: 'text-yellow-300' },
   }
+
+  // Debt-counter pill tone (Pass 2C C2): hidden at 0, yellow 1-5, red >5
+  const debtTone =
+    unackedCount === 0 ? null
+      : unackedCount > 5 ? 'text-rose-300 bg-rose-950/40 border-rose-900/60'
+      : 'text-amber-300 bg-amber-950/30 border-amber-900/50'
 
   return (
     <section className="space-y-3">
@@ -406,6 +467,14 @@ function AtRiskTodaySection({
           · {items.length} {items.length === 1 ? 'item' : 'items'}
           {compliance ? ` · compliance refreshed ${new Date(compliance.generatedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
         </span>
+        {debtTone && (
+          <span
+            className={cn('ml-2 inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium normal-case tracking-normal', debtTone)}
+            title={`${unackedCount} ackable items unactioned > ${debtHours}h`}
+          >
+            📒 {unackedCount} ack-overdue
+          </span>
+        )}
       </div>
       {items.length === 0 ? (
         <div className="rounded-lg border border-emerald-900/40 bg-emerald-950/15 p-4 text-sm text-emerald-300">
@@ -416,26 +485,102 @@ function AtRiskTodaySection({
         <div className="rounded-lg border border-neutral-800 bg-neutral-900/60 p-3 space-y-1.5">
           {items.map((r, i) => {
             const tone = SEV_TONE[r.severity]
+            const lookup = r.ackKind === 'compliance' ? ackState?.compliance
+              : r.ackKind === 'idea' ? ackState?.idea
+              : undefined
+            const ack = r.ackId ? lookup?.[r.ackId] : undefined
             return (
-              <Link
-                key={i}
-                href={r.href}
-                target={r.href.startsWith('http') ? '_blank' : undefined}
+              <div
+                key={`${r.ackKind ?? 'unack'}-${r.ackId ?? i}`}
                 className={cn(
-                  'flex items-center gap-3 px-3 py-2 rounded border hover:bg-neutral-800/50 transition-colors',
+                  'flex items-center gap-3 px-3 py-2 rounded border transition-colors',
                   tone.bg,
                 )}
               >
                 <span className="text-base shrink-0">{tone.icon}</span>
-                <span className={cn('text-sm font-medium shrink-0', tone.text)}>{r.label}</span>
+                <Link
+                  href={r.href}
+                  target={r.href.startsWith('http') ? '_blank' : undefined}
+                  className={cn('text-sm font-medium shrink-0 hover:underline', tone.text)}
+                >
+                  {r.label}
+                </Link>
                 <span className="text-xs text-neutral-500 flex-1 truncate">{r.note}</span>
-                <ArrowRight size={12} className="text-neutral-600 shrink-0" />
-              </Link>
+                {r.ackKind && r.ackId ? (
+                  <AckButton kind={r.ackKind} id={r.ackId} ack={ack} />
+                ) : (
+                  <ArrowRight size={12} className="text-neutral-600 shrink-0" />
+                )}
+              </div>
             )
           })}
         </div>
       )}
     </section>
+  )
+}
+
+function AckButton({
+  kind,
+  id,
+  ack,
+}: {
+  kind: 'compliance' | 'idea'
+  id: string
+  ack: AckRow | undefined
+}) {
+  const qc = useQueryClient()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  if (ack) {
+    const ageHours = (Date.now() - new Date(ack.acked_at).getTime()) / (1000 * 60 * 60)
+    const ageLabel = ageHours < 1
+      ? 'just now'
+      : ageHours < 24
+        ? `${Math.round(ageHours)}h ago`
+        : `${Math.round(ageHours / 24)}d ago`
+    return (
+      <span
+        className="inline-flex items-center gap-1 text-[11px] text-emerald-400 shrink-0"
+        title={`acked by ${ack.acked_by} at ${new Date(ack.acked_at).toLocaleString()}`}
+      >
+        <CheckCircle2 size={12} /> {ageLabel}
+      </span>
+    )
+  }
+
+  const submit = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/finance/ack', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ kind, id, ack_by: 'ben', via: 'command-page' }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      qc.invalidateQueries({ queryKey: ['finance', 'ack-state'] })
+    } catch (err) {
+      setError((err as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={submit}
+      disabled={busy}
+      className={cn(
+        'inline-flex items-center gap-1 rounded border border-neutral-700 bg-neutral-900/60 px-2 py-0.5 text-[11px] text-neutral-300 hover:border-emerald-700 hover:text-emerald-300 disabled:opacity-50 shrink-0',
+        error && 'border-rose-700 text-rose-300',
+      )}
+      title={error ?? 'Mark seen — does not change underlying status'}
+    >
+      {busy ? '…' : 'Ack'}
+    </button>
   )
 }
 

--- a/scripts/weekly-money-digest.mjs
+++ b/scripts/weekly-money-digest.mjs
@@ -19,7 +19,7 @@
 
 import { Client } from '@notionhq/client';
 import { createClient } from '@supabase/supabase-js';
-import { readFileSync, writeFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -113,6 +113,120 @@ async function main() {
     .limit(1);
   const bankNow = cashflow?.[0]?.closing_balance;
 
+  // Pass 2C C3 — accountability sections (compliance / ideas / ack gaps)
+  const weekAgoIso = new Date(Date.now() - 7 * 86400000).toISOString();
+  const fiveDaysAgoIso = new Date(Date.now() - 5 * 86400000).toISOString();
+
+  const complianceSnap = readLatestComplianceSnapshot();
+  const { data: complianceAcks } = await supabase
+    .from('compliance_ack')
+    .select('obligation_id, acked_at, acked_by, acked_via')
+    .gte('acked_at', weekAgoIso)
+    .order('acked_at', { ascending: false });
+  const ackedByObligation = new Map();
+  for (const a of complianceAcks || []) {
+    if (!ackedByObligation.has(a.obligation_id)) ackedByObligation.set(a.obligation_id, a);
+  }
+
+  const complianceHits = [];      // filed OR acked this week
+  const complianceMisses = [];    // due in last week, no filing + no ack
+  const compliancePending = [];   // upcoming next 30d
+  if (complianceSnap?.obligations) {
+    for (const o of complianceSnap.obligations) {
+      const dd = o.days_until_due;
+      const filedThisWeek = o.status === 'filed' && o.last_filed_at && o.last_filed_at >= weekAgoIso.slice(0, 10);
+      const ack = ackedByObligation.get(o.id);
+      if (filedThisWeek) {
+        complianceHits.push({ ...o, _reason: 'filed', _acked_at: o.last_filed_at });
+      } else if (ack) {
+        complianceHits.push({ ...o, _reason: 'acked', _acked_at: ack.acked_at });
+      } else if (dd != null && dd < 0 && dd >= -7 && o.status !== 'filed') {
+        complianceMisses.push({ ...o });
+      } else if (dd != null && dd >= 0 && dd <= 30 && o.status !== 'filed') {
+        compliancePending.push({ ...o });
+      }
+    }
+    compliancePending.sort((a, b) => (a.days_until_due ?? 999) - (b.days_until_due ?? 999));
+  }
+
+  // Idea lifecycle moves this week (lifecycle_stage transitions)
+  const { data: ideaMoves } = await supabase
+    .from('idea_board')
+    .select('id, text, lifecycle_stage, owner, kill_reason, value_estimate, stage_entered_at')
+    .in('lifecycle_stage', ['start', 'killed'])
+    .gte('stage_entered_at', weekAgoIso)
+    .order('stage_entered_at', { ascending: false });
+
+  // Snooze-burned ideas (3+ snoozes) — forced decisions overdue
+  const { data: snoozeRows } = await supabase
+    .from('idea_snoozes')
+    .select('idea_id');
+  const snoozeCount = new Map();
+  for (const s of snoozeRows || []) {
+    snoozeCount.set(s.idea_id, (snoozeCount.get(s.idea_id) || 0) + 1);
+  }
+  const burnedIdeaIds = [...snoozeCount.entries()].filter(([, n]) => n >= 3).map(([id]) => id);
+  let burnedIdeas = [];
+  if (burnedIdeaIds.length > 0) {
+    const { data } = await supabase
+      .from('idea_board')
+      .select('id, text, lifecycle_stage, owner, value_estimate')
+      .in('id', burnedIdeaIds)
+      .not('lifecycle_stage', 'in', '("start","killed")');
+    burnedIdeas = data || [];
+  }
+
+  // Acknowledgement gaps — AT RISK obligations + pilot risks with no fresh ack
+  const ackGaps = [];
+  if (complianceSnap?.obligations) {
+    for (const o of complianceSnap.obligations) {
+      if (!o.at_risk || o.status === 'filed') continue;
+      const ack = ackedByObligation.get(o.id);
+      if (ack && ack.acked_at >= fiveDaysAgoIso) continue;
+      ackGaps.push({
+        kind: 'compliance',
+        id: o.id,
+        label: o.title,
+        last_ack: ack?.acked_at ?? null,
+        severity: o.severity,
+        days_until_due: o.days_until_due,
+      });
+    }
+  }
+  // Pilot risk ack gaps — scope/fundraise stale items not acked in 5d
+  const { data: ideaAcks } = await supabase
+    .from('idea_ack')
+    .select('idea_id, acked_at')
+    .gte('acked_at', fiveDaysAgoIso);
+  const recentIdeaAcks = new Set((ideaAcks || []).map(a => a.idea_id));
+  const { data: stalePilots } = await supabase
+    .from('idea_board')
+    .select('id, text, lifecycle_stage, stage_entered_at, value_estimate')
+    .in('lifecycle_stage', ['scope', 'fundraise']);
+  for (const p of stalePilots || []) {
+    const stage = p.lifecycle_stage;
+    const threshold = stage === 'scope' ? 30 : 14;
+    const enteredAt = p.stage_entered_at;
+    if (!enteredAt) continue;
+    const ageDays = Math.floor((Date.now() - new Date(enteredAt).getTime()) / 86400000);
+    if (ageDays < threshold) continue;
+    if (recentIdeaAcks.has(p.id)) continue;
+    ackGaps.push({
+      kind: 'idea',
+      id: p.id,
+      label: (p.text || 'unnamed').slice(0, 60),
+      last_ack: null,
+      severity: 'high',
+      stage,
+      age_days: ageDays,
+      value_estimate: Number(p.value_estimate || 0),
+    });
+  }
+  ackGaps.sort((a, b) => {
+    const sev = { critical: 0, high: 1, medium: 2 };
+    return (sev[a.severity] ?? 3) - (sev[b.severity] ?? 3);
+  });
+
   // Build blocks
   const blocks = [];
   blocks.push(h2(`💵 Friday Digest — ${today}`));
@@ -182,6 +296,88 @@ async function main() {
     }
   }
 
+  // Pass 2C C3 — Compliance hits/misses this week
+  blocks.push(h3('\u{1F4CB} Compliance this week'));
+  if (!complianceSnap) {
+    blocks.push(para([rt('(no compliance snapshot — run node scripts/build-compliance-calendar.mjs)', { italic: true, color: 'gray' })]));
+  } else {
+    if (complianceHits.length === 0 && complianceMisses.length === 0 && compliancePending.length === 0) {
+      blocks.push(para([rt('(no compliance movement this week)', { italic: true, color: 'gray' })]));
+    }
+    for (const h of complianceHits) {
+      blocks.push(bullet([
+        rt('\u{2705} ', { color: 'green' }),
+        rt(h.title, { bold: true }),
+        rt(`  · ${h._reason === 'filed' ? 'filed' : 'acked'} ${h._acked_at?.slice(0, 10) ?? ''}`, { color: 'green' }),
+      ]));
+    }
+    for (const m of complianceMisses) {
+      blocks.push(bullet([
+        rt('\u{2717} ', { color: 'red' }),
+        rt(m.title, { bold: true }),
+        rt(`  · T+${Math.abs(m.days_until_due)}d past due · ${m.entity}`, { color: 'red' }),
+      ]));
+    }
+    for (const p of compliancePending.slice(0, 5)) {
+      blocks.push(bullet([
+        rt('\u{2192} ', { color: 'gray' }),
+        rt(p.title),
+        rt(`  · T-${p.days_until_due}d · ${p.entity}`, { color: 'gray' }),
+      ]));
+    }
+  }
+
+  // Idea decisions this week
+  blocks.push(h3('\u{1F4A1} Ideas — moves & forced decisions'));
+  const shipped = (ideaMoves || []).filter(i => i.lifecycle_stage === 'start');
+  const killed = (ideaMoves || []).filter(i => i.lifecycle_stage === 'killed');
+  if (shipped.length === 0 && killed.length === 0 && burnedIdeas.length === 0) {
+    blocks.push(para([rt('(no idea lifecycle moves this week)', { italic: true, color: 'gray' })]));
+  }
+  for (const i of shipped) {
+    blocks.push(bullet([
+      rt('\u{1F680} shipped → ', { color: 'green' }),
+      rt((i.text || 'unnamed').slice(0, 60), { bold: true }),
+      rt(`  · owner ${i.owner || 'ben'}`, { color: 'gray' }),
+    ]));
+  }
+  for (const i of killed) {
+    blocks.push(bullet([
+      rt('\u{1F480} killed — ', { color: 'red' }),
+      rt((i.text || 'unnamed').slice(0, 60), { bold: true }),
+      rt(`  · ${i.kill_reason || 'no reason'}`, { color: 'gray' }),
+    ]));
+  }
+  for (const i of burnedIdeas) {
+    blocks.push(bullet([
+      rt('\u{1F4A4}\u{00D7}3 forced decision: ', { color: 'orange' }),
+      rt((i.text || 'unnamed').slice(0, 60), { bold: true }),
+      rt(`  · still in ${i.lifecycle_stage} · owner ${i.owner || 'ben'}`, { color: 'orange' }),
+    ]));
+  }
+
+  // Acknowledgement gaps — AT RISK items not acked > 5d
+  blocks.push(h3('\u{1F4D2} Acknowledgement gaps (>5d unactioned)'));
+  if (ackGaps.length === 0) {
+    blocks.push(para([rt('(none — everything risky has a recent ack)', { italic: true, color: 'green' })]));
+  } else {
+    for (const g of ackGaps.slice(0, 8)) {
+      const lastSeen = g.last_ack
+        ? `last ack ${g.last_ack.slice(0, 10)}`
+        : 'never acked';
+      const tag = g.kind === 'compliance'
+        ? (g.days_until_due != null
+            ? (g.days_until_due < 0 ? `T+${Math.abs(g.days_until_due)}d` : `T-${g.days_until_due}d`)
+            : '')
+        : `${g.stage} ${g.age_days}d idle`;
+      blocks.push(bullet([
+        rt(`[${g.kind === 'compliance' ? 'compliance' : 'idea'}] `, { color: 'gray' }),
+        rt(g.label, { bold: true }),
+        rt(`  · ${tag} · ${lastSeen}`, { color: 'red' }),
+      ]));
+    }
+  }
+
   // Suggested actions
   blocks.push(h3('\u{1F4CC} Suggested next-week actions'));
   blocks.push(bullet('Open the 5 stalest opps in GHL — Won/Lost or move stage'));
@@ -234,6 +430,18 @@ async function main() {
     await sleep(300);
   }
   log(`Done. Open: notion.so/${pageId.replace(/-/g, '')}`);
+}
+
+function readLatestComplianceSnapshot() {
+  const dir = join(__dirname, '..', 'thoughts', 'shared', 'data', 'compliance-calendar');
+  if (!existsSync(dir)) return null;
+  const files = readdirSync(dir).filter(f => f.endsWith('.json')).sort();
+  if (files.length === 0) return null;
+  try {
+    return JSON.parse(readFileSync(join(dir, files[files.length - 1]), 'utf8'));
+  } catch {
+    return null;
+  }
 }
 
 main().catch(err => { console.error('Fatal:', err); process.exit(1); });

--- a/supabase/migrations/20260518000100_ack_tables.sql
+++ b/supabase/migrations/20260518000100_ack_tables.sql
@@ -1,0 +1,37 @@
+-- Pass 2C C1 — Ack tables for compliance + idea accountability
+-- Plan: ~/.claude/plans/coo-cio-cfo-money-brain-phase2.md (Pass 2C)
+--
+-- Lightweight ack tables let the AT RISK pane and weekly digest answer:
+-- "did Ben actually see/action this, or did it just sit there?"
+--
+-- - compliance_ack tracks acks of wiki/GHL obligations (BAS, R&D, grant acquittals).
+-- - idea_ack tracks acks of nightly idea reminders (Pass 2B output).
+--
+-- IDs are slugs (e.g. 'bas-q4-fy26'), not FKs — the canonical list lives in
+-- wiki/finance/compliance-calendar.md + GHL opportunities, not a Postgres table.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS compliance_ack (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  obligation_id text NOT NULL,
+  acked_at      timestamptz NOT NULL DEFAULT now(),
+  acked_by      text NOT NULL,
+  acked_via     text                  -- 'telegram' | 'command-page' | 'api'
+);
+
+CREATE INDEX IF NOT EXISTS compliance_ack_obligation_idx
+  ON compliance_ack (obligation_id, acked_at DESC);
+
+CREATE TABLE IF NOT EXISTS idea_ack (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  idea_id     uuid NOT NULL REFERENCES idea_board(id) ON DELETE CASCADE,
+  acked_at    timestamptz NOT NULL DEFAULT now(),
+  acked_by    text NOT NULL,
+  reminder_id text                    -- which nightly reminder run this acks
+);
+
+CREATE INDEX IF NOT EXISTS idea_ack_idea_idx
+  ON idea_ack (idea_id, acked_at DESC);
+
+COMMIT;


### PR DESCRIPTION
## Summary

Closes Phase 2 of the Money Brain build (`~/.claude/plans/coo-cio-cfo-money-brain-phase2.md` Pass 2C).

**C1 — Ack tables** (`supabase/migrations/20260518000100_ack_tables.sql`, applied to shared DB)
- `compliance_ack(id, obligation_id, acked_at, acked_by, acked_via)`
- `idea_ack(id, idea_id, acked_at, acked_by, reminder_id)`
- IDs are slugs (e.g. `bas-q4-fy26`), not FKs — canonical list lives in `wiki/finance/compliance-calendar.md` + GHL.

**C2 — Debt counter + per-row ack on `/finance/command` AT RISK pane**
- `GET /api/finance/ack-state` — most-recent ack per obligation/idea within 14-day window + debt-hours threshold (24h default).
- `POST /api/finance/ack` — `{ kind: 'compliance'|'idea', id, ack_by?, via?, reminder_id? }`.
- AT RISK section: compliance + pilot rows now show `Ack` button or `✓age`. Header pill `📒 N ack-overdue` is **snapshot, not cumulative** (Q11 default): hidden at 0, yellow 1-5, red >5. Surface age uses source endpoint's `generatedAt` as first-surfaced.

**C3 — Friday digest gains three new sections** (`scripts/weekly-money-digest.mjs`)
- **Compliance this week** — filed ✓ · acked ✓ · T+N missed · T-30 pending (reads latest `thoughts/shared/data/compliance-calendar/*.json`).
- **Ideas — moves & forced decisions** — shipped / killed (with `kill_reason`) / 💤×3 burned-snooze ideas still in pre-funding stages.
- **Acknowledgement gaps** — AT RISK obligations + stale scope/fundraise pilots without an ack in 5+ days, severity-ordered.

## Test plan
- [x] Migration applied: `compliance_ack` + `idea_ack` tables exist on shared DB (`tednluwflfhxyucgwigh`).
- [x] `pnpm build` in `apps/command-center` passes; both new API routes registered.
- [x] `node scripts/weekly-money-digest.mjs --markdown` runs without error.
- [ ] Visit `/finance/command` — Ack a compliance item, refresh, confirm `✓ just now` chip replaces button.
- [ ] Wait 24h+ (or backdate test row) — confirm header pill shows `📒 N ack-overdue`.
- [ ] Run `node scripts/weekly-money-digest.mjs` Friday 3pm cron — confirm three new sections render in Notion Friday Digest page.

Plan: coo-cio-cfo-money-brain-phase2