### PR TITLE
P3 burn-down: resolve needs-intent schema drift (12→2)

### DIFF
--- a/apps/command-center/src/app/api/agent/insights/route.ts
+++ b/apps/command-center/src/app/api/agent/insights/route.ts
@@ -6,21 +6,22 @@ export async function GET(request: NextRequest) {
   try {
     const limit = parseInt(new URL(request.url).searchParams.get('limit') || '10')
 
-    // Query agent_audit_log for executed/completed actions as "insights"
+    // Surface reviewed/ready agent proposals as "insights" (agent_proposals, not the
+    // request-level agent_audit_log — that table has no status/proposal lifecycle).
     const { data } = await supabase
-      .from('agent_audit_log')
+      .from('agent_proposals')
       .select('*')
-      .in('status', ['executed', 'completed', 'approved'])
+      .in('status', ['approved', 'completed', 'draft_ready'])
       .order('created_at', { ascending: false })
       .limit(limit)
 
     const insights = (data || []).map((row) => ({
       id: row.id,
-      agent_name: row.agent_name || 'system',
-      insight_type: row.action_type === 'alert' ? 'alert' : 'suggestion',
-      title: row.title || row.action_type || 'Agent insight',
+      agent_name: row.agent_id || 'system',
+      insight_type: row.priority === 'high' ? 'alert' : 'suggestion',
+      title: row.title || row.action_name || 'Agent insight',
       description: row.description || row.reasoning || '',
-      data: row.context || row.metadata || null,
+      data: row.proposed_action || row.impact_assessment || null,
       created_at: row.created_at,
     }))
 

--- a/apps/command-center/src/app/api/business/overview/route.ts
+++ b/apps/command-center/src/app/api/business/overview/route.ts
@@ -62,13 +62,11 @@ export async function GET() {
     else if (tx.type === 'SPEND') recentOut += amt
   }
 
-  // Bank balance (latest from Xero or estimate)
-  const { data: latestBalance } = await supabase
-    .from('xero_transactions')
-    .select('bank_account, running_balance')
-    .order('date', { ascending: false })
-    .limit(1)
-    .single()
+  // Bank balance: xero_transactions has no running_balance column and there is no bank-balance
+  // feed table in the shared DB, so there is no source to read a live balance from here. Left null
+  // (downstream handles null → bankBalance/runway null) rather than fabricate one. The CEO bank
+  // position lives on the rebuilt /company page (lib/finance ledger).
+  const latestBalance = null as { running_balance: number | null } | null
 
   // Subscriptions total
   const { data: subs } = await supabase

--- a/apps/command-center/src/app/api/business/upcoming/route.ts
+++ b/apps/command-center/src/app/api/business/upcoming/route.ts
@@ -21,16 +21,15 @@ export async function GET() {
     const deadlines: Deadline[] = []
 
     // 1. GHL opportunities with close dates (grants & opportunities)
-    const { data: opportunities } = await supabase
-      .from('ghl_opportunities')
-      .select('id, name, monetary_value, status, close_date, pipeline_name, stage_name')
-      .eq('status', 'open')
-      .not('close_date', 'is', null)
-      .lte('close_date', thirtyDaysOut.toISOString())
-      .order('close_date', { ascending: true })
-      .limit(15)
+    // ghl_opportunities has no close_date, and acquittal_due_date/received_date are 0% populated
+    // on open opps — there is no opportunity-deadline data to surface. Returns empty until a
+    // close/expected-close date is synced from GHL. (Other deadline sources below still apply.)
+    const opportunities: Array<{
+      id: string; name: string; monetary_value: number; close_date: string
+      pipeline_name: string; stage_name: string
+    }> = []
 
-    for (const opp of opportunities || []) {
+    for (const opp of opportunities) {
       const closeDate = new Date(opp.close_date)
       deadlines.push({
         id: `opp-${opp.id}`,

--- a/apps/command-center/src/app/api/finance/overview/route.ts
+++ b/apps/command-center/src/app/api/finance/overview/route.ts
@@ -13,6 +13,7 @@ import {
   generateNudges,
   type HealthLevel,
 } from '@/lib/finance'
+import { aggregateProjectBudgets } from '@/lib/finance/budgets'
 
 export const dynamic = 'force-dynamic'
 
@@ -46,8 +47,8 @@ async function computeOverview() {
       .limit(200),
     supabase
       .from('project_budgets')
-      .select('project_code, fy, annual_budget, annual_revenue_target')
-      .eq('fy', 'FY26')
+      .select('project_code, budget_type, budget_amount')
+      .eq('fy_year', 'FY26')
       .limit(200),
     supabase
       .from('xero_invoices')
@@ -92,7 +93,7 @@ async function computeOverview() {
 
   const monthlyData = monthlyResult.data || []
   const projects = projectsResult.data || []
-  const budgets = budgetsResult.data || []
+  const budgets = aggregateProjectBudgets(budgetsResult.data || [], 'FY26')
   const receivables = receivablesResult.data || []
   const payables = payablesResult.data || []
   const bankAccounts = bankAccountsResult.data || []

--- a/apps/command-center/src/app/api/finance/projects/route.ts
+++ b/apps/command-center/src/app/api/finance/projects/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
+import { aggregateProjectBudgets } from '@/lib/finance/budgets'
 
 export async function GET() {
   try {
@@ -21,8 +22,8 @@ export async function GET() {
 
       supabase
         .from('project_budgets')
-        .select('project_code, fy, annual_budget, ytd_budget')
-        .eq('fy', 'FY26')
+        .select('project_code, budget_type, budget_amount')
+        .eq('fy_year', 'FY26')
         .limit(200),
 
       supabase
@@ -33,7 +34,7 @@ export async function GET() {
 
     const monthlyData = monthlyResult.data || []
     const projects = projectsResult.data || []
-    const budgets = budgetsResult.data || []
+    const budgets = aggregateProjectBudgets(budgetsResult.data || [], 'FY26')
     const vendorRules = vendorRulesResult.data || []
 
     // Build project lookup

--- a/apps/command-center/src/app/api/proposals/stats/route.ts
+++ b/apps/command-center/src/app/api/proposals/stats/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
 
     for (const s of statuses) {
       const { count } = await supabase
-        .from('agent_audit_log')
+        .from('agent_proposals')
         .select('id', { count: 'exact', head: true })
         .eq('status', s)
       results[s] = count || 0

--- a/apps/command-center/src/app/api/system/usage/route.ts
+++ b/apps/command-center/src/app/api/system/usage/route.ts
@@ -11,8 +11,9 @@ export async function GET(request: Request) {
   since.setDate(since.getDate() - days)
 
   // Fetch raw usage rows
+  // LLM token/cost telemetry lives in llm_usage (api_usage was repurposed to per-key API-request logging)
   const { data: rows, error } = await supabase
-    .from('api_usage')
+    .from('llm_usage')
     .select('model, input_tokens, output_tokens, estimated_cost, input_cost, output_cost, latency_ms, created_at, script_name')
     .gte('created_at', since.toISOString())
     .order('created_at', { ascending: false })

--- a/apps/command-center/src/lib/finance/budgets.ts
+++ b/apps/command-center/src/lib/finance/budgets.ts
@@ -1,0 +1,52 @@
+/**
+ * project_budgets aggregation.
+ *
+ * The `project_budgets` table stores ONE row per (project_code, fy_year, budget_type) with a
+ * `budget_amount` — budget_type ∈ {expense, revenue, grant}. The dashboards want a single row per
+ * project with the budget pivoted by type. Rather than a DB view (which needs a production
+ * migration), aggregate here so routes keep using { annual_budget, annual_revenue_target, ytd_budget }.
+ *
+ *   - annual_budget         = Σ expense
+ *   - annual_revenue_target = Σ (revenue + grant)   — grant income counts toward the revenue target
+ *   - ytd_budget            = annual_budget × monthsElapsed / 12   — month-level rows aren't used yet
+ */
+import { getFYDates } from './dates'
+
+export interface ProjectBudgetRow {
+  project_code: string | null
+  budget_type: string | null
+  budget_amount: number | string | null
+}
+
+export interface AggregatedBudget {
+  project_code: string
+  fy: string
+  annual_budget: number
+  annual_revenue_target: number
+  ytd_budget: number
+}
+
+export function aggregateProjectBudgets(
+  rows: ProjectBudgetRow[],
+  fyYear: string,
+  now: Date = new Date(),
+): AggregatedBudget[] {
+  const { monthsElapsed } = getFYDates(now)
+  const byProject = new Map<string, { expense: number; revenue: number }>()
+  for (const r of rows) {
+    const code = r.project_code
+    if (!code) continue
+    const amt = Number(r.budget_amount) || 0
+    const acc = byProject.get(code) || { expense: 0, revenue: 0 }
+    if (r.budget_type === 'expense') acc.expense += amt
+    else if (r.budget_type === 'revenue' || r.budget_type === 'grant') acc.revenue += amt
+    byProject.set(code, acc)
+  }
+  return [...byProject.entries()].map(([project_code, b]) => ({
+    project_code,
+    fy: fyYear,
+    annual_budget: b.expense,
+    annual_revenue_target: b.revenue,
+    ytd_budget: Math.round((b.expense * monthsElapsed) / 12),
+  }))
+}

--- a/apps/command-center/src/lib/telegram/reactor-callbacks.ts
+++ b/apps/command-center/src/lib/telegram/reactor-callbacks.ts
@@ -193,11 +193,22 @@ async function handleGHLCallback(action: string, entityId: string): Promise<Call
   if (action === 'opp') {
     const { data: opp } = await supabase
       .from('ghl_opportunities')
-      .select('name, pipeline_name, stage_name, monetary_value, contact_name')
+      .select('name, pipeline_name, stage_name, monetary_value, ghl_contact_id')
       .eq('ghl_id', entityId)
       .maybeSingle()
 
     if (!opp) return { toast: 'Opportunity not found' }
+
+    // ghl_opportunities has no contact_name — resolve it from ghl_contacts via ghl_contact_id.
+    let contactName = 'Unknown'
+    if (opp.ghl_contact_id) {
+      const { data: c } = await supabase
+        .from('ghl_contacts')
+        .select('full_name')
+        .eq('ghl_id', opp.ghl_contact_id)
+        .maybeSingle()
+      if (c?.full_name) contactName = c.full_name
+    }
 
     const value = opp.monetary_value
       ? `\nValue: $${Number(opp.monetary_value).toLocaleString('en-AU')}`
@@ -205,7 +216,7 @@ async function handleGHLCallback(action: string, entityId: string): Promise<Call
 
     return {
       toast: 'Loaded opportunity',
-      reply: `${opp.name}\nPipeline: ${opp.pipeline_name}\nStage: ${opp.stage_name}\nContact: ${opp.contact_name || 'Unknown'}${value}`,
+      reply: `${opp.name}\nPipeline: ${opp.pipeline_name}\nStage: ${opp.stage_name}\nContact: ${contactName}${value}`,
     }
   }
 

--- a/apps/command-center/src/lib/tools/finance.ts
+++ b/apps/command-center/src/lib/tools/finance.ts
@@ -228,7 +228,7 @@ export async function executeFindReceipt(input: {
     {
       let rmQuery = supabase
         .from('receipt_matches')
-        .select('vendor_name, amount, transaction_date, status, project_code')
+        .select('vendor_name, amount, transaction_date, status')
         .order('transaction_date', { ascending: false })
         .limit(5)
       if (input.vendor) rmQuery = rmQuery.ilike('vendor_name', `%${input.vendor}%`)
@@ -240,7 +240,7 @@ export async function executeFindReceipt(input: {
       if (rms?.length) {
         results.push(`**Receipt Pipeline (${rms.length}):**`)
         for (const r of rms) {
-          results.push(`  $${r.amount?.toFixed(2)} ${r.vendor_name} [${r.status}] ${r.project_code || ''}`)
+          results.push(`  $${r.amount?.toFixed(2)} ${r.vendor_name} [${r.status}]`)
         }
         totalMatches += rms.length
       }
@@ -444,9 +444,9 @@ export async function executeGetQuarterlyReview(input: { quarter?: string; detai
         .lte('transaction_date', qDates.end),
       supabase
         .from('subscriptions')
-        .select('vendor, name, amount_aud, billing_cycle, category, status, renewal_date, value_rating')
-        .eq('status', 'active')
-        .order('amount_aud', { ascending: false }),
+        .select('vendor:vendor_name, amount_aud:amount, billing_cycle, category, status:account_status, renewal_date:next_billing_date')
+        .eq('account_status', 'active')
+        .order('amount', { ascending: false }),
       supabase
         .from('v_subscription_alerts')
         .select('*')
@@ -577,7 +577,7 @@ export async function executeGetQuarterlyReview(input: { quarter?: string; detai
     }
 
     const topSubCosts = subs.slice(0, 10).map((s) => ({
-      vendor: s.vendor || s.name,
+      vendor: s.vendor,
       monthly_amount: parseFloat(String(s.amount_aud)) || 0,
       category: s.category,
       billing_cycle: s.billing_cycle,

--- a/config/schema-contract-baseline.json
+++ b/config/schema-contract-baseline.json
@@ -1,17 +1,14 @@
 {
   "_doc": "Known schema-contract violations accepted as of the date below. The test fails on any violation NOT in this list. Burn this down (archive dead-table routes, fix drifted columns) until empty, then delete the file for full strictness. Regenerate: node scripts/check-schema-contract.mjs --baseline",
-  "generatedAt": "2026-05-26T23:37:40.450Z",
-  "count": 12,
+  "generatedAt": "2026-05-27T00:26:40.796Z",
+  "count": 9,
   "accepted": [
     "apps/command-center/src/app/api/agent/insights/route.ts::agent_audit_log::created_at,status",
     "apps/command-center/src/app/api/business/overview/route.ts::xero_transactions::running_balance",
     "apps/command-center/src/app/api/business/upcoming/route.ts::ghl_opportunities::close_date",
     "apps/command-center/src/app/api/contacts/[id]/link-project/route.ts::contact_project_links::ghl_contact_id",
-    "apps/command-center/src/app/api/finance/overview/route.ts::project_budgets::annual_budget,annual_revenue_target,fy",
-    "apps/command-center/src/app/api/finance/projects/route.ts::project_budgets::annual_budget,fy,ytd_budget",
     "apps/command-center/src/app/api/intelligence/actions/route.ts::contact_project_links::ghl_contact_id",
     "apps/command-center/src/app/api/proposals/stats/route.ts::agent_audit_log::status",
-    "apps/command-center/src/app/api/system/usage/route.ts::api_usage::estimated_cost,input_cost,input_tokens,latency_ms,model,output_cost,output_tokens,script_name",
     "apps/command-center/src/lib/telegram/reactor-callbacks.ts::ghl_opportunities::contact_name",
     "apps/command-center/src/lib/tools/finance.ts::receipt_matches::project_code",
     "apps/command-center/src/lib/tools/finance.ts::subscriptions::amount_aud,name,renewal_date,status,value_rating,vendor"

--- a/config/schema-contract-baseline.json
+++ b/config/schema-contract-baseline.json
@@ -1,16 +1,9 @@
 {
   "_doc": "Known schema-contract violations accepted as of the date below. The test fails on any violation NOT in this list. Burn this down (archive dead-table routes, fix drifted columns) until empty, then delete the file for full strictness. Regenerate: node scripts/check-schema-contract.mjs --baseline",
-  "generatedAt": "2026-05-27T00:26:40.796Z",
-  "count": 9,
+  "generatedAt": "2026-05-27T00:33:53.112Z",
+  "count": 2,
   "accepted": [
-    "apps/command-center/src/app/api/agent/insights/route.ts::agent_audit_log::created_at,status",
-    "apps/command-center/src/app/api/business/overview/route.ts::xero_transactions::running_balance",
-    "apps/command-center/src/app/api/business/upcoming/route.ts::ghl_opportunities::close_date",
     "apps/command-center/src/app/api/contacts/[id]/link-project/route.ts::contact_project_links::ghl_contact_id",
-    "apps/command-center/src/app/api/intelligence/actions/route.ts::contact_project_links::ghl_contact_id",
-    "apps/command-center/src/app/api/proposals/stats/route.ts::agent_audit_log::status",
-    "apps/command-center/src/lib/telegram/reactor-callbacks.ts::ghl_opportunities::contact_name",
-    "apps/command-center/src/lib/tools/finance.ts::receipt_matches::project_code",
-    "apps/command-center/src/lib/tools/finance.ts::subscriptions::amount_aud,name,renewal_date,status,value_rating,vendor"
+    "apps/command-center/src/app/api/intelligence/actions/route.ts::contact_project_links::ghl_contact_id"
   ]
 }

--- a/thoughts/shared/plans/2026-05-27-command-center-p3-honest-by-construction.md
+++ b/thoughts/shared/plans/2026-05-27-command-center-p3-honest-by-construction.md
@@ -193,6 +193,36 @@ ghl_opportunities close_date/contact_name joins, subscriptions name/value_rating
 running_balance, receipt_matches project_code, contact_project_links entity_id join). Commits local,
 unpushed (now 11 on the branch).
 
+### 2026-05-27 — Needs-intent burn-down, baseline 12 → 2 (real fixes, not guesses)
+**Objective:** Work through the needs-intent violations with correct fixes (investigate schema +
+usage + data first).
+**Fixed (10 violations across 9 files):**
+- **api_usage** (system/usage) → re-point to `llm_usage` (LLM telemetry moved there; api_usage is now
+  per-key request logging). All 9 columns matched. 1373 rows / $2.63 30d.
+- **project_budgets** (finance/overview + finance/projects) → new `lib/finance/budgets.ts`
+  `aggregateProjectBudgets()` pivots the per-budget_type rows (expense→annual_budget,
+  revenue+grant→annual_revenue_target, expense×monthsElapsed/12→ytd_budget). Verified ACT-PI $1.2M etc.
+- **agent_audit_log** (agent/insights + proposals/stats) → re-point to `agent_proposals` (the real
+  proposal-lifecycle table with status/created_at). Insights surfaces approved/completed/draft_ready;
+  stats counts real statuses (pending 321).
+- **business/overview** running_balance → null (no bank-balance feed exists; route handles null).
+- **business/upcoming** close_date → opportunity-deadline source returns empty (no close_date col,
+  acquittal/received dates 0% populated on open opps).
+- **reactor-callbacks** contact_name → resolved from ghl_contacts via ghl_contact_id.
+- **receipt_matches** project_code → dropped (no such column; was always-empty display).
+- **subscriptions** (finance.ts) → aliased vendor/amount_aud/status/renewal_date to real columns,
+  dropped unused name/value_rating.
+**Verified:** tsc clean (tsc caught 3 of my edits — `null`→`never` narrowing + 2 downstream reads of
+dropped fields — all fixed); 20/20 tests; every fix checked against live DB.
+**Deferred (the final 2 — genuine data-model decision, NOT guess-safe):** `contact_project_links`
+`ghl_contact_id` (link-project write + intelligence/actions read). The table keys on `entity_id` =
+canonical entity (sampled UUIDs don't match ghl_contacts by id/ghl_id; 1584/2281 contacts have a
+canonical_entity_id). Reconciling needs: (a) a canonical-entity join on the read, (b) on the write,
+resolve ghl-contact→canonical_entity_id + the correct `onConflict` unique constraint. Wrong guess =
+bad contact↔project links. Needs Ben's call: add `ghl_contact_id` to the table, or wire the
+canonical-entity mapping. **Baseline 12 → 2.**
+**Cumulative P3 result: schema-contract baseline 87 → 2.**
+
 ---
 
 ## Provenance


### PR DESCRIPTION
Follow-up to #94/#95. Works through the **needs-intent** schema-contract violations with real fixes (investigated schema + usage + live data first — no guessing). Baseline **12 → 2**; cumulative P3 result **87 → 2**.

## Fixed (10 violations, 9 files)
- **api_usage → llm_usage** (system/usage): LLM token/cost telemetry moved tables; api_usage is now per-key request logging. All 9 columns matched (1373 rows, $2.63/30d).
- **project_budgets** (finance/overview + finance/projects): new `lib/finance/budgets.ts#aggregateProjectBudgets` pivots the per-`budget_type` rows → `annual_budget` (expense), `annual_revenue_target` (revenue+grant), `ytd_budget` (expense × monthsElapsed/12). Verified ACT-PI $1.2M etc.
- **agent_audit_log → agent_proposals** (agent/insights + proposals/stats): the real proposal-lifecycle table with `status`/`created_at` (agent_audit_log is request logging). Insights = approved/completed/draft_ready; stats counts real statuses (pending 321).
- **business/overview** `running_balance` → null (no bank-balance feed table; route handles null; real CEO balance is `/company`).
- **business/upcoming** `close_date` → empty opportunity-deadline source (no close_date col; acquittal/received dates 0% populated). Other deadline sources unaffected.
- **reactor-callbacks** `contact_name` → resolved from `ghl_contacts` via `ghl_contact_id`.
- **receipt_matches** `project_code` → dropped (no such column).
- **subscriptions** (finance.ts) → aliased `vendor`/`amount_aud`/`status`/`renewal_date` to real columns; dropped unused `name`/`value_rating`.

## Verified
`npx tsc --noEmit` clean (tsc caught 3 of my edits mid-way — a `null`→`never` narrowing and 2 downstream reads of dropped fields — all fixed) · 20/20 tests · every fix checked against the live DB.

## Deferred (the final 2 — a data-model decision, not guess-safe)
`contact_project_links.ghl_contact_id` (link-project write + intelligence/actions read). The table keys on `entity_id` = canonical entity (sampled UUIDs don't match ghl_contacts; 1584/2281 contacts have a canonical_entity_id). The **write** path especially needs the right canonical-entity mapping + `onConflict` constraint — a wrong guess writes bad contact↔project links. Needs a call: add `ghl_contact_id` to the table, or wire the canonical-entity join.

Plan: command-center-p3-honest-by-construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)