### PR TITLE
feat(finance): exclude transfers + ATO from receipt-coverage

### DIFF
--- a/apps/command-center/src/app/api/finance/transactions/reality/route.ts
+++ b/apps/command-center/src/app/api/finance/transactions/reality/route.ts
@@ -5,6 +5,23 @@ export const dynamic = 'force-dynamic'
 
 const ACT_ACCOUNTS = ['NAB Visa ACT #8815', 'NJ Marchesi T/as ACT Everyday']
 
+// Rows where "no receipt" is the correct state — bank statement IS the evidence.
+// Excluded from receipt-coverage denominator so the headline reflects real action items.
+function isNoReceiptNeeded(contactName: string | null | undefined): boolean {
+  const n = (contactName || '').trim()
+  if (!n) return false
+  // Owner / inter-account transfers (Marchesi family + Knight family)
+  if (/^(Nicholas|Nic|Benjamin|Ben)(\s+(Marchesi|Knight|)|$)/i.test(n)) return true
+  if (/Marchesi|Knight/i.test(n) && /^(Nicholas|Nic|Benjamin|Ben)/i.test(n)) return true
+  if (n === 'Nicholas' || n === 'Nic' || n === 'Ben' || n === 'Benjamin') return true
+  if (n === 'Nicholas Marchesi' || n === 'Benjamin Knight') return true
+  // Government / tax payments — no receipt
+  if (n === 'Australian Taxation Office' || /^ATO\b/i.test(n)) return true
+  // Bank fees / interest
+  if (/^(NAB|Bank|Internal|Transfer)\b/i.test(n) && /(fee|charge|interest|transfer)/i.test(n)) return true
+  return false
+}
+
 function firstDescr(li: any[] | null | undefined): string {
   if (!Array.isArray(li) || !li.length) return ''
   return li.map((x) => x?.description || x?.Description || '').filter(Boolean).join(' | ')
@@ -78,10 +95,17 @@ export async function GET(request: NextRequest) {
       const key = `${(b.contact_name || '').trim().toUpperCase()}|${Number(b.total).toFixed(2)}|${b.date}`
       if (b.has_attachments) billAttachmentByKey.set(key, true)
     }
-    const billReceipted = bills.filter((b: any) => b.has_attachments).length
-    const spendReceipted = unmatchedSpends.filter((s: any) => s.has_attachments).length
+    // "No receipt needed" categories don't count against receipt coverage —
+    // bank statement IS the evidence for transfers + ATO + bank fees.
+    const noReceiptNeeded = [
+      ...bills.filter((b: any) => isNoReceiptNeeded(b.contact_name)),
+      ...unmatchedSpends.filter((s: any) => isNoReceiptNeeded(s.contact_name)),
+    ].length
+    const receiptableTotal = totalDeduped - noReceiptNeeded
+    const billReceipted = bills.filter((b: any) => b.has_attachments && !isNoReceiptNeeded(b.contact_name)).length
+    const spendReceipted = unmatchedSpends.filter((s: any) => s.has_attachments && !isNoReceiptNeeded(s.contact_name)).length
     const receipted = billReceipted + spendReceipted
-    const receiptedPct = totalDeduped > 0 ? Math.round((receipted / totalDeduped) * 100) : 0
+    const receiptedPct = receiptableTotal > 0 ? Math.round((receipted / receiptableTotal) * 100) : 0
 
     // ----- Audit issue counts -----
     // Duplicates: same vendor+amount+date appearing twice on the same project
@@ -128,10 +152,12 @@ export async function GET(request: NextRequest) {
       tagged,
       untagged,
       taggedPct,
-      // Receipts
+      // Receipts (denominator excludes no-receipt-needed: transfers, ATO, bank fees)
       receipted,
-      unreceipted: totalDeduped - receipted,
+      unreceipted: receiptableTotal - receipted,
       receiptedPct,
+      noReceiptNeeded,
+      receiptableTotal,
       // Audit
       duplicates,
       mismatches,

--- a/apps/command-center/src/app/finance/transactions/page.tsx
+++ b/apps/command-center/src/app/finance/transactions/page.tsx
@@ -605,8 +605,8 @@ export default function TransactionsExplorer() {
             >
               <div className="text-xs text-white/40 uppercase tracking-wider mb-1">Receipted</div>
               <div className={`text-xl font-bold tabular-nums ${reality.receiptedPct >= 95 ? 'text-emerald-300' : reality.receiptedPct >= 80 ? 'text-amber-300' : 'text-red-300'}`}>{reality.receiptedPct}%</div>
-              <div className="text-[10px] text-white/40">{reality.receipted.toLocaleString()} of {reality.totalDeduped.toLocaleString()}</div>
-              <div className="text-[10px] text-white/30">{reality.unreceipted.toLocaleString()} missing →</div>
+              <div className="text-[10px] text-white/40">{reality.receipted.toLocaleString()} of {(reality.receiptableTotal ?? reality.totalDeduped).toLocaleString()}</div>
+              <div className="text-[10px] text-white/30">{reality.unreceipted.toLocaleString()} missing → · {reality.noReceiptNeeded ?? 0} excluded (transfers/ATO)</div>
             </Link>
             <Link
               href="/finance/audit"


### PR DESCRIPTION
## Summary

Two improvements after walking through the 715 \"missing receipts\":

### 1. Receipt coverage now reflects real action items
Previously every spend without an attachment counted against the percentage, including inter-account owner transfers and ATO payments where the bank statement IS the evidence.

Added \`isNoReceiptNeeded(contact)\` matcher to \`/api/finance/transactions/reality\`:
- Owner / inter-account: Nicholas Marchesi, Benjamin Knight, \"Nicholas\", etc.
- Tax: Australian Taxation Office, ATO
- Bank fees / transfers

**Result:** 224 rows worth \$147K excluded from denominator. Receipt % went 76% → 80%. Real action items dropped from ~715 to ~531 rows that genuinely need receipts.

The reality strip on /finance/transactions now shows:
\`X of Y · N missing · M excluded (transfers/ATO)\`

### 2. Bill-attachment sync
Ran \`scripts/sync-bill-attachments-to-txns.mjs\` across all FY26 quarters. Copied 5 attachments from auto-billed connector bills (Qantas, Notion, BP, Flight Bar Witta) onto their matching bank transactions — \$2,066 recovered.

Most auto-billed spends don't have matching bills though, so the gap there is smaller than expected and the rest needs separate investigation (probably auto-billing connectors aren't fully set up).

## Test plan

- [ ] Open /finance/transactions — Receipted tile shows new \"excluded\" subline
- [ ] Receipt % shows 80% (was 76%)
- [ ] noReceiptNeeded field in /api/finance/transactions/reality response = 224
- [ ] No regression on tagged %, audit count

Plan: finance-tagging-platform-2026-05-18