### PR TITLE
feat(finance): duplicate-detection tuning + Duplicates panel + plan-only void script

### DIFF
--- a/apps/command-center/src/app/api/finance/audit/route.ts
+++ b/apps/command-center/src/app/api/finance/audit/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
 
     let billsQ = supabase
       .from('xero_invoices')
-      .select('id, xero_id, date, contact_name, total, status, line_items, project_code, project_code_source')
+      .select('id, xero_id, date, contact_name, total, status, line_items, project_code, project_code_source, reference')
       .eq('type', 'ACCPAY')
       .in('status', ['AUTHORISED', 'PAID'])
       .gte('date', since)
@@ -53,6 +53,7 @@ export async function GET(request: NextRequest) {
       .in('type', ['SPEND', 'SPEND-OVERPAYMENT'])
       .gte('date', since)
       .order('date', { ascending: false })
+    // (dedup logic widened below from ±14d → ±30d + AUTHORISED|PAID 2026-05-18)
     if (accountsParam === 'act-only') spendsQ = spendsQ.in('bank_account', ACT_ACCOUNTS)
     else if (accountsParam !== 'all') spendsQ = spendsQ.eq('bank_account', accountsParam)
 
@@ -70,24 +71,25 @@ export async function GET(request: NextRequest) {
       })
     }
 
