### PR TITLE
fix(finance): paginate 9 row-cap-truncated totals

### DIFF
--- a/apps/command-center/src/app/api/bookkeeping/progress/route.ts
+++ b/apps/command-center/src/app/api/bookkeeping/progress/route.ts
@@ -1,25 +1,27 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 export async function GET() {
   try {
-    // Fetch all data in parallel
-    const [txResult, invResult] = await Promise.all([
+    // Fetch all data in parallel (paginated past PostgREST ~1000-row cap)
+    const [transactions, invoices] = await Promise.all([
       // All transactions for aggregation
-      supabase
-        .from('xero_transactions')
-        .select('total, type, date, contact_name')
-        .order('date', { ascending: false }),
+      fetchAllRows<{ total: number; type: string; date: string; contact_name: string }>((from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('total, type, date, contact_name')
+          .order('date', { ascending: false })
+          .range(from, to)),
 
       // All invoices
-      supabase
-        .from('xero_invoices')
-        .select('invoice_number, contact_name, amount_due, total, type, status, due_date')
-        .in('status', ['AUTHORISED', 'SENT', 'PAID']),
+      fetchAllRows<{ invoice_number: string; contact_name: string; amount_due: number; total: number; type: string; status: string; due_date: string }>((from, to) =>
+        supabase
+          .from('xero_invoices')
+          .select('invoice_number, contact_name, amount_due, total, type, status, due_date')
+          .in('status', ['AUTHORISED', 'SENT', 'PAID'])
+          .range(from, to)),
     ])
-
-    const transactions = txResult.data || []
-    const invoices = invResult.data || []
 
     // Aggregate income/expenses totals
     let totalIncome = 0

--- a/apps/command-center/src/app/api/business/overview/route.ts
+++ b/apps/command-center/src/app/api/business/overview/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 /**
  * GET /api/business/overview
@@ -26,11 +27,13 @@ export async function GET() {
   thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
   const thirtyDaysAgoStr = thirtyDaysAgo.toISOString().split('T')[0]
 
-  // FY totals
-  const { data: fyTxns } = await supabase
-    .from('xero_transactions')
-    .select('total, type')
-    .gte('date', fyStartStr)
+  // FY totals (paginated past PostgREST ~1000-row cap)
+  const fyTxns = await fetchAllRows<{ total: number; type: string }>((from, to) =>
+    supabase
+      .from('xero_transactions')
+      .select('total, type')
+      .gte('date', fyStartStr)
+      .range(from, to))
 
   let fyIncome = 0, fyExpenses = 0
   for (const tx of fyTxns || []) {
@@ -92,11 +95,13 @@ export async function GET() {
   // === LIVE R&D SPEND DATA ===
   const RD_ELIGIBLE_PROJECTS = ['ACT-EL', 'ACT-IN', 'ACT-JH', 'ACT-GD', 'ACT-PS', 'ACT-CF']
 
-  const { data: rdTxns } = await supabase
-    .from('xero_transactions')
-    .select('project_code, total')
-    .in('project_code', RD_ELIGIBLE_PROJECTS)
-    .gte('date', fyStartStr)
+  const rdTxns = await fetchAllRows<{ project_code: string; total: number }>((from, to) =>
+    supabase
+      .from('xero_transactions')
+      .select('project_code, total')
+      .in('project_code', RD_ELIGIBLE_PROJECTS)
+      .gte('date', fyStartStr)
+      .range(from, to))
 
   let rdSpendTotal = 0
   const rdByProject: Record<string, number> = {}

--- a/apps/command-center/src/app/api/finance/accountant-pack/route.ts
+++ b/apps/command-center/src/app/api/finance/accountant-pack/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 const FY_START = '2025-07-01'
 const R_AND_D_PROJECTS = ['ACT-EL', 'ACT-IN', 'ACT-JH', 'ACT-GD']
@@ -21,8 +22,8 @@ export async function GET() {
       projectsResult,
       receivablesResult,
       payablesResult,
-      transactionsResult,
-      invoicesResult,
+      transactions,
+      invoices,
       pipelineResult,
     ] = await Promise.all([
       // Monthly financials
@@ -56,19 +57,21 @@ export async function GET() {
         .order('due_date', { ascending: true })
         .limit(500),
 
-      // All FY26 transactions for R&D and coverage
-      supabase
-        .from('xero_transactions')
-        .select('id, date, contact_name, total, type, project_code')
-        .gte('date', FY_START)
-        .limit(2000),
+      // All FY26 transactions for R&D and coverage (paginated past PostgREST ~1000-row cap)
+      fetchAllRows<{ id: string; date: string; contact_name: string; total: number; type: string; project_code: string }>((from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('id, date, contact_name, total, type, project_code')
+          .gte('date', FY_START)
+          .range(from, to)),
 
-      // All FY26 invoices for completeness
-      supabase
-        .from('xero_invoices')
-        .select('id, contact_name, total, project_code, type')
-        .gte('date', FY_START)
-        .limit(2000),
+      // All FY26 invoices for completeness (paginated past PostgREST ~1000-row cap)
+      fetchAllRows<{ id: string; contact_name: string; total: number; project_code: string; type: string }>((from, to) =>
+        supabase
+          .from('xero_invoices')
+          .select('id, contact_name, total, project_code, type')
+          .gte('date', FY_START)
+          .range(from, to)),
 
       // Pipeline data
       supabase
@@ -83,8 +86,6 @@ export async function GET() {
     const projects = projectsResult.data || []
     const receivables = receivablesResult.data || []
     const payables = payablesResult.data || []
-    const transactions = transactionsResult.data || []
-    const invoices = invoicesResult.data || []
     const pipelineData = pipelineResult.data || []
 
     const projectMap = new Map(projects.map(p => [p.code, p]))

--- a/apps/command-center/src/app/api/finance/founder-pay/route.ts
+++ b/apps/command-center/src/app/api/finance/founder-pay/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 const FY26_START = '2025-07-01'
 const FY26_END = '2026-06-30'
@@ -36,7 +37,7 @@ interface FounderPayResponse {
 export async function GET() {
   try {
     // Mirrors scripts/sync-money-framework-to-notion.mjs::fetchKnightPhotography + fetchFY26Totals
-    const [knightRes, fy26Res] = await Promise.all([
+    const [knightRes, fy26Rows] = await Promise.all([
       supabase
         .from('xero_invoices')
         .select('invoice_number, date, total, status')
@@ -46,20 +47,21 @@ export async function GET() {
         .lte('date', FY26_END)
         .order('date', { ascending: false })
         .limit(40),
-      supabase
-        .from('xero_invoices')
-        .select('type, total, status, amount_paid')
-        .gte('date', FY26_START)
-        .lte('date', FY26_END),
+      fetchAllRows<{ type: string; total: number; status: string; amount_paid: number }>((from, to) =>
+        supabase
+          .from('xero_invoices')
+          .select('type, total, status, amount_paid')
+          .gte('date', FY26_START)
+          .lte('date', FY26_END)
+          .range(from, to)),
     ])
 
     if (knightRes.error) throw knightRes.error
-    if (fy26Res.error) throw fy26Res.error
 
     const knightInvoices = (knightRes.data || []) as FounderInvoice[]
     let income = 0
     let expenses = 0
-    for (const i of fy26Res.data || []) {
+    for (const i of fy26Rows) {
       const t = Number(i.total || 0)
       if (i.type === 'ACCREC') income += t
       else if (i.type === 'ACCPAY') expenses += t

--- a/apps/command-center/src/app/api/finance/invoices/route.ts
+++ b/apps/command-center/src/app/api/finance/invoices/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 export const dynamic = 'force-dynamic'
 
@@ -43,13 +44,15 @@ export async function GET() {
     oneWeek.setDate(oneWeek.getDate() + 7)
     const oneWeekStr = oneWeek.toISOString().split('T')[0]
 
-    // Fetch all active invoices + projects in parallel
-    const [invResult, projectsResult] = await Promise.all([
-      supabase
-        .from('xero_invoices')
-        .select('id, xero_id, invoice_number, type, status, contact_name, date, due_date, total, amount_due, amount_paid, has_attachments, reference, project_code, line_items, fully_paid_date')
-        .in('status', ['DRAFT', 'SUBMITTED', 'AUTHORISED', 'PAID'])
-        .order('due_date', { ascending: true, nullsFirst: false }),
+    // Fetch all active invoices (paginated past PostgREST ~1000-row cap) + projects in parallel
+    const [invoices, projectsResult] = await Promise.all([
+      fetchAllRows<InvoiceRow>((from, to) =>
+        supabase
+          .from('xero_invoices')
+          .select('id, xero_id, invoice_number, type, status, contact_name, date, due_date, total, amount_due, amount_paid, has_attachments, reference, project_code, line_items, fully_paid_date')
+          .in('status', ['DRAFT', 'SUBMITTED', 'AUTHORISED', 'PAID'])
+          .order('due_date', { ascending: true, nullsFirst: false })
+          .range(from, to)),
       supabase
         .from('projects')
         .select('code, name, tier')
@@ -57,7 +60,6 @@ export async function GET() {
         .order('name'),
     ])
 
-    const invoices = (invResult.data || []) as InvoiceRow[]
     const projects = projectsResult.data || []
 
     // Compute stats and enrich items

--- a/apps/command-center/src/app/api/projects/financials/route.ts
+++ b/apps/command-center/src/app/api/projects/financials/route.ts
@@ -3,11 +3,13 @@ import { supabase } from '@/lib/supabase'
 
 export async function GET() {
   try {
-    // Fetch project financials, R&D expenses, and tagging coverage in parallel
-    const [financialsResult, rdResult, coverageResult] = await Promise.all([
+    // Fetch project financials, R&D expenses, and tagging coverage in parallel.
+    // Coverage uses count-only queries (head: true) — never transfer >1000 rows just to count them.
+    const [financialsResult, rdResult, totalCountResult, taggedCountResult] = await Promise.all([
       supabase.from('v_project_financials').select('*'),
       supabase.from('xero_transactions').select('vendor_name, total, date').eq('project_code', 'ACT-RD'),
-      supabase.from('xero_transactions').select('id, project_code', { count: 'exact', head: false }),
+      supabase.from('xero_transactions').select('id', { count: 'exact', head: true }),
+      supabase.from('xero_transactions').select('id', { count: 'exact', head: true }).not('project_code', 'is', null),
     ])
 
     if (financialsResult.error) throw financialsResult.error
@@ -29,10 +31,9 @@ export async function GET() {
     }
     const rdTotal = rdExpenses.reduce((s, r) => s + Math.abs(Number(r.total || 0)), 0)
 
-    // Tagging coverage
-    const allTx = coverageResult.data || []
-    const totalTx = allTx.length
-    const taggedTx = allTx.filter(t => t.project_code != null).length
+    // Tagging coverage (count-only — head:true queries return no rows)
+    const totalTx = totalCountResult.count || 0
+    const taggedTx = taggedCountResult.count || 0
 
     return NextResponse.json({
       projects: projects.map(p => ({

--- a/apps/command-center/src/app/api/reports/cash-flow-forecast/route.ts
+++ b/apps/command-center/src/app/api/reports/cash-flow-forecast/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 export async function GET() {
   try {
@@ -7,10 +8,12 @@ export async function GET() {
     const sixMonthsAgo = new Date()
     sixMonthsAgo.setMonth(sixMonthsAgo.getMonth() - 6)
 
-    const { data: txns } = await supabase
-      .from('xero_transactions')
-      .select('total, type, date')
-      .gte('date', sixMonthsAgo.toISOString().split('T')[0])
+    const txns = await fetchAllRows<{ total: number; type: string; date: string }>((from, to) =>
+      supabase
+        .from('xero_transactions')
+        .select('total, type, date')
+        .gte('date', sixMonthsAgo.toISOString().split('T')[0])
+        .range(from, to))
 
     let totalInflow = 0, totalOutflow = 0
     for (const tx of txns || []) {

--- a/apps/command-center/src/app/api/reports/profit-loss/route.ts
+++ b/apps/command-center/src/app/api/reports/profit-loss/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
+
+type PLTxn = { total: number; bank_account: string; contact_name: string; date: string }
 
 export async function GET() {
   try {
@@ -8,19 +11,24 @@ export async function GET() {
     if (now.getMonth() < 6) fyStart.setFullYear(fyStart.getFullYear() - 1)
     const fyStartStr = fyStart.toISOString().split('T')[0]
 
-    // Get RECEIVE transactions (income)
-    const { data: income } = await supabase
-      .from('xero_transactions')
-      .select('total, bank_account, contact_name, date')
-      .eq('type', 'RECEIVE')
-      .gte('date', fyStartStr)
-
-    // Get SPEND transactions (expenses)
-    const { data: expenses } = await supabase
-      .from('xero_transactions')
-      .select('total, bank_account, contact_name, date')
-      .eq('type', 'SPEND')
-      .gte('date', fyStartStr)
+    // Get RECEIVE transactions (income) + SPEND transactions (expenses),
+    // paginated past PostgREST ~1000-row cap
+    const [income, expenses] = await Promise.all([
+      fetchAllRows<PLTxn>((from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('total, bank_account, contact_name, date')
+          .eq('type', 'RECEIVE')
+          .gte('date', fyStartStr)
+          .range(from, to)),
+      fetchAllRows<PLTxn>((from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('total, bank_account, contact_name, date')
+          .eq('type', 'SPEND')
+          .gte('date', fyStartStr)
+          .range(from, to)),
+    ])
 
     // Group income by contact/source
     const incomeByAccount: Record<string, number> = {}

--- a/apps/command-center/src/app/api/reports/yearly/route.ts
+++ b/apps/command-center/src/app/api/reports/yearly/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from '@/lib/finance/query'
 
 export async function GET(request: Request) {
   try {
@@ -21,19 +22,24 @@ export async function GET(request: Request) {
     const prevStartStr = prevFyStart.toISOString().split('T')[0]
     const prevEndStr = prevFyEnd.toISOString().split('T')[0]
 
-    // === CURRENT FY FINANCIAL DATA ===
-    const { data: currentTxns } = await supabase
-      .from('xero_transactions')
-      .select('total, type, contact_name, date')
-      .gte('date', fyStartStr)
-      .lte('date', fyEndStr)
-
-    // === PREVIOUS FY FINANCIAL DATA ===
-    const { data: prevTxns } = await supabase
-      .from('xero_transactions')
-      .select('total, type')
-      .gte('date', prevStartStr)
-      .lte('date', prevEndStr)
+    // === CURRENT FY FINANCIAL DATA === (paginated past PostgREST ~1000-row cap)
+    const [currentTxns, prevTxns] = await Promise.all([
+      fetchAllRows<{ total: number; type: string; contact_name: string; date: string }>((from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('total, type, contact_name, date')
+          .gte('date', fyStartStr)
+          .lte('date', fyEndStr)
+          .range(from, to)),
+      // === PREVIOUS FY FINANCIAL DATA ===
+      fetchAllRows<{ total: number; type: string }>((from, to) =>
+        supabase
+          .from('xero_transactions')
+          .select('total, type')
+          .gte('date', prevStartStr)
+          .lte('date', prevEndStr)
+          .range(from, to)),
+    ])
 
     let income = 0, expenses = 0, prevIncome = 0, prevExpenses = 0
     const incomeBySource: Record<string, number> = {}

--- a/apps/command-center/src/lib/finance/query.ts
+++ b/apps/command-center/src/lib/finance/query.ts
@@ -17,3 +17,33 @@ export async function execSql<T = Record<string, unknown>>(
 
   return (result.data || []) as T[]
 }
+
+/**
+ * Fetch ALL rows for a query, paging past PostgREST's ~1000-row max-rows cap.
+ *
+ * The Supabase JS client returns at most ~1000 rows per request — EVEN with `.range(0, 9999)` or
+ * `.limit(5000)` — because PostgREST enforces a server `max-rows` cap that range/limit don't override.
+ * Any unpaginated `.select()` that then sums/counts >1000 rows silently truncates (wrong totals, no
+ * error). Use this for every org-wide / multi-thousand-row aggregation.
+ *
+ * `make(from, to)` must return a query ALREADY ranged to [from, to], e.g.:
+ *   fetchAllRows((from, to) => supabase.from('xero_transactions').select('total,type').gte('date', x).range(from, to))
+ *
+ * For pure totals/counts prefer `count: 'exact', head: true` (no rows transferred) or SQL via execSql.
+ */
+export async function fetchAllRows<T = Record<string, unknown>>(
+  make: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>,
+): Promise<T[]> {
+  const PAGE = 1000
+  const rows: T[] = []
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await make(from, from + PAGE - 1)
+    if (error) {
+      const msg = (error as { message?: string })?.message ?? String(error)
+      throw new Error(`fetchAllRows failed: ${msg}`)
+    }
+    const batch = data ?? []
+    rows.push(...batch)
+    if (batch.length < PAGE) return rows
+  }
+}

--- a/thoughts/shared/reviews/command-center-trust-map/F-rowcap-sweep.md
+++ b/thoughts/shared/reviews/command-center-trust-map/F-rowcap-sweep.md
@@ -1,0 +1,66 @@
+# F — Row-cap truncation sweep
+
+PostgREST (Supabase JS) returns **at most ~1000 rows per request** — a server-side `max-rows` cap that `.range(0, N)` does **not** override. Any `.from(table).select(...)` whose query scope can match >1000 rows, then reduces/sums/counts those rows in JS, **silently truncates**: wrong totals, no error. Safe patterns: `count:'exact', head:true` (returns 0 rows, count is accurate), `.single()/.maybeSingle()`, tight `.eq(<unique/small>)` scope, small `.limit(n)`, SQL aggregation via `exec_sql`/`.rpc()`, or an explicit `fetchAll`/`fetchPaged` pagination loop.
+
+Verified row counts (Supabase `tednluwflfhxyucgwigh`, 2026-05-26):
+`xero_transactions` 3.7k total · **FY26 (date≥2025-07-01) = 2321** · since 2024-07-01 = 3674 · **FY26 SPEND = 1991** · last-6-months = **1064** · last-3-months SPEND = 513 · `total<0` rows = **0** (sign filter `.lt('total',0)` returns nothing).
+`xero_invoices` 2.2k total · **active (DRAFT/SUBMITTED/AUTHORISED/PAID) = 2122** · **FY26 (any status) = 1651** · ACCREC (all statuses) = 125 · ACCREC AUTHORISED|PAID since Jul24 = 79 · open ACCREC (AUTHORISED|SENT) = **17**.
+
+---
+
+## HIGH severity — confirmed-wrong totals (>1000 rows in scope, summed/counted in JS, no pagination)
+
+| file:line | table | what it computes | why it truncates | fix |
+|---|---|---|---|---|
+| `app/api/bookkeeping/progress/route.ts:9` & `:16` | xero_transactions / xero_invoices | `totalIncome`, `totalExpenses`, `netPosition`, monthly trend, top contacts, receivables/payables totals — **all-time, no date/limit** | both fetched with only `.order()` (no pagination); txns 3.7k, active invoices 2.1k → caps at 1000 each | add `fetchAll` paginator (pattern already in `finance/audit/route.ts:29`) |
+| `app/api/finance/invoices/route.ts:48` | xero_invoices | `receivableTotal`, `payableTotal`, `paidTotal`, overdue/due-this-week totals + counts | DRAFT/SUBMITTED/AUTHORISED/PAID, no date filter = **2122 rows**, only `.order()` | paginate, or compute totals in SQL |
+| `app/api/finance/founder-pay/route.ts:49` | xero_invoices | FY26 `income`/`expenses` → `fy26Net` | `gte FY26_START, lte FY26_END`, no limit = **1651 rows** | paginate the FY26 invoice fetch |
+| `app/api/finance/accountant-pack/route.ts:61` & `:68` | xero_transactions / xero_invoices | FY26 R&D + coverage totals | `.limit(2000)` is **false safety** — max-rows still caps at 1000; FY26 txn 2321, FY26 inv 1651 | paginate (or `count`+SQL sums) |
+| `app/api/projects/financials/route.ts:10` | xero_transactions | tagging coverage `totalTx`/`taggedTx` via `allTx.length` | `count:'exact', head:false` whole table (3674) but uses the **row array** (`.length`), not the count field → capped at 1000 | use the returned `count` for total; SQL `COUNT(*) FILTER` for tagged |
+| `app/api/reports/profit-loss/route.ts:12` & `:20` | xero_transactions | FY `totalIncome`/`totalExpenses` (income+expense, by contact) | FY-scoped (`gte fyStart`) = 2321 rows current FY, summed | paginate, or SQL `SUM` by type |
+| `app/api/reports/yearly/route.ts:25` | xero_transactions | current-FY income/expenses + monthly + by-source | `gte fyStartStr, lte fyEndStr` = 2321, summed | paginate / SQL (prev-FY query line 32 also FY-scoped → same risk) |
+| `app/api/reports/cash-flow-forecast/route.ts:10` | xero_transactions | `avgMonthlyInflow`/`Outflow` → drives the whole 6-month forecast | last 6 months = **1064 rows** > cap; averages understated | paginate the 6-month window |
+| `app/api/business/overview/route.ts:30` | xero_transactions | FY `fyIncome`/`fyExpenses` (line 95 `rdTxns` FY R&D-by-project too) | `gte fyStartStr` = 2321, summed; rdTxns FY across 6 projects also FY-scoped | paginate the FY queries (month/30-day queries lines 43/56 are bounded — safe) |
+
+**Note on `rd-tracking`:** `app/api/finance/rd-tracking/route.ts:71` (JS fallback) and `:134` (`totalsByProject`) are FY-scoped (`gte '2024-07-01'`, 3674 rows) and summed without pagination — *would* be HIGH, but both filter `.lt('total', 0)` and **there are 0 rows with `total<0`** in the table, so they return empty (no truncation today). This is a latent correctness bug (wrong sign filter — spend is stored as positive `total` with `type='SPEND'`), not a live truncation. Flagging for the sign-bug sweep, not as a row-cap.
+
+---
+
+## MEDIUM — scope realistically near or occasionally over 1000 rows
+
+| file:line | table | what it computes | reasoning |
+|---|---|---|---|
+| `app/api/finance/transactions/route.ts:57` & `:69` | xero_invoices / xero_transactions | explorer rows (`since` default 2024-07-01) via `.range(0, limit-1)`, limit default 5000 cap 10000 | **`.range(0,4999)` false safety** — caps at 1000. Spends+RECEIVE since Jul24 likely >1000 → page silently shows 1000 of more. Display-only (no $ total), but misleads on completeness |
+| `app/api/intelligence/route.ts:237` | xero_invoices | receipt-gap `missing`/`missingValue` over all FY ACCPAY | `gte fyStart` ACCPAY subset of 1651 FY26 invoices; could sit near the cap. ⚠️ open question: exact FY ACCPAY count not measured |
+| `app/api/subscriptions/discover/route.ts:104` & `:162` | xero_transactions | recurrence detection (fallback) + vendor→project map: ALL SPEND, no date filter | only fires if the recurring-RPC errors; all-time SPEND ≈2000 → truncates, dropping detected subscriptions. line 162 always runs |
+| `lib/tools/finance.ts:800` | xero_transactions | `top_untagged_vendors` grouping (ALL untagged, no limit) | headline `untagged`/`total`/`coverage_pct` use `count:head` (accurate); only the vendor-count grouping truncates if untagged >1000 |
+| `lib/tools/finance.ts:844` | xero_transactions | `executeTriggerAutoTag` processes untagged via `.limit(5000)` | false safety — auto-tags only first 1000 untagged per run, silently skips the rest |
+| `app/api/strategy/route.ts:118` | xero_transactions | FY26 SPEND AUTHORISED coverage signals, `.limit(5000)` | false safety; FY26 SPEND=1991, AUTHORISED subset smaller but may exceed 1000 |
+| `app/api/xero/spending-by-project/route.ts:13` | xero_transactions | spend-by-project totals, `?months=` (default 3) | default 3mo = 513 (safe); `?months=12` ≈ all FY26 SPEND (1991) → truncates. Parameter-dependent |
+| `app/api/finance/revenue-model/route.ts:24` | xero_invoices | monthly actual ACCREC since 2024-07-01, summed | ACCREC AUTHORISED|PAID since Jul24 = 79 today → safe now, but unbounded by date; flag as it grows |
+| `app/api/finance/lifetime-ledger/route.ts:40` | xero_invoices | per-customer lifetime paid/outstanding totals (ALL ACCREC) | ACCREC = 125 today → safe now, but "lifetime" + no pagination means it silently truncates once ACCREC passes 1000 |
+
+---
+
+## LOW / note — `.range(0, N≥1000)` or `.limit(N≥1000)` false-safety, currently under cap; or tightly-scoped
+
+- `app/api/finance/projects/[code]/route.ts:506` & `:514` — `xero_invoices`/`xero_transactions` `.range(0,4999)` but `.eq('project_code', X)`; largest project (ACT-GD/ACT-HV) is hundreds, none >1000. Sums per-project — false safety, fine today.
+- `app/api/finance/projects/[code]/transactions/route.ts:71` & `:79` — `.range(0,9999)`, per-`project_code`; same as above.
+- `app/api/finance/vendors/[name]/route.ts:13` & `:21` — `.range(0,999)`, per-`contact_name`; a single vendor with >1000 txns is implausible.
+- `app/api/intelligence/route.ts:213` (`getPipelineSummary`) — `opportunities_unified` `.range(0,4999)` but scoped `.not('project_codes','is',null)` (ACT-linked subset of 15.5k); `total_value`/`weighted_value` truncate only if ACT-linked active opps exceed 1000 (today they don't).
+- `app/api/strategy/route.ts:63` — `opportunities_unified` `.limit(500)` intentional small cap.
+- `app/api/finance/pipeline-review/route.ts:31`, `app/api/pipeline/unified/route.ts:11` — `opportunities_unified .limit(1000)/.limit(500)` — at/under the cap, top-pipeline display.
+- `app/api/harvest/budget/route.ts:30` — `xero_transactions .eq('project_code','ACT-HV')` (~110 rows), summed — safe.
+- `app/api/finance/self-reliance/route.ts:97` — ACCREC FY26 `.limit(500)`, but FY26 ACCREC AUTH|PAID ≈79 — safe.
+
+**Verified SAFE (no change needed):** `lib/finance/ledger.ts` (`getOrgLedger` uses `fetchAllRows`), `finance/audit`, `finance/transactions/reality`, `finance/workbench` (rows via `fetchPaged`, summary via `execSql`), `finance/dext-push-audit` (all via `fetchPaged`), `finance/data-quality` (views), `finance/reconciliation` (count:head), `finance/today-actions`/`rd-tracking` count blocks (count:head), `finance/tax` (BAS-quarter scope, <1000), `finance/weekly-review` (week-window + count:head + open-receivables), `reports/monthly` (single-month), `ecosystem/pulse` (view + 60-day grant window + open receivables), and all `single()`/`maybeSingle()`/`.eq(id)` lookups across contacts/grants/receipts/pipeline/calendar.
+
+---
+
+## Summary
+
+**9 confirmed-wrong totals (HIGH):** `bookkeeping/progress` (income/expense/net + everything), `finance/invoices` (receivables/payables/paid), `finance/founder-pay` (FY26 net), `finance/accountant-pack` (R&D/coverage, `.limit(2000)` false-safety), `projects/financials` (coverage uses `.length` not count), `reports/profit-loss` (FY P&L), `reports/yearly` (FY income/expense), `reports/cash-flow-forecast` (6-month averages, 1064 rows), `business/overview` (FY income/expense + FY R&D).
+
+**Single worst actively-wrong total:** `app/api/bookkeeping/progress/route.ts` — `totalIncome`/`totalExpenses`/`netPosition` sum **all-time** `xero_transactions` (3.7k) and `xero_invoices` (2.1k) with zero pagination; both cap at 1000, so every headline number on that surface is understated by the same class of bug as the production org-`cash_spent` case ($590K vs $975K).
+
+Plus **9 MEDIUM** (parameter/scope/fallback-dependent or growing toward the cap) and **~12 LOW** (`.range/.limit` false-safety currently under cap, or per-entity scoped). The dominant fix is the existing `fetchAll`/`fetchPaged` paginator (see `finance/audit/route.ts:29`) or moving the aggregation into SQL via `exec_sql`.


### PR DESCRIPTION
Row-cap sweep found 9 finance surfaces summing >1000 rows without pagination → silently truncated (same class as org cash_spent $590K-vs-$975K). Adds shared `fetchAllRows()` and routes each through it. Full audit: `thoughts/shared/reviews/command-center-trust-map/F-rowcap-sweep.md`. tsc clean, build passes, output shapes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)