### PR TITLE
feat(finance): /finance/actions surface + Notion FY26 Close Sprint linkout

### DIFF
--- a/apps/command-center/src/app/api/admin/sync-health/route.ts
+++ b/apps/command-center/src/app/api/admin/sync-health/route.ts
@@ -92,7 +92,15 @@ function categoriseAndScore(row: Omit<SyncRow, 'health' | 'category'>): SyncRow 
 export async function GET() {
   let raw: string
   try {
-    raw = execSync('pm2 jlist', { encoding: 'utf8', timeout: 5000 })
+    // maxBuffer raised — pm2 jlist output for 50+ processes can exceed default 1MB.
+    // Use absolute path because the Next.js dev server may not inherit a PATH that
+    // contains Homebrew (/opt/homebrew/bin) when started in some shells.
+    const pm2Bin = '/opt/homebrew/bin/pm2'
+    raw = execSync(`${pm2Bin} jlist`, {
+      encoding: 'utf8',
+      timeout: 10000,
+      maxBuffer: 1024 * 1024 * 20, // 20 MB
+    })
   } catch (err) {
     return NextResponse.json(
       { error: 'pm2 not available', detail: String(err) },

--- a/apps/command-center/src/app/api/finance/actions/route.ts
+++ b/apps/command-center/src/app/api/finance/actions/route.ts
@@ -1,0 +1,233 @@
+import { NextResponse } from 'next/server'
+import { Client } from '@notionhq/client'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+const REPO = path.resolve(process.cwd(), '..', '..')
+const NOTION_DB_IDS_PATH = path.join(REPO, 'config', 'notion-database-ids.json')
+
+interface ActionRow {
+  id: string
+  name: string
+  description: string
+  status: string
+  owner: string
+  priority: string
+  source: string
+  due: string | null
+  daysUntilDue: number | null
+  overdue: boolean
+  url: string
+  createdAt: string
+  linkedDecisions: string[] // page IDs
+}
+
+interface Response {
+  generatedAt: string
+  totals: {
+    total: number
+    open: number
+    blocked: number
+    done: number
+    overdue: number
+  }
+  ownerRollup: Array<{ owner: string; total: number; open: number; blocked: number; overdue: number }>
+  priorityRollup: Array<{ priority: string; open: number }>
+  byOwner: Record<string, ActionRow[]>
+  allOpen: ActionRow[]
+}
+
+function loadNotionDbIds(): { actionItems?: string; actionItemsDataSource?: string } {
+  try {
+    return JSON.parse(readFileSync(NOTION_DB_IDS_PATH, 'utf-8'))
+  } catch {
+    return {}
+  }
+}
+
+function getText(prop: any): string {
+  if (!prop) return ''
+  if (prop.type === 'title') {
+    return (prop.title ?? []).map((t: any) => t.plain_text ?? '').join('')
+  }
+  if (prop.type === 'rich_text') {
+    return (prop.rich_text ?? []).map((t: any) => t.plain_text ?? '').join('')
+  }
+  if (prop.type === 'select') {
+    return prop.select?.name ?? ''
+  }
+  return ''
+}
+
+function getDate(prop: any): string | null {
+  if (!prop || prop.type !== 'date') return null
+  return prop.date?.start ?? null
+}
+
+function getRelation(prop: any): string[] {
+  if (!prop || prop.type !== 'relation') return []
+  return (prop.relation ?? []).map((r: any) => r.id)
+}
+
+function priorityWeight(p: string): number {
+  switch (p) {
+    case 'Critical':
+      return 0
+    case 'High':
+      return 1
+    case 'Medium':
+      return 2
+    case 'Low':
+      return 3
+    default:
+      return 4
+  }
+}
+
+function statusWeight(s: string): number {
+  switch (s) {
+    case 'Blocked':
+      return 0
+    case 'Doing':
+      return 1
+    case 'To do':
+      return 2
+    case 'Done':
+      return 3
+    case 'Cancelled':
+      return 4
+    default:
+      return 5
+  }
+}
+
+export async function GET() {
+  const notionToken = process.env.NOTION_TOKEN
+  if (!notionToken) {
+    return NextResponse.json({ error: 'NOTION_TOKEN not set' }, { status: 503 })
+  }
+
+  const ids = loadNotionDbIds()
+  const dataSourceId = ids.actionItemsDataSource
+  if (!dataSourceId) {
+    return NextResponse.json(
+      { error: 'actionItemsDataSource not found in config/notion-database-ids.json' },
+      { status: 503 },
+    )
+  }
+
+  const notion = new Client({ auth: notionToken })
+
+  let allRows: any[] = []
+  let cursor: string | undefined
+  let pages = 0
+  do {
+    // Notion SDK v5: dataSources.query (databases.query was removed).
+    const res = await (notion as any).dataSources.query({
+      data_source_id: dataSourceId,
+      page_size: 100,
+      start_cursor: cursor,
+    })
+    allRows = allRows.concat(res.results)
+    cursor = res.has_more ? (res.next_cursor ?? undefined) : undefined
+    pages++
+    if (pages > 20) break // safety
+  } while (cursor)
+
+  const now = Date.now()
+  const rows: ActionRow[] = allRows.map((p: any) => {
+    const props = p.properties ?? {}
+    const due = getDate(props.Due)
+    const dueMs = due ? new Date(due + 'T23:59:59Z').getTime() : null
+    const daysUntilDue =
+      dueMs != null ? Math.ceil((dueMs - now) / (1000 * 60 * 60 * 24)) : null
+    const status = getText(props.Status)
+    const isOpen = status !== 'Done' && status !== 'Cancelled'
+    return {
+      id: p.id,
+      name: getText(props.Name),
+      description: getText(props.Description),
+      status,
+      owner: getText(props.Owner) || 'Unassigned',
+      priority: getText(props.Priority) || 'Medium',
+      source: getText(props.Source) || '',
+      due,
+      daysUntilDue,
+      overdue: isOpen && daysUntilDue != null && daysUntilDue < 0,
+      url: p.url,
+      createdAt: p.created_time,
+      linkedDecisions: getRelation(props['Linked Decision']),
+    }
+  })
+
+  const allOpen = rows
+    .filter(r => r.status !== 'Done' && r.status !== 'Cancelled')
+    .sort((a, b) => {
+      // Overdue first, then by priority, then by status, then by due date
+      if (a.overdue !== b.overdue) return a.overdue ? -1 : 1
+      const pDiff = priorityWeight(a.priority) - priorityWeight(b.priority)
+      if (pDiff !== 0) return pDiff
+      const sDiff = statusWeight(a.status) - statusWeight(b.status)
+      if (sDiff !== 0) return sDiff
+      const aDue = a.due ?? '9999-12-31'
+      const bDue = b.due ?? '9999-12-31'
+      return aDue.localeCompare(bDue)
+    })
+
+  const owners = Array.from(new Set(allOpen.map(r => r.owner)))
+  const byOwner: Record<string, ActionRow[]> = {}
+  for (const owner of owners) {
+    byOwner[owner] = allOpen.filter(r => r.owner === owner)
+  }
+
+  const ownerRollup = owners
+    .map(owner => {
+      const rs = rows.filter(r => r.owner === owner)
+      const open = rs.filter(r => r.status !== 'Done' && r.status !== 'Cancelled')
+      return {
+        owner,
+        total: rs.length,
+        open: open.length,
+        blocked: rs.filter(r => r.status === 'Blocked').length,
+        overdue: open.filter(r => r.overdue).length,
+      }
+    })
+    .sort((a, b) => b.open - a.open)
+
+  const priorityOrder = ['Critical', 'High', 'Medium', 'Low']
+  const priorityRollup = priorityOrder.map(p => ({
+    priority: p,
+    open: allOpen.filter(r => r.priority === p).length,
+  }))
+
+  const totals = rows.reduce(
+    (acc, r) => {
+      acc.total++
+      if (r.status === 'Done') acc.done++
+      else if (r.status === 'Cancelled') acc.done++
+      else {
+        acc.open++
+        if (r.status === 'Blocked') acc.blocked++
+        if (r.overdue) acc.overdue++
+      }
+      return acc
+    },
+    { total: 0, open: 0, blocked: 0, done: 0, overdue: 0 },
+  )
+
+  const response: Response = {
+    generatedAt: new Date().toISOString(),
+    totals,
+    ownerRollup,
+    priorityRollup,
+    byOwner,
+    allOpen,
+  }
+
+  return NextResponse.json(response, {
+    headers: { 'Cache-Control': 'no-store' },
+  })
+}

--- a/apps/command-center/src/app/finance/actions/page.tsx
+++ b/apps/command-center/src/app/finance/actions/page.tsx
@@ -1,0 +1,290 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { AlertTriangle, CheckCircle2, ClipboardList, ExternalLink, RefreshCw } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface ActionRow {
+  id: string
+  name: string
+  description: string
+  status: string
+  owner: string
+  priority: string
+  source: string
+  due: string | null
+  daysUntilDue: number | null
+  overdue: boolean
+  url: string
+  createdAt: string
+  linkedDecisions: string[]
+}
+
+interface Response {
+  generatedAt: string
+  totals: { total: number; open: number; blocked: number; done: number; overdue: number }
+  ownerRollup: Array<{ owner: string; total: number; open: number; blocked: number; overdue: number }>
+  priorityRollup: Array<{ priority: string; open: number }>
+  byOwner: Record<string, ActionRow[]>
+  allOpen: ActionRow[]
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  'To do': 'border-neutral-800 bg-neutral-900 text-neutral-400',
+  Doing: 'border-blue-800/60 bg-blue-950/30 text-blue-300',
+  Blocked: 'border-red-800/60 bg-red-950/40 text-red-300',
+  Done: 'border-emerald-800/50 bg-emerald-950/30 text-emerald-300',
+  Cancelled: 'border-neutral-800 bg-neutral-950 text-neutral-600',
+}
+const PRIORITY_COLORS: Record<string, string> = {
+  Critical: 'bg-red-900/40 text-red-300',
+  High: 'bg-orange-900/40 text-orange-300',
+  Medium: 'bg-yellow-900/30 text-yellow-300',
+  Low: 'bg-neutral-900 text-neutral-500',
+}
+
+function formatDue(due: string | null, days: number | null, overdue: boolean): string {
+  if (!due) return '—'
+  if (overdue) return `${due} · T+${Math.abs(days!)}d overdue`
+  if (days === 0) return `${due} · today`
+  if (days! < 0) return `${due} · T+${Math.abs(days!)}d`
+  return `${due} · T-${days}d`
+}
+
+export default function FinanceActionsPage() {
+  const [priorityFilter, setPriorityFilter] = useState<string | null>(null)
+  const [sourceFilter, setSourceFilter] = useState<string | null>(null)
+
+  const { data, isLoading, error, refetch, isRefetching } = useQuery<Response>({
+    queryKey: ['finance', 'actions'],
+    queryFn: async () => {
+      const res = await fetch('/api/finance/actions', { cache: 'no-store' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    staleTime: 60 * 1000,
+    refetchInterval: 5 * 60 * 1000,
+  })
+
+  function filterRow(r: ActionRow): boolean {
+    if (priorityFilter && r.priority !== priorityFilter) return false
+    if (sourceFilter && r.source !== sourceFilter) return false
+    return true
+  }
+
+  return (
+    <div className="min-h-screen bg-neutral-950 text-neutral-100 p-6 lg:p-10">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <header className="flex items-start justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 text-emerald-400 text-sm font-medium uppercase tracking-wider mb-1">
+              <ClipboardList size={16} /> All Open Actions
+            </div>
+            <h1 className="text-3xl font-semibold">Grouped by owner · sorted by priority + due</h1>
+            <p className="text-neutral-400 text-sm mt-1">
+              Live from Notion Action Items DB · refreshes every 5 min · click a row to open in Notion
+            </p>
+          </div>
+          <button
+            onClick={() => refetch()}
+            className="inline-flex items-center gap-2 rounded-md border border-neutral-800 px-3 py-1.5 text-sm hover:bg-neutral-900"
+            disabled={isRefetching}
+          >
+            <RefreshCw size={14} className={cn(isRefetching && 'animate-spin')} />
+            Refresh
+          </button>
+        </header>
+
+        {isLoading && <div className="text-neutral-500 text-sm">Loading…</div>}
+        {error && (
+          <div className="rounded-lg border border-red-900/40 bg-red-950/30 p-4 text-sm text-red-300">
+            Failed to load: {String((error as Error).message)}
+          </div>
+        )}
+
+        {data && (
+          <>
+            {/* TOTALS STRIP */}
+            <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+              <Tile label="Total" value={data.totals.total} />
+              <Tile label="Open" value={data.totals.open} accent="blue" />
+              <Tile label="Blocked" value={data.totals.blocked} accent="red" />
+              <Tile label="Overdue" value={data.totals.overdue} accent="red" />
+              <Tile label="Done" value={data.totals.done} accent="green" />
+            </div>
+
+            {/* FILTERS */}
+            <div className="flex flex-wrap gap-2 items-center text-sm">
+              <span className="text-neutral-500">Filter:</span>
+              {data.priorityRollup.map(p => (
+                <button
+                  key={p.priority}
+                  onClick={() => setPriorityFilter(priorityFilter === p.priority ? null : p.priority)}
+                  className={cn(
+                    'rounded-md px-2.5 py-1 border text-xs',
+                    priorityFilter === p.priority
+                      ? 'border-emerald-700 bg-emerald-950/40 text-emerald-300'
+                      : 'border-neutral-800 hover:bg-neutral-900',
+                  )}
+                  disabled={p.open === 0}
+                >
+                  {p.priority} · {p.open}
+                </button>
+              ))}
+              <span className="text-neutral-700 mx-1">|</span>
+              {['Standard Ledger meeting', 'Cron alert', 'Friday Digest', 'Money Sync', 'Manual'].map(
+                src => {
+                  const count = data.allOpen.filter(r => r.source === src).length
+                  if (count === 0) return null
+                  return (
+                    <button
+                      key={src}
+                      onClick={() => setSourceFilter(sourceFilter === src ? null : src)}
+                      className={cn(
+                        'rounded-md px-2.5 py-1 border text-xs',
+                        sourceFilter === src
+                          ? 'border-emerald-700 bg-emerald-950/40 text-emerald-300'
+                          : 'border-neutral-800 hover:bg-neutral-900',
+                      )}
+                    >
+                      {src} · {count}
+                    </button>
+                  )
+                },
+              )}
+              {(priorityFilter || sourceFilter) && (
+                <button
+                  onClick={() => {
+                    setPriorityFilter(null)
+                    setSourceFilter(null)
+                  }}
+                  className="text-xs text-neutral-500 hover:text-neutral-300 underline ml-2"
+                >
+                  Clear
+                </button>
+              )}
+            </div>
+
+            {/* OWNER COLUMNS */}
+            <div className="space-y-6">
+              {data.ownerRollup.map(rollup => {
+                const items = (data.byOwner[rollup.owner] ?? []).filter(filterRow)
+                if (items.length === 0) return null
+                return (
+                  <section key={rollup.owner}>
+                    <div className="flex items-baseline gap-3 mb-2">
+                      <h2 className="text-sm font-medium uppercase tracking-wider text-neutral-300">
+                        {rollup.owner}
+                      </h2>
+                      <span className="text-xs text-neutral-500">
+                        {items.length} shown · {rollup.open} total open
+                        {rollup.overdue > 0 && (
+                          <span className="text-red-400 ml-2">· {rollup.overdue} overdue</span>
+                        )}
+                        {rollup.blocked > 0 && (
+                          <span className="text-red-400 ml-2">· {rollup.blocked} blocked</span>
+                        )}
+                      </span>
+                    </div>
+                    <div className="rounded-lg border border-neutral-800 overflow-hidden divide-y divide-neutral-900">
+                      {items.map(item => (
+                        <a
+                          key={item.id}
+                          href={item.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="block px-4 py-3 hover:bg-neutral-900/40 transition"
+                        >
+                          <div className="flex items-start gap-3">
+                            <span
+                              className={cn(
+                                'inline-block rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide shrink-0',
+                                PRIORITY_COLORS[item.priority] ?? PRIORITY_COLORS.Medium,
+                              )}
+                              style={{ minWidth: '52px', textAlign: 'center' }}
+                            >
+                              {item.priority}
+                            </span>
+                            <span
+                              className={cn(
+                                'inline-block rounded border px-1.5 py-0.5 text-[10px] shrink-0',
+                                STATUS_COLORS[item.status] ?? STATUS_COLORS['To do'],
+                              )}
+                              style={{ minWidth: '60px', textAlign: 'center' }}
+                            >
+                              {item.status}
+                            </span>
+                            <div className="flex-1 min-w-0">
+                              <div className="text-sm text-neutral-200">{item.name}</div>
+                              {item.description && (
+                                <div className="text-xs text-neutral-500 mt-1 line-clamp-2">
+                                  {item.description}
+                                </div>
+                              )}
+                            </div>
+                            <div className="flex flex-col items-end gap-1 text-xs shrink-0 ml-2">
+                              <span
+                                className={cn(
+                                  'whitespace-nowrap',
+                                  item.overdue ? 'text-red-400' : 'text-neutral-500',
+                                )}
+                              >
+                                {formatDue(item.due, item.daysUntilDue, item.overdue)}
+                              </span>
+                              {item.source && (
+                                <span className="text-neutral-600 text-[10px] uppercase tracking-wider">
+                                  {item.source}
+                                </span>
+                              )}
+                            </div>
+                            <ExternalLink size={12} className="text-neutral-700 shrink-0 mt-1" />
+                          </div>
+                        </a>
+                      ))}
+                    </div>
+                  </section>
+                )
+              })}
+            </div>
+
+            <p className="text-xs text-neutral-600">
+              Generated at {new Date(data.generatedAt).toLocaleString()}. Source:{' '}
+              <a
+                href="https://www.notion.so/6e92d3e0b5ce479987688f7bbb584f69"
+                className="underline hover:text-neutral-400"
+              >
+                Action Items DB
+              </a>
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Tile({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: number
+  accent?: 'blue' | 'red' | 'green'
+}) {
+  const accentClass =
+    accent === 'red'
+      ? 'border-red-800/60 bg-red-950/30 text-red-300'
+      : accent === 'blue'
+        ? 'border-blue-800/60 bg-blue-950/30 text-blue-300'
+        : accent === 'green'
+          ? 'border-emerald-800/50 bg-emerald-950/30 text-emerald-300'
+          : 'border-neutral-800 bg-neutral-900/40'
+  return (
+    <div className={cn('rounded-lg border p-3', accentClass)}>
+      <div className="text-xs uppercase tracking-wider opacity-80">{label}</div>
+      <div className="text-2xl font-semibold mt-1">{value}</div>
+    </div>
+  )
+}

--- a/apps/command-center/src/lib/nav-data.ts
+++ b/apps/command-center/src/lib/nav-data.ts
@@ -31,6 +31,8 @@ import {
   ClipboardList,
   Bot,
   ShieldAlert,
+  ListChecks,
+  Activity,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 
@@ -111,6 +113,7 @@ export const navStructure: SidebarNavGroup[] = [
           // 2026-05-16 UX audit — grouped by job-to-do with 5 section dividers (ux-audit.md).
           { href: '#today', label: 'Today', icon: Sun, divider: true },
           { href: '/finance/command', label: 'Money Command', icon: Compass, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
+          { href: '/finance/actions', label: 'All Open Actions', icon: ListChecks, color: 'text-amber-400', bg: 'bg-amber-500/20' },
           { href: '/finance/workbench', label: 'Workbench', icon: ClipboardList, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
           { href: '/finance/ai-suggestions', label: 'AI Suggestions', icon: Sparkles, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
           { href: '/finance/xero-page-copilot', label: 'Xero Page Copilot', icon: Bot, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
@@ -137,6 +140,7 @@ export const navStructure: SidebarNavGroup[] = [
 
           { href: '#hub', label: 'Hub', icon: DollarSign, divider: true },
           { href: '/finance', label: 'All finance (operate hub)', icon: DollarSign, color: 'text-foreground', bg: 'bg-white/10' },
+          { href: '/admin/sync-health', label: 'Sync Health', icon: Activity, color: 'text-neutral-400', bg: 'bg-neutral-500/20' },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

Single 'all open actions' page reading from Notion Action Items DB. Companion to FY26 Close Sprint Notion page (now links to both the underlying DB and this view).

### What landed

**1. `/finance/actions` page** — grouped by owner, with priority + status chips, overdue flags, source tags, click-through to Notion.

**2. `GET /api/finance/actions`** — Notion SDK v5 `dataSources.query` against `actionItemsDataSource`. Returns totals + owner/priority rollups + grouping. Sorted by overdue → priority → status → due.

**3. FY26 Close Sprint Notion page updated** — new "All open actions — single view" section above "Live tracking surfaces" with linkouts to (a) Notion Action Items board with filter guidance, (b) the new /finance/actions page.

**4. Fix: sync-health pm2 jlist ENOBUFS** — absolute pm2 path + maxBuffer 20MB. Now returns 106 entries cleanly (was failing with ENOBUFS on >50 processes).

## Smoke tested

Local dev (port 3002):
- `/api/finance/actions`: 30 actions returned (24 SL + 6 pre-existing). Owner rollup SL=19 Ben=7 Nic=2 Both=2. Critical=6 High=17 Medium=6 Low=1. 4 overdue surfaced.
- `/api/admin/sync-health`: 106 entries, 100 green / 5 yellow / 1 red
- `/api/finance/pty-readiness`: 22 items, 14% critical-path, T-44d
- `/finance/actions` page: HTTP 200 ✓
- `/admin/sync-health` page: HTTP 200 ✓

## Test plan (human review)

- [ ] Visit https://command.act.place/finance/actions after merge
- [ ] Confirm all 24 SL workstreams visible under "Standard Ledger" owner column
- [ ] Click filter chip "Critical · 6" → confirms 6 critical items shown
- [ ] Click filter chip "Standard Ledger meeting · 24" → confirms 24 SL items shown
- [ ] Click any row → opens in Notion in new tab
- [ ] Visit FY26 Close Sprint Notion page → confirm "All open actions" section is present and links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)