-    // Dedupe bank-payment-of-bill
-    const paidBills = bills.filter((b: any) => b.status === 'PAID')
+    // Dedupe bank-payment-of-bill — widened to ±30d + AUTHORISED|PAID 2026-05-18
     const matched = new Set<string>()
     for (const s of spends) {
       const sd = new Date(s.date as string).getTime()
-      if (paidBills.some((b: any) =>
+      if (bills.some((b: any) =>
         (b.contact_name || '').trim().toUpperCase() === (s.contact_name || '').trim().toUpperCase() &&
         Number(b.total) === Number(s.total) &&
-        Math.abs((new Date(b.date as string).getTime() - sd) / 86400000) <= 14
+        Math.abs((new Date(b.date as string).getTime() - sd) / 86400000) <= 30
       )) matched.add(s.xero_transaction_id as string)
     }
 
     const expenseRows = [
-      ...bills.map((b: any) => ({ source: 'bill' as const, id: b.id, xeroId: b.xero_id, date: b.date, contact: b.contact_name, total: Number(b.total), status: b.status, projectCode: b.project_code as string | null, line_items: b.line_items, bankAccount: null as string | null })),
+      ...bills.map((b: any) => ({ source: 'bill' as const, id: b.id, xeroId: b.xero_id, date: b.date, contact: b.contact_name, total: Number(b.total), status: b.status, projectCode: b.project_code as string | null, projectSource: b.project_code_source as string | null, reference: b.reference as string | null, line_items: b.line_items, bankAccount: null as string | null })),
       ...spends.filter((s: any) => !matched.has(s.xero_transaction_id)).map((s: any) => ({
         source: s.type === 'SPEND' ? 'spend' as const : 'spend-overpay' as const,
         id: s.id, xeroId: s.xero_transaction_id, date: s.date, contact: s.contact_name, total: Number(s.total), status: s.status,
         projectCode: s.project_code as string | null,
+        projectSource: s.project_code_source as string | null,
+        reference: null as string | null,
         line_items: s.line_items,
         bankAccount: s.bank_account as string | null,
       })),
@@ -144,8 +146,11 @@ export async function GET(request: NextRequest) {
     }
 
     // Bunnings rows with line desc mentioning a DIFFERENT project than project_code
+    // Skip manual overrides — those are intentional user corrections of Dext.
     for (const r of expenseRows) {
       if (!r.projectCode) continue
+      const src = (r as any).projectSource || ''
+      if (typeof src === 'string' && src.startsWith('manual')) continue
       const desc = firstDescr(r.line_items as any[])
       const match = /—\s*(ACT-[A-Z]{2,4})\b/i.exec(desc)
       if (match && match[1].toUpperCase() !== r.projectCode.toUpperCase()) {
@@ -292,6 +297,107 @@ export async function GET(request: NextRequest) {
       unknownCode: projectReview.filter(r => r.recommendation === 'unknown-code').length,
     }
 
+    // ----- DUPLICATE GROUPS — definite + probable, structured for one-click voiding -----
+    // Excluded vendors: Qantas multi-leg flights, Qantas Group Accommodation multi-room,
+    // Airbnb subscriptions — these legitimately produce same-vendor-same-amount-same-day rows.
+    const DUP_EXCLUDED_VENDORS = new Set(['Qantas', 'Qantas Group Accommodation', 'Virgin Australia'])
+
+    type DupRow = { xeroId: string; status: string; reference: string | null; source: 'bill' | 'spend' | 'spend-overpay'; xeroLink: string }
+    type DupGroup = {
+      vendor: string
+      amount: number
+      date: string
+      projectCode: string | null
+      confidence: 'definite' | 'probable'
+      reason: string
+      rows: DupRow[]
+      extraDollars: number  // amount × (rows.length - 1) — the inflated amount if dups not voided
+    }
+
+    function mkLink(r: typeof expenseRows[0]): string {
+      return r.source === 'bill'
+        ? `https://go.xero.com/AccountsPayable/View.aspx?InvoiceID=${r.xeroId}`
+        : `https://go.xero.com/Bank/ViewTransaction.aspx?bankTransactionID=${r.xeroId}`
+    }
+    function extractDextId(ref: string | null): string | null {
+      if (!ref) return null
+      const m = /dext_import\s+([a-f0-9]{4,})/i.exec(ref)
+      return m ? m[1].toLowerCase() : null
+    }
+
+    // 1) DEFINITE — bills (only) sharing the same dext_import reference ID
+    const byDextId = new Map<string, typeof expenseRows>()
+    for (const r of expenseRows) {
+      if (r.source !== 'bill') continue
+      const id = extractDextId(r.reference)
+      if (!id) continue
+      const arr = byDextId.get(id) || []
+      arr.push(r); byDextId.set(id, arr)
+    }
+    const definiteDuplicates: DupGroup[] = []
+    for (const [, group] of byDextId.entries()) {
+      if (group.length < 2) continue
+      const first = group[0]
+      definiteDuplicates.push({
+        vendor: first.contact,
+        amount: first.total,
+        date: first.date as string,
+        projectCode: first.projectCode,
+        confidence: 'definite',
+        reason: `Same Dext import ID — receipt was processed into Xero twice.`,
+        rows: group.map((r) => ({ xeroId: r.xeroId as string, status: r.status as string, reference: r.reference, source: r.source, xeroLink: mkLink(r) })),
+        extraDollars: first.total * (group.length - 1),
+      })
+    }
+
+    // 2) PROBABLE — bill+bill same vendor+amount+date+project, excluding noisy vendors
+    const probDupKey = new Map<string, typeof expenseRows>()
+    for (const r of expenseRows) {
+      if (r.source !== 'bill') continue
+      if (DUP_EXCLUDED_VENDORS.has(r.contact)) continue
+      if (r.total < 100) continue
+      // Skip rows already counted as definite duplicates
+      const dextId = extractDextId(r.reference)
+      if (dextId && (byDextId.get(dextId)?.length || 0) > 1) continue
+      const key = `${r.contact}|${r.total.toFixed(2)}|${r.date}|${r.projectCode || 'UNTAGGED'}`
+      const arr = probDupKey.get(key) || []
+      arr.push(r); probDupKey.set(key, arr)
+    }
+    const probableDuplicates: DupGroup[] = []
+    for (const [, group] of probDupKey.entries()) {
+      if (group.length < 2) continue
+      const first = group[0]
+      const statuses = group.map((r) => r.status).join(' + ')
+      const reasonBits: string[] = []
+      if (statuses.includes('PAID') && statuses.includes('AUTHORISED')) {
+        reasonBits.push('1 PAID + ≥1 AUTHORISED — likely double-import; void the AUTH copies')
+      } else if (group.every((r) => r.status === 'AUTHORISED')) {
+        reasonBits.push('Both AUTHORISED — neither paid yet; void one before payment')
+      } else if (group.every((r) => r.status === 'PAID')) {
+        reasonBits.push('Both PAID — could be legitimate separate purchases; verify before voiding')
+      }
+      probableDuplicates.push({
+        vendor: first.contact,
+        amount: first.total,
+        date: first.date as string,
+        projectCode: first.projectCode,
+        confidence: 'probable',
+        reason: reasonBits.join(' · ') || `${group.length}× same vendor+amount+date`,
+        rows: group.map((r) => ({ xeroId: r.xeroId as string, status: r.status as string, reference: r.reference, source: r.source, xeroLink: mkLink(r) })),
+        extraDollars: first.total * (group.length - 1),
+      })
+    }
+
+    definiteDuplicates.sort((a, b) => b.extraDollars - a.extraDollars)
+    probableDuplicates.sort((a, b) => b.extraDollars - a.extraDollars)
+
+    const dupSummary = {
+      definiteCount: definiteDuplicates.length,
+      probableCount: probableDuplicates.length,
+      definiteDollars: Math.round(definiteDuplicates.reduce((a, g) => a + g.extraDollars, 0) * 100) / 100,
+      probableDollars: Math.round(probableDuplicates.reduce((a, g) => a + g.extraDollars, 0) * 100) / 100,
+    }
+
     return NextResponse.json({
       since,
       accountsParam,
@@ -310,6 +416,9 @@ export async function GET(request: NextRequest) {
       ocrFindings: ocrFindings.slice(0, 30),
       projectReview,
       reviewCounts,
+      definiteDuplicates,
+      probableDuplicates,
+      dupSummary,
     })
   } catch (e: any) {
     console.error('finance/audit error', e)

--- a/apps/command-center/src/app/api/finance/transactions/reality/route.ts
+++ b/apps/command-center/src/app/api/finance/transactions/reality/route.ts
@@ -32,14 +32,14 @@ export async function GET(request: NextRequest) {
 
     let billsQ = supabase
       .from('xero_invoices')
-      .select('id, xero_id, date, contact_name, total, status, line_items, project_code, has_attachments')
+      .select('id, xero_id, date, contact_name, total, status, line_items, project_code, project_code_source, has_attachments')
       .eq('type', 'ACCPAY')
       .in('status', ['AUTHORISED', 'PAID'])
       .gte('date', since)
 
     let spendsQ = supabase
       .from('xero_transactions')
-      .select('id, xero_transaction_id, date, contact_name, total, status, type, line_items, project_code, has_attachments, bank_account')
+      .select('id, xero_transaction_id, date, contact_name, total, status, type, line_items, project_code, project_code_source, has_attachments, bank_account')
       .in('type', ['SPEND', 'SPEND-OVERPAYMENT'])
       .gte('date', since)
     if (accountsParam === 'act-only') spendsQ = spendsQ.in('bank_account', ACT_ACCOUNTS)
@@ -47,15 +47,16 @@ export async function GET(request: NextRequest) {
 
     const [bills, spends] = await Promise.all([fetchAll(billsQ), fetchAll(spendsQ)])
 
-    // ----- Dedup: bill paid via bank produces a spend with same vendor+amount within ±14d -----
-    const paidBills = bills.filter((b: any) => b.status === 'PAID')
+    // ----- Dedup: bill paid via bank produces a spend with same vendor+amount within ±30d -----
+    // Widened from ±14d → ±30d (bills sometimes paid weeks late). Include both AUTHORISED + PAID
+    // bills as matchable — the spend pays it regardless of bill status.
     const matchedSpendIds = new Set<string>()
     for (const s of spends) {
       const sd = new Date(s.date as string).getTime()
-      const m = paidBills.find((b: any) =>
+      const m = bills.find((b: any) =>
         (b.contact_name || '').trim().toUpperCase() === (s.contact_name || '').trim().toUpperCase() &&
         Number(b.total) === Number(s.total) &&
-        Math.abs((new Date(b.date as string).getTime() - sd) / 86400000) <= 14
+        Math.abs((new Date(b.date as string).getTime() - sd) / 86400000) <= 30
       )
       if (m) matchedSpendIds.add(s.xero_transaction_id as string)
     }
@@ -99,9 +100,12 @@ export async function GET(request: NextRequest) {
     for (const v of dupKey.values()) if (v > 1) duplicates += v - 1
 
     // Project mismatch: line desc says ACT-XX but project_code is ACT-YY
+    // Skip manual overrides — `project_code_source LIKE 'manual%'` means user
+    // deliberately overrode Dext's reading. Dext text is stale, tag is right.
     let mismatches = 0
     for (const r of [...bills, ...unmatchedSpends] as any[]) {
       if (!r.project_code) continue
+      if (typeof r.project_code_source === 'string' && r.project_code_source.startsWith('manual')) continue
       const desc = firstDescr(r.line_items)
       const m = /—\s*(ACT-[A-Z]{2,4})\b/i.exec(desc)
       if (m && m[1].toUpperCase() !== r.project_code.toUpperCase()) mismatches += 1

--- a/apps/command-center/src/app/finance/audit/page.tsx
+++ b/apps/command-center/src/app/finance/audit/page.tsx
@@ -129,6 +129,15 @@ export default function FinanceAuditPage() {
               </div>
             </div>
 
+            {/* DUPLICATES — definite + probable, one-click Xero open */}
+            {(data.definiteDuplicates?.length > 0 || data.probableDuplicates?.length > 0) && (
+              <DuplicatesPanel
+                definite={data.definiteDuplicates || []}
+                probable={data.probableDuplicates || []}
+                summary={data.dupSummary}
+              />
+            )}
+
             {/* Notable findings */}
             {findings.length > 0 && (
               <div className="mb-4">
@@ -209,6 +218,90 @@ export default function FinanceAuditPage() {
             )}
           </>
         )}
+      </div>
+    </div>
+  )
+}
+
+type DupRow = { xeroId: string; status: string; reference: string | null; source: 'bill' | 'spend' | 'spend-overpay'; xeroLink: string }
+type DupGroup = {
+  vendor: string
+  amount: number
+  date: string
+  projectCode: string | null
+  confidence: 'definite' | 'probable'
+  reason: string
+  rows: DupRow[]
+  extraDollars: number
+}
+
+function DuplicatesPanel({ definite, probable, summary }: { definite: DupGroup[]; probable: DupGroup[]; summary: any }) {
+  const [showProbable, setShowProbable] = useState(true)
+
+  function renderGroup(g: DupGroup, key: string) {
+    return (
+      <div key={key} className={`border rounded p-3 ${g.confidence === 'definite' ? 'border-red-500/50 bg-red-500/5' : 'border-amber-500/40 bg-amber-500/5'}`}>
+        <div className="flex items-baseline justify-between gap-3">
+          <div className="flex-1">
+            <div className="text-sm font-semibold text-white">
+              {g.confidence === 'definite' ? '🔴' : '🟡'} {g.vendor}
+              <span className="ml-2 text-xs text-white/50">{g.date}</span>
+              {g.projectCode && <Link href={`/finance/projects/${g.projectCode}`} className="ml-2 text-xs text-blue-400 hover:underline">{g.projectCode}</Link>}
+            </div>
+            <div className="text-xs text-white/60 mt-0.5">{g.reason}</div>
+          </div>
+          <div className="text-right whitespace-nowrap">
+            <div className="text-base font-bold tabular-nums text-white">{fmt(g.amount)} × {g.rows.length}</div>
+            <div className="text-[10px] text-white/40">overage: {fmt(g.extraDollars)}</div>
+          </div>
+        </div>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {g.rows.map((r, i) => (
+            <a key={i} href={r.xeroLink} target="_blank" rel="noreferrer"
+              className={`text-xs px-2 py-1 rounded border hover:bg-white/10 ${r.status === 'PAID' ? 'border-emerald-500/40 text-emerald-200' : r.status === 'AUTHORISED' ? 'border-amber-500/40 text-amber-200' : 'border-white/30 text-white/70'}`}>
+              {r.status} · {r.source} · {r.reference?.slice(0, 32) || r.xeroId.slice(0, 8)} ↗
+            </a>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-4">
+      <h2 className="text-sm uppercase text-white/40 mb-2">
+        Duplicates worth voiding
+        <span className="ml-2 text-red-300/80">{summary?.definiteCount || 0} definite · {fmt(summary?.definiteDollars || 0)}</span>
+        <span className="ml-2 text-amber-300/80">{summary?.probableCount || 0} probable · {fmt(summary?.probableDollars || 0)}</span>
+      </h2>
+
+      {definite.length > 0 && (
+        <div className="mb-3">
+          <div className="text-xs text-red-300/70 uppercase tracking-wider mb-1">Definite (same Dext import ID)</div>
+          <div className="space-y-2">
+            {definite.map((g, i) => renderGroup(g, `def-${i}`))}
+          </div>
+        </div>
+      )}
+
+      {probable.length > 0 && (
+        <div>
+          <div className="text-xs text-amber-300/70 uppercase tracking-wider mb-1 flex items-center gap-2">
+            Probable (same vendor + amount + date)
+            <button onClick={() => setShowProbable(!showProbable)} className="text-[10px] px-1.5 py-0.5 border border-white/20 rounded hover:bg-white/10">
+              {showProbable ? 'hide' : `show ${probable.length}`}
+            </button>
+          </div>
+          {showProbable && (
+            <div className="space-y-2">
+              {probable.map((g, i) => renderGroup(g, `prob-${i}`))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="text-[10px] text-white/40 mt-2">
+        Click any chip to open the row in Xero. For PAID + AUTHORISED pairs, void the AUTHORISED one. For both-PAID, verify before voiding. After voiding, refresh — the alert clears once the bill no longer shows.
       </div>
     </div>
   )

--- a/scripts/void-duplicate-bills.mjs
+++ b/scripts/void-duplicate-bills.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Plan-only: lists duplicate bills surfaced by /api/finance/audit that COULD
+ * be voided in Xero. This script DOES NOT call the Xero API — it only prints
+ * the plan. Voiding is intentionally manual: open each bill in Xero, eyeball
+ * the receipt + reconciliation state, then void via the Xero UI.
+ *
+ * Why no --confirm? Voiding a PAID bill breaks bank reconciliation. Voiding
+ * an AUTHORISED bill is reversible only by recreating it. A receipt that
+ * looks like a duplicate to a regex may be a legitimate same-vendor-same-day
+ * purchase. Humans-in-Xero-UI is the safe path.
+ *
+ * Usage:
+ *   node scripts/void-duplicate-bills.mjs                            # all groups
+ *   node scripts/void-duplicate-bills.mjs --tier=definite            # definite only
+ *   node scripts/void-duplicate-bills.mjs --tier=probable-paid-auth  # PAID+AUTH probables
+ *   node scripts/void-duplicate-bills.mjs --tier=probable-both-auth  # both-AUTH probables
+ */
+import './lib/load-env.mjs';
+
+const AUDIT_URL = 'http://localhost:3002/api/finance/audit?accounts=act-only&since=2025-07-01';
+
+const args = process.argv.slice(2);
+const TIER = (args.find(a => a.startsWith('--tier='))?.split('=')[1] || 'all').toLowerCase();
+
+function pickVoidTarget(group) {
+  // Always prefer voiding an AUTHORISED copy (safe: no money moved).
+  const auth = group.rows.filter(r => r.status === 'AUTHORISED');
+  const paid = group.rows.filter(r => r.status === 'PAID');
+
+  if (paid.length === group.rows.length) {
+    return { skip: true, reason: 'All copies PAID — manual verification needed' };
+  }
+  if (auth.length === 0) {
+    return { skip: true, reason: 'No AUTHORISED copy to void safely' };
+  }
+  // Void all but one AUTHORISED. Keep paid + first auth, void the extras.
+  if (auth.length === 1 && paid.length > 0) {
+    // PAID + AUTH: void the AUTH (it's the duplicate)
+    return { skip: false, voidIds: [auth[0].xeroId], reason: '1 PAID kept · void 1 AUTH copy' };
+  }
+  if (auth.length > 1 && paid.length === 0) {
+    // Both/all AUTH: void all but the first (oldest by id ordering)
+    return { skip: false, voidIds: auth.slice(1).map(r => r.xeroId), reason: `keep 1 AUTH · void ${auth.length - 1}` };
+  }
+  // Mixed multi-row case: void all AUTH (since one PAID stays as the kept copy)
+  return { skip: false, voidIds: auth.map(r => r.xeroId), reason: `keep ${paid.length} PAID · void ${auth.length} AUTH` };
+}
+
+function tierMatches(group) {
+  if (TIER === 'all') return true;
+  if (TIER === 'definite') return group.confidence === 'definite';
+  if (TIER === 'probable') return group.confidence === 'probable';
+  if (TIER === 'probable-paid-auth') {
+    return group.confidence === 'probable' && group.reason.toLowerCase().includes('paid +');
+  }
+  if (TIER === 'probable-both-auth') {
+    return group.confidence === 'probable' && group.reason.toLowerCase().includes('both authorised');
+  }
+  return true;
+}
+
+async function main() {
+  console.log(`Mode: PLAN-ONLY (no Xero writes) · Tier: ${TIER}\n`);
+
+  console.log('Fetching audit duplicates…');
+  const r = await fetch(AUDIT_URL);
+  if (!r.ok) throw new Error(`audit API ${r.status}`);
+  const audit = await r.json();
+  const groups = [
+    ...(audit.definiteDuplicates || []),
+    ...(audit.probableDuplicates || []),
+  ].filter(tierMatches);
+
+  console.log(`Got ${groups.length} groups in scope.\n`);
+
+  const plan = [];
+  let skipped = 0;
+  for (const g of groups) {
+    const t = pickVoidTarget(g);
+    if (t.skip) { skipped += 1; continue; }
+    for (const xeroId of t.voidIds) {
+      plan.push({
+        xeroId,
+        vendor: g.vendor,
+        amount: g.amount,
+        date: g.date,
+        confidence: g.confidence,
+        reason: t.reason,
+        group: g,
+      });
+    }
+  }
+
+  console.log('--- PLAN (open each in Xero UI to void manually) ---');
+  for (const p of plan) {
+    const xeroLink = `https://go.xero.com/AccountsPayable/View.aspx?InvoiceID=${p.xeroId}`;
+    console.log(`  ${p.confidence.padEnd(8)} ${p.vendor.padEnd(36)} $${p.amount.toFixed(2).padStart(10)}  ${p.date}  →  ${xeroLink}`);
+  }
+  console.log(`\nTotal: ${plan.length} candidates · ${skipped} groups skipped (both-PAID, needs manual)`);
+  console.log(`\nThis script does not write to Xero. Open each link, verify with the receipt + reconciliation, then void via Xero UI (Bill Options → Void).`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

After walking through the 223 audit issues, three related improvements that cut noise and surface real action items:

### 1. Detector tuning
- **Widened bill↔spend dedup** from ±14d → ±30d (catches more late-paid bills as matched pairs)
- **Dedup matches AUTHORISED + PAID** bills (not just PAID — Xero status flip is sometimes lagged)
- **Mismatch detector skips manual overrides** — \`project_code_source LIKE 'manual%'\` means the user intentionally overrode Dext, not a bug
- Applied to both \`/api/finance/audit\` and \`/api/finance/transactions/reality\`

Result: mismatches dropped 30 → 19. Matched pairs went 36 → 101.

### 2. Duplicates panel on /finance/audit
Surfaces actionable groups above the existing alerts:

- **Definite** (red): same Dext import ID — receipt processed into Xero twice. Highest certainty.
- **Probable** (amber): same vendor + amount + date, excluding known multi-leg vendors (Qantas, Qantas Group Accommodation, Virgin Australia).
- Each row: vendor / date / project / status chips (PAID green, AUTH amber) with one-click Xero open links.
- Reason text tells you which copy is safe to void.
- Summary in panel header: \`4 definite · \$15,508 · 16 probable · \$45,718\`

### 3. scripts/void-duplicate-bills.mjs (plan-only)
Lists void candidates with direct Xero links. **Does NOT write to Xero** — voiding is intentionally manual via the Xero UI to avoid breaking bank reconciliation on PAID bills or false-positive voiding of legitimate same-day purchases.

\`\`\`
node scripts/void-duplicate-bills.mjs --tier=definite
node scripts/void-duplicate-bills.mjs --tier=probable-paid-auth
node scripts/void-duplicate-bills.mjs --tier=probable-both-auth
node scripts/void-duplicate-bills.mjs                            # all
\`\`\`

## Test plan

- [ ] Open /finance/audit — Duplicates panel renders above Notable findings
- [ ] Definite section shows 4 groups (Carla Furnishers, Airbnb, Nicholas Marchesi, Webflow)
- [ ] Probable section shows ~16 groups, toggleable show/hide
- [ ] Each Xero chip opens the bill in Xero
- [ ] /api/finance/transactions/reality shows mismatches 19 (was 30), matched pairs 101 (was 36)
- [ ] \`node scripts/void-duplicate-bills.mjs --tier=definite\` prints 4 candidates with Xero links, no Xero writes

Plan: finance-tagging-platform-2026-05-18