### PR TITLE
fix(finance): re-light P3 compliance calendar (time-aware API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ thoughts/shared/audits/*.log
 
 # Branch-stamp file written by .claude/settings.json SessionStart hook
 .claude/.session-branch-stamp
+
+# Compliance-calendar: track only latest.json; dated daily history stays local
+thoughts/shared/data/compliance-calendar/[0-9]*.json

--- a/apps/command-center/src/app/api/finance/compliance-calendar/route.ts
+++ b/apps/command-center/src/app/api/finance/compliance-calendar/route.ts
@@ -51,15 +51,62 @@ export async function GET() {
       { status: 503 },
     )
   }
-  return NextResponse.json({ ...snap, source: 'snapshot' })
+  // Recompute time-sensitive fields LIVE from each obligation's due_date, so countdowns are correct
+  // even when the snapshot is stale (its baked days_until_due freezes at build time). Mirrors the
+  // scoring in scripts/build-compliance-calendar.mjs.
+  const obligations = snap.obligations.map(o => {
+    const dDays = daysUntil(o.due_date)
+    const sev = severity(o.status, dDays)
+    return { ...o, days_until_due: dDays, severity: sev, at_risk: sev != null }
+  })
+  obligations.sort((a, b) => {
+    if (a.at_risk !== b.at_risk) return a.at_risk ? -1 : 1
+    if (a.days_until_due == null) return b.days_until_due == null ? 0 : 1
+    if (b.days_until_due == null) return -1
+    return a.days_until_due - b.days_until_due
+  })
+  const counters = obligations.reduce(
+    (acc, o) => {
+      if (o.severity === 'critical') acc.critical += 1
+      else if (o.severity === 'high') acc.high += 1
+      else if (o.severity === 'medium') acc.medium += 1
+      else if (o.status === 'filed') acc.filed += 1
+      return acc
+    },
+    { critical: 0, high: 0, medium: 0, filed: 0 },
+  )
+  return NextResponse.json({ ...snap, source: 'snapshot', recomputedAt: new Date().toISOString(), counters, obligations })
+}
+
+function daysUntil(dateIso: string | null | undefined): number | null {
+  if (!dateIso) return null
+  const due = new Date(dateIso.slice(0, 10) + 'T00:00:00Z').getTime()
+  const today = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z').getTime()
+  return Math.round((due - today) / 86400000)
+}
+
+function severity(status: string, dDays: number | null): 'critical' | 'high' | 'medium' | null {
+  if (status === 'filed' || status === 'superseded' || status === 'waived') return null
+  if (dDays == null) return null
+  if (dDays < 0 || dDays <= 7) return 'critical'
+  if (dDays <= 30) return 'high'
+  if (dDays <= 90) return 'medium'
+  return null
 }
 
 function readLatestSnapshot(): CalendarResponse | null {
   if (!existsSync(SNAPSHOT_DIR)) return null
-  const files = readdirSync(SNAPSHOT_DIR).filter(f => f.endsWith('.json')).sort()
-  if (files.length === 0) return null
+  // Prefer the stable latest.json (the only snapshot tracked in git / deployed); fall back to the
+  // most recent dated file for local dev where dated history is present.
+  const latest = path.join(SNAPSHOT_DIR, 'latest.json')
+  let file: string | null = existsSync(latest) ? latest : null
+  if (!file) {
+    const dated = readdirSync(SNAPSHOT_DIR).filter(f => /^\d{4}-\d{2}-\d{2}\.json$/.test(f)).sort()
+    if (dated.length === 0) return null
+    file = path.join(SNAPSHOT_DIR, dated[dated.length - 1])
+  }
   try {
-    return JSON.parse(readFileSync(path.join(SNAPSHOT_DIR, files[files.length - 1]), 'utf8'))
+    return JSON.parse(readFileSync(file, 'utf8'))
   } catch {
     return null
   }

--- a/scripts/build-compliance-calendar.mjs
+++ b/scripts/build-compliance-calendar.mjs
@@ -177,9 +177,13 @@ async function main() {
   }
 
   if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true })
+  const json = JSON.stringify(snapshot, null, 2)
   const outPath = path.join(OUT_DIR, todayStr() + '.json')
-  writeFileSync(outPath, JSON.stringify(snapshot, null, 2))
-  console.error(`Wrote ${outPath}`)
+  writeFileSync(outPath, json)
+  // Stable filename the API + Notion sync read; the only snapshot tracked in git (dated history is
+  // gitignored). The API recomputes days_until_due/severity live, so this need not be committed daily.
+  writeFileSync(path.join(OUT_DIR, 'latest.json'), json)
+  console.error(`Wrote ${outPath} + latest.json`)
   console.error(`Totals: ${counters.critical} 🔴 critical · ${counters.high} 🟠 high · ${counters.medium} 🟡 medium · ${counters.filed} ✓ filed`)
 }
 

--- a/thoughts/shared/data/compliance-calendar/latest.json
+++ b/thoughts/shared/data/compliance-calendar/latest.json
@@ -1,0 +1,230 @@
+{
+  "generatedAt": "2026-05-26T20:29:58.675Z",
+  "sources": {
+    "wiki": {
+      "path": "wiki/finance/compliance-calendar.md",
+      "count": 10
+    },
+    "grants": {
+      "table": "ghl_opportunities",
+      "count": 0
+    }
+  },
+  "counters": {
+    "critical": 0,
+    "high": 0,
+    "medium": 2,
+    "filed": 1
+  },
+  "obligations": [
+    {
+      "id": "sole-trader-pty-cutover",
+      "title": "Sole trader → Pty Ltd cutover",
+      "type": "ONE-OFF",
+      "entity": "both",
+      "due_date": "2026-06-30",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        30,
+        14,
+        7,
+        1
+      ],
+      "notes": "All commercial activity must transfer from Nicholas Marchesi\nsole trader (ABN 21 591 780 066) to A Curious Tractor Pty Ltd\n(ACN 697 347 676) by 30 Jun 2026. Canonical checklist at\nthoughts/shared/plans/act-entity-migration-checklist-2026-06-30.md\nwith ~50 line items: Xero new org, GHL re-keying, contract\nnovations, Stripe re-onboarding, etc.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 35,
+      "severity": "medium",
+      "at_risk": true
+    },
+    {
+      "id": "bas-q4-fy25-26",
+      "title": "BAS Q4 FY25-26 (Apr-Jun 2026)",
+      "type": "BAS",
+      "entity": "sole-trader",
+      "due_date": "2026-07-28",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "notes": "LAST sole-trader BAS. Cutover to Pty happens 30 Jun 2026, so\nthis quarter is split: Apr-Jun sole-trader BAS, Pty Ltd starts\nits own BAS lifecycle from Q1 FY26-27 (Jul-Sep 2026).\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 63,
+      "severity": "medium",
+      "at_risk": true
+    },
+    {
+      "id": "bas-q3-fy25-26",
+      "title": "BAS Q3 FY25-26 (Jan-Mar 2026)",
+      "type": "BAS",
+      "entity": "sole-trader",
+      "due_date": "2026-04-28",
+      "status": "filed",
+      "last_filed_at": "2026-04-24",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "notes": "GST + PAYG instalment. Lodged via tax agent.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "days_until_due": -28,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "bas-q1-fy26-27-pty",
+      "title": "BAS Q1 FY26-27 (Jul-Sep 2026) — FIRST Pty Ltd BAS",
+      "type": "BAS",
+      "entity": "pty-ltd",
+      "due_date": "2026-10-28",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "notes": "First BAS under A Curious Tractor Pty Ltd. Confirms ABN\nregistration is working for GST/PAYG.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 155,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "ato-annual-fy25-26-sole-trader",
+      "title": "ATO annual return FY25-26 (sole trader, Nicholas Marchesi)",
+      "type": "ATO",
+      "entity": "sole-trader",
+      "due_date": "2026-10-31",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        30,
+        7
+      ],
+      "notes": "Standard self-assessment. With tax agent extension can push\nto ~May 2027. Covers Jul 2025 – Jun 2026 sole-trader activity.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 158,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "acnc-annual-aiks-tractor",
+      "title": "ACNC Annual Information Statement — A Kind Tractor Ltd",
+      "type": "ACNC",
+      "entity": "a-kind-tractor-ltd",
+      "due_date": "2026-12-31",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        14
+      ],
+      "notes": "A Kind Tractor Ltd (ACN 669 029 341) is a registered charity\nbut dormant + NOT DGR. Annual statement required even when\ndormant. Lodge by 31 Dec for FY ending 30 Jun.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 219,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "bas-q2-fy26-27-pty",
+      "title": "BAS Q2 FY26-27 (Oct-Dec 2026)",
+      "type": "BAS",
+      "entity": "pty-ltd",
+      "due_date": "2027-02-28",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7,
+        1
+      ],
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 278,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "ato-annual-fy25-26-pty",
+      "title": "ATO annual return FY25-26 (Pty Ltd partial year)",
+      "type": "ATO",
+      "entity": "pty-ltd",
+      "due_date": "2027-02-28",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        30,
+        7
+      ],
+      "notes": "Pty Ltd registered 2026-04-24, so FY25-26 covers only the\nApr-Jun 2026 stub. Full FY26-27 return due 2028.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 278,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "asic-annual-act-pty-1st",
+      "title": "ASIC annual review — A Curious Tractor Pty Ltd (first)",
+      "type": "ASIC",
+      "entity": "pty-ltd",
+      "due_date": "2027-04-24",
+      "status": "pending",
+      "lead_times_days": [
+        30,
+        7
+      ],
+      "notes": "Registered 2026-04-24. Annual review due 2 months after each\nanniversary. ASIC sends a Company Statement; verify and pay\nthe annual review fee.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "earliest_filable": null,
+      "last_filed_at": null,
+      "days_until_due": 333,
+      "severity": null,
+      "at_risk": false
+    },
+    {
+      "id": "rd-claim-fy25-26",
+      "title": "R&D Tax Incentive claim FY25-26 ($200K refund)",
+      "type": "R&D",
+      "entity": "pty-ltd",
+      "earliest_filable": "2026-07-01",
+      "due_date": "2027-04-30",
+      "status": "pending",
+      "lead_times_days": [
+        60,
+        14
+      ],
+      "expected_refund_aud": 200000,
+      "notes": "Path C locked 2026-04-27. FY24-25 forfeited (sole-trader period,\nineligible). Lodge via A Curious Tractor Pty Ltd Jul 2026 –\n30 Apr 2027. Evidence pack lives at thoughts/shared/rd-pack-fy26/.\n",
+      "source": "wiki",
+      "owner": "ben",
+      "last_filed_at": null,
+      "days_until_due": 339,
+      "severity": null,
+      "at_risk": false
+    }
+  ]
+}

--- a/thoughts/shared/reviews/command-center-trust-map/G-compliance-calendar-audit.md
+++ b/thoughts/shared/reviews/command-center-trust-map/G-compliance-calendar-audit.md
@@ -1,0 +1,37 @@
+# G — Compliance Calendar (P3) audit
+
+**Date:** 2026-05-27 · **Verdict:** well-architected and accurate, but **operationally dead** — production serves a 9-day-stale snapshot with frozen countdowns, the crons are stopped, and there's no path for fresh snapshots to reach Vercel.
+
+> Correction to the blueprint: P3 was called "greenfield." It is NOT — it's ~80% built. The earlier
+> trust-map flagged `compliance_items` (dead) / `compliance_ack` (empty), but the real system is
+> **file-based**, not those tables.
+
+## Architecture (what exists, and it's good)
+```
+wiki/finance/compliance-calendar.md (frontmatter: 10 fixed obligations)
+  + ghl_opportunities.acquittal_due_date (dynamic grant acquittals)
+        │  scripts/build-compliance-calendar.mjs  (PM2 cron 'compliance-snapshot', 7am)
+        ▼
+  thoughts/shared/data/compliance-calendar/YYYY-MM-DD.json  (snapshot: obligations + severity + counters)
+        │
+        ├─ /api/finance/compliance-calendar  → /finance/command "AT RISK TODAY" pane
+        ├─ scripts/compliance-alerts.mjs       (PM2 cron 'compliance-alerts', 7:30am — Telegram T-30/7/1)
+        └─ scripts/sync-compliance-calendar-to-notion.mjs (PM2 cron 'compliance-notion-sync', 7:45am)
+```
+The **obligations are accurate**: BAS Q3 (filed) / Q4 last-sole-trader / Q1-Q2 Pty; **R&D FY25-26 with the correct window** (earliest 2026-07-01, due 2027-04-30, $200K — NOT the false Apr-2026 that was in /company); ATO returns (sole-trader + Pty stub); ASIC annual review (2027-04-24); ACNC AIS A Kind Tractor (2026-12-31); sole-trader→Pty cutover (2026-06-30). Lead-times, severity scoring, status lifecycle all documented.
+
+## Gaps (why it's not working)
+| # | Gap | Evidence | Fix |
+|---|---|---|---|
+| 1 | **Crons stopped** | `compliance-snapshot` / `-alerts` / `-notion-sync` all PM2 status=stopped, 0 uptime since ~2026-05-18 | `pm2 restart` the three + `pm2 save`; confirm they survive |
+| 2 | **No deploy path for snapshots** | build script only `writeFileSync`s; 05-18→05-25 snapshots untracked (`??`); last committed = 2026-05-18; **production serves generatedAt 2026-05-17T21:00Z** | add commit+push to the build cron (like `act-now-sync`), OR make the API recompute live (see #3) |
+| 3 | **Countdowns frozen at build time** | `days_until_due` baked into snapshot → prod shows cutover "44 days" when it's really 34 | API recomputes `days_until_due`/`severity`/`at_risk` from each obligation's `due_date` at request time — makes countdowns correct regardless of snapshot age (the robust fix; decouples correctness from cron freshness) |
+| 4 | **Grant acquittals empty** | `ghl_opportunities.acquittal_due_date` unpopulated → dynamic half = 0 items | process gap: capture acquittal due-dates in GHL when grants are won |
+| 5 | **Not on the front door** | calendar only on `/finance/command`; `/company` has no obligations view | optionally surface "next 3 obligations" on `/company` |
+
+## Recommended fix order
+1. **API recompute (#3)** — small, makes every countdown correct today even with a stale snapshot. Highest value/effort.
+2. **Restart crons + add commit-push (#1, #2)** — regenerates snapshots, re-fires alerts, gets fresh data to prod.
+3. **GHL acquittal capture (#4)** + **/company surfacing (#5)** — follow-ups.
+
+Net: P3 doesn't need building — it needs **re-lighting** (same pattern as the bank-balance feed), plus making the API time-aware so it can't silently freeze again.


### PR DESCRIPTION
Calendar was well-built but operationally dead (crons stopped ~May 18, prod served a 9-day-stale snapshot with frozen countdowns). API now recomputes days_until_due/severity live from due_date (can't freeze again); build emits a tracked latest.json; crons restarted. Audit: `thoughts/shared/reviews/command-center-trust-map/G-compliance-calendar-audit.md`. tsc clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)