### PR TITLE
feat(finance): reality-check strip — 4-tile health dashboard

### DIFF
--- a/apps/command-center/src/app/api/finance/transactions/reality/route.ts
+++ b/apps/command-center/src/app/api/finance/transactions/reality/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export const dynamic = 'force-dynamic'
+
+const ACT_ACCOUNTS = ['NAB Visa ACT #8815', 'NJ Marchesi T/as ACT Everyday']
+
+function firstDescr(li: any[] | null | undefined): string {
+  if (!Array.isArray(li) || !li.length) return ''
+  return li.map((x) => x?.description || x?.Description || '').filter(Boolean).join(' | ')
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const sp = new URL(request.url).searchParams
+    const since = sp.get('since') || '2025-07-01'
+    const accountsParam = (sp.get('accounts') || 'act-only').toLowerCase()
+
+    async function fetchAll<T = any>(query: any): Promise<T[]> {
+      const out: T[] = []
+      let from = 0
+      while (true) {
+        const { data, error } = await query.range(from, from + 999)
+        if (error) throw new Error(error.message)
+        if (!data?.length) break
+        out.push(...data)
+        if (data.length < 1000) break
+        from += 1000
+      }
+      return out
+    }
+
+    let billsQ = supabase
+      .from('xero_invoices')
+      .select('id, xero_id, date, contact_name, total, status, line_items, project_code, has_attachments')
+      .eq('type', 'ACCPAY')
+      .in('status', ['AUTHORISED', 'PAID'])
+      .gte('date', since)
+
+    let spendsQ = supabase
+      .from('xero_transactions')
+      .select('id, xero_transaction_id, date, contact_name, total, status, type, line_items, project_code, has_attachments, bank_account')
+      .in('type', ['SPEND', 'SPEND-OVERPAYMENT'])
+      .gte('date', since)
+    if (accountsParam === 'act-only') spendsQ = spendsQ.in('bank_account', ACT_ACCOUNTS)
+    else if (accountsParam !== 'all') spendsQ = spendsQ.eq('bank_account', accountsParam)
+
+    const [bills, spends] = await Promise.all([fetchAll(billsQ), fetchAll(spendsQ)])
+
+    // ----- Dedup: bill paid via bank produces a spend with same vendor+amount within ±14d -----
+    const paidBills = bills.filter((b: any) => b.status === 'PAID')
+    const matchedSpendIds = new Set<string>()
+    for (const s of spends) {
+      const sd = new Date(s.date as string).getTime()
+      const m = paidBills.find((b: any) =>
+        (b.contact_name || '').trim().toUpperCase() === (s.contact_name || '').trim().toUpperCase() &&
+        Number(b.total) === Number(s.total) &&
+        Math.abs((new Date(b.date as string).getTime() - sd) / 86400000) <= 14
+      )
+      if (m) matchedSpendIds.add(s.xero_transaction_id as string)
+    }
+    const matchedPairs = matchedSpendIds.size
+    const unmatchedSpends = spends.filter((s: any) => !matchedSpendIds.has(s.xero_transaction_id))
+
+    // ----- Counts (deduped: each matched pair counted once via the bill side) -----
+    const totalDeduped = bills.length + unmatchedSpends.length
+    const taggedBills = bills.filter((b: any) => b.project_code).length
+    const taggedSpends = unmatchedSpends.filter((s: any) => s.project_code).length
+    const tagged = taggedBills + taggedSpends
+    const untagged = totalDeduped - tagged
+    const taggedPct = totalDeduped > 0 ? Math.round((tagged / totalDeduped) * 100) : 0
+
+    // ----- Receipt coverage -----
+    // A row is "receipted" if it has_attachments=true OR it's a spend whose matched bill has_attachments
+    const billAttachmentByKey = new Map<string, boolean>()
+    for (const b of bills) {
+      const key = `${(b.contact_name || '').trim().toUpperCase()}|${Number(b.total).toFixed(2)}|${b.date}`
+      if (b.has_attachments) billAttachmentByKey.set(key, true)
+    }
+    const billReceipted = bills.filter((b: any) => b.has_attachments).length
+    const spendReceipted = unmatchedSpends.filter((s: any) => s.has_attachments).length
+    const receipted = billReceipted + spendReceipted
+    const receiptedPct = totalDeduped > 0 ? Math.round((receipted / totalDeduped) * 100) : 0
+
+    // ----- Audit issue counts -----
+    // Duplicates: same vendor+amount+date appearing twice on the same project
+    const dupKey = new Map<string, number>()
+    const allRows = [...bills, ...unmatchedSpends].map((r: any) => ({
+      contact: (r.contact_name || '').trim().toUpperCase(),
+      total: Number(r.total).toFixed(2),
+      date: r.date,
+      project: r.project_code || 'UNTAGGED',
+    }))
+    for (const r of allRows) {
+      const key = `${r.project}|${r.contact}|${r.total}|${r.date}`
+      dupKey.set(key, (dupKey.get(key) || 0) + 1)
+    }
+    let duplicates = 0
+    for (const v of dupKey.values()) if (v > 1) duplicates += v - 1
+
+    // Project mismatch: line desc says ACT-XX but project_code is ACT-YY
+    let mismatches = 0
+    for (const r of [...bills, ...unmatchedSpends] as any[]) {
+      if (!r.project_code) continue
+      const desc = firstDescr(r.line_items)
+      const m = /—\s*(ACT-[A-Z]{2,4})\b/i.exec(desc)
+      if (m && m[1].toUpperCase() !== r.project_code.toUpperCase()) mismatches += 1
+    }
+
+    // Totals
+    const billsTotal = bills.reduce((a: number, b: any) => a + Number(b.total), 0)
+    const unmatchedSpendsTotal = unmatchedSpends.reduce((a: number, s: any) => a + Number(s.total), 0)
+    const grandTotal = billsTotal + unmatchedSpendsTotal
+
+    return NextResponse.json({
+      since,
+      accountsParam,
+      // Headline numbers
+      spendsRaw: spends.length,
+      billsCount: bills.length,
+      matchedPairs,
+      totalDeduped,
+      // Tagging
+      tagged,
+      untagged,
+      taggedPct,
+      // Receipts
+      receipted,
+      unreceipted: totalDeduped - receipted,
+      receiptedPct,
+      // Audit
+      duplicates,
+      mismatches,
+      // Money
+      grandTotal: Math.round(grandTotal * 100) / 100,
+      billsTotal: Math.round(billsTotal * 100) / 100,
+      unmatchedSpendsTotal: Math.round(unmatchedSpendsTotal * 100) / 100,
+    })
+  } catch (e: any) {
+    console.error('finance/transactions/reality error', e)
+    return NextResponse.json({ error: e?.message || 'failed' }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/finance/transactions/page.tsx
+++ b/apps/command-center/src/app/finance/transactions/page.tsx
@@ -109,6 +109,10 @@ export default function TransactionsExplorer() {
   const [batchOcrBusy, setBatchOcrBusy] = useState(false)
   const [batchOcrProgress, setBatchOcrProgress] = useState({ done: 0, total: 0 })
 
+  // Reality-check strip (org-wide stats, separate from the filter-scoped row set)
+  const [reality, setReality] = useState<any>(null)
+  const [realityLoading, setRealityLoading] = useState(false)
+
   async function runOcr(row: Row) {
     if (!row.hasAttachments) { setToast('No Xero attachment on this row'); setTimeout(() => setToast(null), 2000); return }
     setOcrBusy((s) => { const n = new Set(s); n.add(row.id); return n })
@@ -201,6 +205,16 @@ export default function TransactionsExplorer() {
   }, [])
 
   useEffect(load, [projectFilter, since, accountFilter])
+
+  // Load reality stats once per (since, accountFilter) change — org-wide, ignores project filter
+  useEffect(() => {
+    setRealityLoading(true)
+    const sp = new URLSearchParams({ accounts: accountFilter, since })
+    fetch(`/api/finance/transactions/reality?${sp.toString()}`)
+      .then(r => r.json())
+      .then(setReality)
+      .finally(() => setRealityLoading(false))
+  }, [since, accountFilter])
 
   const filtered = useMemo(() => {
     let r = rows
@@ -564,6 +578,49 @@ export default function TransactionsExplorer() {
             </div>
           )}
         </div>
+
+        {/* Reality-check strip — org-wide, click any tile to drill in */}
+        {reality && !reality.error && (
+          <div className="bg-white/5 border border-white/15 rounded-lg p-3 mb-3 grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div className="text-center">
+              <div className="text-xs text-white/40 uppercase tracking-wider mb-1">Volume</div>
+              <div className="text-xl font-bold text-white tabular-nums">{reality.totalDeduped.toLocaleString()}</div>
+              <div className="text-[10px] text-white/40">{reality.billsCount} bills + {reality.spendsRaw - reality.matchedPairs} unmatched spends</div>
+              <div className="text-[10px] text-white/30">{reality.matchedPairs} bill↔spend pairs deduped</div>
+            </div>
+            <button
+              onClick={() => { setProjectFilter('UNTAGGED'); setSelected(new Set()) }}
+              className={`text-center rounded p-1 transition-colors ${reality.taggedPct >= 95 ? 'hover:bg-emerald-500/10' : 'hover:bg-amber-500/10'}`}
+              title="Click to filter to UNTAGGED rows"
+            >
+              <div className="text-xs text-white/40 uppercase tracking-wider mb-1">Tagged</div>
+              <div className={`text-xl font-bold tabular-nums ${reality.taggedPct >= 95 ? 'text-emerald-300' : reality.taggedPct >= 80 ? 'text-amber-300' : 'text-red-300'}`}>{reality.taggedPct}%</div>
+              <div className="text-[10px] text-white/40">{reality.tagged.toLocaleString()} of {reality.totalDeduped.toLocaleString()}</div>
+              <div className="text-[10px] text-white/30">{reality.untagged.toLocaleString()} need tags →</div>
+            </button>
+            <Link
+              href="/finance/reconciliation"
+              className={`text-center rounded p-1 transition-colors block ${reality.receiptedPct >= 95 ? 'hover:bg-emerald-500/10' : 'hover:bg-amber-500/10'}`}
+              title="Open reconciliation — match bank lines to receipts"
+            >
+              <div className="text-xs text-white/40 uppercase tracking-wider mb-1">Receipted</div>
+              <div className={`text-xl font-bold tabular-nums ${reality.receiptedPct >= 95 ? 'text-emerald-300' : reality.receiptedPct >= 80 ? 'text-amber-300' : 'text-red-300'}`}>{reality.receiptedPct}%</div>
+              <div className="text-[10px] text-white/40">{reality.receipted.toLocaleString()} of {reality.totalDeduped.toLocaleString()}</div>
+              <div className="text-[10px] text-white/30">{reality.unreceipted.toLocaleString()} missing →</div>
+            </Link>
+            <Link
+              href="/finance/audit"
+              className={`text-center rounded p-1 transition-colors block ${(reality.duplicates + reality.mismatches) === 0 ? 'hover:bg-emerald-500/10' : 'hover:bg-red-500/10'}`}
+              title="Open audit — duplicates and project-tag mismatches"
+            >
+              <div className="text-xs text-white/40 uppercase tracking-wider mb-1">Audit issues</div>
+              <div className={`text-xl font-bold tabular-nums ${(reality.duplicates + reality.mismatches) === 0 ? 'text-emerald-300' : 'text-red-300'}`}>{reality.duplicates + reality.mismatches}</div>
+              <div className="text-[10px] text-white/40">{reality.duplicates} dups · {reality.mismatches} mismatch</div>
+              <div className="text-[10px] text-white/30">go to audit →</div>
+            </Link>
+          </div>
+        )}
+        {realityLoading && !reality && <div className="bg-white/5 border border-white/15 rounded-lg p-3 mb-3 text-center text-xs text-white/40">Loading reality check…</div>}
 
         {/* Auto-suggest + paint-bucket + batch-OCR toolbar */}
         <div className="bg-emerald-500/5 border border-emerald-500/20 rounded-lg p-3 mb-3 flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary

Adds a 4-tile header strip to /finance/transactions showing the org-wide state at a glance. Org-wide (ignores project filter) — answers \"where am I drifting?\".

### What renders

```
┌──────────────┬──────────────┬──────────────┬──────────────┐
│   VOLUME     │   TAGGED     │  RECEIPTED   │ AUDIT ISSUES │
│   2,971      │    99%       │    76%       │     223      │
│ 1,328 bills  │ 2,939 / 2,971│ 2,256 / 2,971│ 193 dup ·    │
│ + 1,643 spnd │ 32 need →    │ 715 miss →   │ 30 mismatch  │
│ 36 deduped   │              │              │ go to audit  │
└──────────────┴──────────────┴──────────────┴──────────────┘
```

- **Tagged %** — click → filters page to UNTAGGED
- **Receipted %** — click → /finance/reconciliation
- **Audit issues** — click → /finance/audit
- Colors flip green/amber/red based on 95% / 80% thresholds

### New endpoint

\`/api/finance/transactions/reality\` — single read of all bills + spends since the chosen date, dedups bill↔spend pairs (same vendor+amount within ±14d), computes:
- Volume (bills + spends + matched pairs)
- Tagged % (rows with project_code)
- Receipt % (rows with has_attachments)
- Duplicates count (same vendor+amount+date×2+, threshold $100)
- Project-mismatch count (line desc says ACT-XX but tag is ACT-YY)
- Money totals

## Test plan

- [ ] Open /finance/transactions — strip renders with live numbers
- [ ] Click Tagged tile → project filter switches to UNTAGGED
- [ ] Click Receipted tile → navigates to /finance/reconciliation
- [ ] Click Audit tile → navigates to /finance/audit
- [ ] Color thresholds: 99% tagged shows emerald, 76% receipted shows amber, audit count > 0 shows red

Plan: finance-tagging-platform-2026-05-18