### PR TITLE
feat(finance): P2 — entity dimension + durable bank-balance re-light

### DIFF
--- a/apps/command-center/src/app/api/intelligence/route.ts
+++ b/apps/command-center/src/app/api/intelligence/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import { getFYDates } from '@/lib/finance/dates'
 import { getOrgLedger, getMonthlyPL, getCashPosition, getRdTaxWindow, RD_REFUND_RATE } from '@/lib/finance/ledger'
+import { ACT_ENTITIES, getCutoverStatus } from '@/lib/finance/entities'
 
 /**
  * /company front-door data. Rebuilt 2026-05-26 on the one ledger (lib/finance/ledger.ts).
@@ -56,6 +57,11 @@ export async function GET() {
       timestamp: now.toISOString(),
       fy: `FY${fyStart.slice(2, 4)}-${fyEnd.slice(2, 4)}`,
       data_quality: dataQuality,
+      entity: {
+        current: 'ACT-ST',
+        entities: ACT_ENTITIES,
+        cutover: getCutoverStatus(now),
+      },
       financial: {
         revenue: pl.revenue,
         expenses: pl.expenses,

--- a/apps/command-center/src/app/company/page.tsx
+++ b/apps/command-center/src/app/company/page.tsx
@@ -13,6 +13,11 @@ interface IntelligenceData {
   timestamp: string
   fy: string
   data_quality: Record<string, Wired>
+  entity: {
+    current: string
+    cutover: { cutoverDate: string; daysUntil: number; passed: boolean; message: string }
+    entities: Array<{ code: string; shortName: string; identifier: string; role: string; status: string; tradingNow: boolean }>
+  }
   financial: {
     revenue: number
     expenses: number
@@ -141,7 +146,7 @@ export default function CompanyPage() {
     return <div className="p-8 text-red-400">Failed to load intelligence data</div>
   }
 
-  const { financial: fin, receivables: recv, projects: proj, relationships: rel, pipeline: pipe, receipts: rcpt, rd, activity: act, data_quality: dq } = data
+  const { financial: fin, receivables: recv, projects: proj, relationships: rel, pipeline: pipe, receipts: rcpt, rd, activity: act, data_quality: dq, entity: ent } = data
 
   // Alerts — honest, no fabricated deadlines.
   const alerts: Array<{ severity: 'critical' | 'warning' | 'info'; message: string }> = []
@@ -165,6 +170,18 @@ export default function CompanyPage() {
           Company Overview
         </h1>
         <p className="text-sm text-white/40 mt-1">{data.fy} — {new Date(data.timestamp).toLocaleString('en-AU', { timeZone: 'Australia/Brisbane', dateStyle: 'medium', timeStyle: 'short' })}</p>
+      </div>
+
+      {/* Entity / Pty cutover strip */}
+      <div className={`glass-card p-3 border-l-4 ${ent.cutover.passed ? 'border-red-500/50' : ent.cutover.daysUntil <= 45 ? 'border-amber-500/50' : 'border-white/10'} flex items-center justify-between gap-3 text-xs`}>
+        <div className="text-white/70">
+          <span className="text-white/40">Entity:</span>{' '}
+          {ent.entities.find(e => e.code === ent.current)?.shortName || ent.current} ({ent.current})
+          <span className="text-white/30"> · {ent.cutover.message}</span>
+        </div>
+        <span className={`shrink-0 font-medium ${ent.cutover.passed ? 'text-red-400' : ent.cutover.daysUntil <= 45 ? 'text-amber-400' : 'text-white/50'}`}>
+          {ent.cutover.passed ? 'cutover overdue' : `${ent.cutover.daysUntil}d to Pty cutover`}
+        </span>
       </div>
 
       {broken.length > 0 && (

--- a/apps/command-center/src/lib/finance/entities.ts
+++ b/apps/command-center/src/lib/finance/entities.ts
@@ -1,0 +1,84 @@
+/**
+ * ACT entity registry — the three legal entities money can belong to.
+ *
+ * Today 100% of financial data is ACT-ST (Nic Marchesi sole trader) under one Xero tenant; the Pty
+ * and the charity have no money in the books yet. Multi-entity reporting is therefore a CUTOVER to
+ * prepare for (trading migrates to A Curious Tractor Pty Ltd by 30 Jun 2026), not a backfill. This
+ * registry + the `entityCode` param on the ledger (getOrgLedger) make that migration a data event,
+ * not another rebuild. Source of truth: wiki/decisions/act-core-facts.md.
+ */
+
+export type EntityStatus = 'trading' | 'registered-dormant' | 'dormant'
+
+export interface ActEntity {
+  code: string
+  legalName: string
+  shortName: string
+  /** ABN or ACN. */
+  identifier: string
+  role: string
+  status: EntityStatus
+  /** Does this entity carry ACT's trading money today? */
+  tradingNow: boolean
+  notes: string
+}
+
+export const ACT_ENTITIES: ActEntity[] = [
+  {
+    code: 'ACT-ST',
+    legalName: 'NJ Marchesi, sole trader (trading as A Curious Tractor)',
+    shortName: 'Sole trader',
+    identifier: 'ABN 21 591 780 066',
+    role: 'Current trading vehicle',
+    status: 'trading',
+    tradingNow: true,
+    notes: 'All money in the books today is ACT-ST. Ceases trading at the Pty cutover (by 30 Jun 2026).',
+  },
+  {
+    code: 'ACT-PL',
+    legalName: 'A Curious Tractor Pty Ltd',
+    shortName: 'A Curious Tractor Pty Ltd',
+    identifier: 'ACN 697 347 676',
+    role: 'Future trading company — Knight + Marchesi family trusts 50/50',
+    status: 'registered-dormant',
+    tradingNow: false,
+    notes: 'Registered 2026-04-24. Trading migrates here by 30 Jun 2026. The FY25-26 R&D claim lodges via this entity.',
+  },
+  {
+    code: 'ACT-CH',
+    legalName: 'A Kind Tractor Ltd',
+    shortName: 'A Kind Tractor (charity)',
+    identifier: 'ACN 669 029 341',
+    role: 'Charity — dormant, not DGR',
+    status: 'dormant',
+    tradingNow: false,
+    notes: 'No money in the books. Activation / DGR endorsement is a future strategic decision.',
+  },
+]
+
+/** Trading migrates off the sole trader to A Curious Tractor Pty Ltd by this date. */
+export const PTY_CUTOVER_DATE = '2026-06-30'
+
+export interface CutoverStatus {
+  cutoverDate: string
+  daysUntil: number
+  fromEntity: string
+  toEntity: string
+  passed: boolean
+  message: string
+}
+
+export function getCutoverStatus(now: Date = new Date()): CutoverStatus {
+  const daysUntil = Math.ceil((new Date(PTY_CUTOVER_DATE).getTime() - now.getTime()) / 86400000)
+  const passed = daysUntil < 0
+  return {
+    cutoverDate: PTY_CUTOVER_DATE,
+    daysUntil,
+    fromEntity: 'ACT-ST',
+    toEntity: 'ACT-PL',
+    passed,
+    message: passed
+      ? 'Pty cutover date has passed — confirm trading has migrated to A Curious Tractor Pty Ltd (ACT-PL) and the books are split.'
+      : `Trading on the sole trader (ACT-ST). Migrate to A Curious Tractor Pty Ltd by 30 Jun 2026 — ${daysUntil} days.`,
+  }
+}

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -25,6 +25,11 @@ const cronScripts = [
     cron_restart: '0 3 * * *', // Daily 3am AEST (before daily briefing at 7am)
   },
   {
+    name: 'xero-bank-balances',
+    script: 'scripts/sync-xero-bank-balances.mjs',
+    cron_restart: '0 6 * * *', // Daily 6am AEST — refresh bank closing balances (Reports/BankSummary) BEFORE the 7am briefings + 8:13 daily-pulse. Was manual-only until 2026-05-27, so cash ran ~27d stale ($586K shown vs true ~$130K). Balance-only upsert — no transaction re-tag risk.
+  },
+  {
     name: 'daily-briefing',
     script: 'scripts/daily-briefing.mjs',
     cron_restart: '0 7 * * *', // Daily 7am AEST


### PR DESCRIPTION
**Bank feed:** re-lit stale balances (cash was $586K stale → true ~$130K, runway 5.3mo→1.2mo critical) + scheduled the balance sync daily 6am in PM2 so it stays fresh. **Entity dimension:** `lib/finance/entities.ts` registry (sole trader / Pty / charity) + Pty-cutover countdown on /company. tsc clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)