### PR TITLE
Phase-4 prep: re-light relationship_health cron + pipeline-consolidation plan

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -667,6 +667,12 @@ const cronScripts = [
     cron_restart: '0 18 * * 5', // Friday 6pm AEST
   },
   {
+    name: 'relationship-health',
+    script: 'scripts/relationship-health.mjs',
+    args: 'update',
+    cron_restart: '15 3 * * *', // Daily 3:15am AEST — recompute relationship scores. The populator was never scheduled (only the Fri consumer was), so relationship_health froze ~4 weeks (last Apr 29) until re-lit 2026-05-27. Feeds the 7 /relationships + intelligence routes + the Fri review.
+  },
+  {
     name: 'project-intelligence',
     script: 'scripts/generate-project-intelligence-snapshots.mjs',
     cron_restart: '0 6 * * *', // Daily 6am AEST (before daily-briefing at 7am)

--- a/scripts/tag-goods-revenue-invoices.py
+++ b/scripts/tag-goods-revenue-invoices.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+Tag Goods revenue invoices with the canonical 'ACT-GD — Goods' Project Tracking option.
+
+WHY: Goods revenue in Xero is split/under-tagged — some invoices carry the archived
+legacy option 'Goods.', some carry no Project Tracking at all. This consolidates them
+onto the active 'ACT-GD — Goods' option so the project P&L is correct.
+See: thoughts/shared/finance/2026-05-27-goods-xero-project-tagging-cleanup.md
+
+USAGE:
+  python3 scripts/tag-goods-revenue-invoices.py            # DRY RUN (default): GET + report, no writes
+  python3 scripts/tag-goods-revenue-invoices.py --apply    # WRITE to live Xero
+
+PRE-REQS:
+  - Fresh token: `node scripts/sync-xero-tokens.mjs` first (access tokens last 30 min)
+  - Run from the act-global-infrastructure root (reads .xero-tokens.json + .env.local)
+
+CAVEATS:
+  - Candidates are paid/authorised ACCREC invoices the mirror tags ACT-GD. Xero MAY
+    reject line-item edits on PAID invoices via API; --apply reports per-invoice success/fail.
+  - Tagging fixes PROJECT attribution only. Some grant lines may be coded to non-income
+    accounts (deferred), which is a separate bookkeeper classification question.
+  - Conflicts on OTHER live projects are never auto-changed (only 'Goods.' -> canonical).
+"""
+import os, json, sys, time, urllib.request, urllib.parse, urllib.error
+
+D = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOK = json.load(open(os.path.join(D, ".xero-tokens.json")))["access_token"]
+def env(k): return [l.split("=",1)[1].strip().strip('"') for l in open(os.path.join(D,".env.local")) if l.startswith(k+"=")][0]
+TENANT = env("XERO_TENANT_ID"); SB_KEY = env("SUPABASE_SERVICE_ROLE_KEY")
+H = {"Authorization":"Bearer "+TOK, "Xero-tenant-id":TENANT, "Accept":"application/json"}
+CAT = "1a1ad7c5-249a-4b1f-842d-06ba2a63a0fe"        # Project Tracking category
+CANON = "ACT-GD — Goods"                             # canonical option (active)
+LEGACY = {"Goods.", "Goods"}                         # archived legacy option(s) to migrate
+APPLY = "--apply" in sys.argv
+
+def sb_get(p): return json.load(urllib.request.urlopen(urllib.request.Request(f"https://tednluwflfhxyucgwigh.supabase.co/rest/v1/{p}", headers={"apikey":SB_KEY,"Authorization":"Bearer "+SB_KEY})))
+def xget(p): return json.load(urllib.request.urlopen(urllib.request.Request("https://api.xero.com/api.xro/2.0/"+p, headers=H)))
+def proj_opt(line):
+    for t in (line.get("Tracking") or []):
+        if t.get("Name") == "Project Tracking": return t.get("Option")
+    return None
+
+cand = sb_get("xero_invoices?select=invoice_number,xero_id,contact_name,status,total,income_type"
+              "&type=eq.ACCREC&project_code=eq.ACT-GD&status=in.(AUTHORISED,PAID)&order=contact_name")
+print(f"Candidate Goods revenue invoices (mirror ACT-GD, ACCREC, live): {len(cand)}  mode={'APPLY' if APPLY else 'DRY RUN'}\n")
+
+work = []
+for c in cand:
+    try:
+        inv = xget(f"Invoices/{c['xero_id']}")["Invoices"][0]
+    except urllib.error.HTTPError as e:
+        print(f"  ! {c['invoice_number']} GET {e.code}"); continue
+    add = migrate = already = other = 0
+    for li in inv.get("LineItems", []):
+        opt = proj_opt(li)
+        if opt == CANON: already += 1
+        elif opt is None: add += 1
+        elif opt in LEGACY: migrate += 1
+        else: other += 1
+    acts = []
+    if add: acts.append(f"ADD {add}")
+    if migrate: acts.append(f"MIGRATE 'Goods.' {migrate}")
+    if already: acts.append(f"ok {already}")
+    if other: acts.append(f"OTHER-PROJECT {other} (left alone)")
+    print(f"  {inv.get('InvoiceNumber','?'):10} {(c['contact_name'] or '')[:26]:26} {inv.get('Status'):10} ${float(inv.get('Total') or 0):>9,.0f} it={c.get('income_type') or 'null':6} | {', '.join(acts)}")
+    if add or migrate:
+        work.append((c, inv))
+    time.sleep(1.1)
+
+print(f"\nWORKLIST: {len(work)} invoices need ADD and/or MIGRATE. 'OTHER-PROJECT' lines are never touched.")
+if not APPLY:
+    print("DRY RUN — nothing written. Re-run with --apply (after approval + fresh token) to write.")
+    sys.exit(0)
+
+print("\nAPPLYING to LIVE Xero...")
+ok = fail = 0
+for c, inv in work:
+    lines = []
+    for li in inv.get("LineItems", []):
+        nl = {k: li[k] for k in ("LineItemID","Description","Quantity","UnitAmount","AccountCode","TaxType","ItemCode","DiscountRate") if li.get(k) is not None}
+        tr = [t for t in (li.get("Tracking") or []) if not (t.get("Name")=="Project Tracking" and t.get("Option") in LEGACY)]
+        if not any(t.get("Name")=="Project Tracking" for t in tr):
+            tr.append({"TrackingCategoryID": CAT, "Name": "Project Tracking", "Option": CANON})
+        nl["Tracking"] = tr
+        lines.append(nl)
+    body = {"Invoices": [{"InvoiceID": inv["InvoiceID"], "LineItems": lines}]}
+    req = urllib.request.Request("https://api.xero.com/api.xro/2.0/Invoices", data=json.dumps(body).encode(), method="POST", headers={**H, "Content-Type":"application/json"})
+    try:
+        urllib.request.urlopen(req); ok += 1; print(f"  ok   {inv.get('InvoiceNumber')}")
+    except urllib.error.HTTPError as e:
+        fail += 1; print(f"  FAIL {inv.get('InvoiceNumber')} {e.code}: {e.read().decode()[:160]}")
+    time.sleep(1.1)
+print(f"\nDone. tagged {ok}, failed {fail}.")

--- a/thoughts/shared/finance/2026-05-27-goods-xero-project-tagging-cleanup.md
+++ b/thoughts/shared/finance/2026-05-27-goods-xero-project-tagging-cleanup.md
@@ -1,0 +1,97 @@
+# Ticket: Xero `project_code` derivation overrides real line tracking (Goods + cross-project)
+
+- **Date raised:** 2026-05-27
+- **Source:** Goods funder-figure reconciliation (Goods Asset Register repo) against ACT global Supabase (`tednluwflfhxyucgwigh`)
+- **Owner:** act-infra / Xero sync
+- **Priority:** High (funder reporting depends on it)
+
+## Summary
+`xero_invoices.project_code` (and `xero_transactions.project_code`) is a **derived** field set by competing heuristics recorded in `project_code_source`: `xero_tracking`, `vendor_rule`, `tracking_match`, `keyword_match`. A weaker heuristic can **override the actual Xero line-item Project Tracking**, so project-level financial rollups are unreliable. This surfaced while reconciling Goods funder figures.
+
+## Evidence
+- **INV-0303 (Homeland School Company):** all 4 tracked line items are `ACT-GD — Goods` in Xero (TrackingOptionID `63aee6ea-0005-48b8-8019-5fe9666ead29`), but the mirror has `project_code = ACT-JH` with `project_code_source = keyword_match`. A keyword heuristic overrode correct line tracking. (The invoice is genuinely Goods: 65 beds + washers, Maningrida, $44,000 AUTHORISED, due 30 Jun 2026.)
+- **Goods ACCREC mismatch:** by `project_code = ACT-GD` there are **29** invoices / **$649,711** paid; by line-item Project Tracking `ACT-GD — Goods` there are **7** invoices / **$237,150** paid. The large grant invoices (Snow, Centrecorp, VFFF) are `project_code = ACT-GD` but are NOT line-tagged Goods; INV-0303 is line-tagged Goods but mis-derived. **Neither method alone is authoritative.**
+- Other mis-derivations seen: INV-0327 (The John Villiers Trust) line-tagged Goods but `project_code = ACT-CORE` (`tracking_match`); INV-0317 (PICC) `project_code = ACT-PI` (`vendor_rule`).
+
+## Impact
+- Goods funder/revenue figures do not reconcile. Downstream consumers: Goods Enterprise HQ dashboard (Notion), `v2/src/lib/data/grant-content.ts`, Funder Reporting pages.
+- Any project P&L or funder rollup keyed on `project_code` inherits the error.
+
+## Root cause
+Derivation precedence lets weaker heuristics (`keyword_match`) win over the strongest signal (Xero line-item Project Tracking). Relevant code:
+- `scripts/sync-xero-to-supabase.mjs` (sets `project_code_source = 'xero_tracking'`, ~L808)
+- `scripts/tag-transactions-by-vendor.mjs` (sets `vendor_rule` ~L263, `tracking_match` ~L272)
+- `scripts/lib/project-code-resolver.mjs`
+- `vendor_project_rules` table
+
+## Recommended fixes
+1. **Precedence:** line-item Project Tracking (`xero_tracking`) must always win. Suggested order: `xero_tracking` > `manual` > `vendor_rule` > `keyword_match`. Never let `keyword_match` override an explicit line tracking option.
+2. **Backfill:** re-derive `project_code` for every invoice/transaction that has line-item Project Tracking; set `project_code_source = 'xero_tracking'`. This alone fixes INV-0303 and likely others.
+3. **Vendor rule:** add `Homeland School Company -> ACT-GD` to `vendor_project_rules`; audit the keyword rule that matched JusticeHub.
+4. **Data-quality guard:** flag rows where derived `project_code` disagrees with the line-item Project Tracking option, for review.
+5. Optionally expose `project_code_from_tracking` on the row so consumers can prefer the line-tracking truth directly.
+
+## Live Xero finding (2026-05-27): revenue is untagged at source
+A live Xero P&L by the `ACT-GD — Goods` tracking option shows: **FY26 = $53,991 income (all "Other Revenue") + $355,246 expenses; FY24 and FY25 = $0 tagged.** Expenses are well-categorised and tagged; **revenue is essentially untagged.**
+
+This means fix #1 (precedence: prefer line tracking) is necessary but **not sufficient for revenue** — there is no Goods line tracking on the grant/sales invoices to prefer. The underlying Xero invoices (Snow, Centrecorp, VFFF, Homeland, Rotary, QIC, and the commercial buyers) must be **tagged** with the `ACT-GD — Goods` Project Tracking option before any project-tracking-based Goods revenue total is correct. Until then, Goods revenue can only be attributed at the **contact level** (which is what the verified funder figures do). Recommend a one-off bulk tagging pass over Goods revenue invoices (dry-run first), then the derivation precedence keeps it clean going forward.
+
+## Manual tagging worklist (dry-run 2026-05-27)
+Script: `scripts/tag-goods-revenue-invoices.py` (dry-run by default; `--apply` writes to live Xero; run `node scripts/sync-xero-tokens.mjs` first for a fresh token). 17 live Goods revenue invoices (ACCREC, mirror `project_code = ACT-GD`). Goal: set Project Tracking = `ACT-GD — Goods` on every revenue line.
+
+**To tag manually in Xero:** open the invoice, Edit, set the "Project Tracking" column to `ACT-GD — Goods` on each line, Approve/Save. The UI allows tracking edits on paid invoices.
+
+### ADD canonical tag (lines currently have NO Project Tracking) — 12 invoices, all PAID
+- INV-0259 Centrecorp $37,620 (2 lines)
+- INV-0291 Centrecorp $85,712 (2 lines)
+- INV-0253 Vincent Fairfax (VFFF) $50,000 (1 line)
+- INV-0220 Snow $1,285 (2 lines)
+- INV-0240 Snow $16,600 (5 lines)
+- INV-0258 Snow $5,545 (3 lines)
+- INV-0321 Snow $132,000 (2 lines, FY26 Scale-Up)
+- INV-0282 Julalikari $19,800 (3 lines)
+- INV-0283 Mala'la $5,434 (2 lines)
+- INV-0260 Our Community Shed $13,500 (1 line)
+- INV-0308 Our Community Shed $6,765 (2 lines)
+- INV-0232 QIC $12,000 (2 lines)
+
+### MIGRATE archived `Goods.` -> `ACT-GD — Goods` — 5 invoices
+- INV-0208 Snow $27,500 (1 line on `Goods.`)
+- INV-0227 Snow $110,000 (4 lines on `Goods.` + 1 to ADD)
+- INV-0268 Snow $110,000 (1 line on `Goods.`)
+- INV-0255 Red Dust $15,950 (1 line `Goods.` + 1 to ADD)
+- INV-0222 Rotary $82,500 (2 lines `Goods.` + 1 to ADD; AUTHORISED, the rest are PAID)
+
+### Already correct (no action)
+- INV-0303 Homeland School ($44K, AUTHORISED) — line-tagged `ACT-GD — Goods` already; mirror only mis-derives it to ACT-JH.
+- INV-0327 The John Villiers Trust ($1,200) — already line-tagged Goods.
+
+### Notes
+- `Goods.` is an ARCHIVED Project Tracking option (`84297961-be6e-48a7-82f3-18484a287ca3`); `ACT-GD — Goods` is the active one (`63aee6ea-0005-48b8-8019-5fe9666ead29`).
+- All ADD targets are PAID; API edits on paid invoices may bounce, but the Xero UI handles tracking edits fine.
+- Some grant lines (e.g. Snow INV-0268 $110K) may be coded to a non-income account; tagging fixes project attribution, not income classification (bookkeeper to confirm).
+- After tagging, the Goods P&L by `ACT-GD — Goods` should reconcile toward the contact-level funder figures (Snow $402,930 etc.).
+
+## Related: `project_funding_allocations` / `project_funding_drawdowns` carry the same voided-invoice defect
+Goods funding drawdowns were auto-backfilled 2026-05-21 (`source = xero_invoice_auto`) from Xero invoices **without excluding VOIDED/DELETED**:
+- **Centrecorp** allocation `committed_amount = 832,832` (drawing), 12 drawdowns = $832,832 "drawn" — but only INV-0259 ($37,620) + INV-0291 ($85,712) = **$123,332** are real; the other 10 are voided/deleted. Real position: $123,332 received, ~$265K re-pitched as quotes, $420K relationship commitment.
+- **Rotary** allocation status `closed` with $0 drawn, but INV-0222 ($82,500) is AUTHORISED/unpaid = an open receivable, not closed.
+- **Snow** committed $395K (ex-GST grant) / 6 drawdowns = $395K — reconciles to the grant agreement; note it is ex-GST and differs from the inc-GST cash received ($402,930).
+- **Not in Supabase** (tracked in Notion Grants & Capital Pipeline): QIC $12K, Homeland $44K, and most pipeline funders. Minderoo ($900K proposed) IS in Supabase.
+
+### Fix
+1. Drawdown backfill/sync must exclude VOIDED/DELETED/DRAFT (count only paid/authorised).
+2. Clean the existing 10 voided Centrecorp drawdown records (or re-run a corrected backfill).
+3. Set Centrecorp `committed_amount` to the relationship commitment ($420K), not the sum of invoices incl. voided.
+4. Correct the Rotary allocation status (open/awaiting, not closed).
+
+## Reproduce
+For all `type = ACCREC` invoices, compare the set where `project_code = 'ACT-GD'` against the set where any line item has Project Tracking option containing "Goods". They differ: 29 vs 7 invoices. Spot-check INV-0303 — `line_items[].tracking[].Option` is all `ACT-GD — Goods` while `project_code = ACT-JH`.
+
+## Acceptance criteria
+- INV-0303 `project_code = ACT-GD` (`source = xero_tracking`).
+- The Goods ACCREC set by `project_code` matches the line-tracking set, except grant invoices that have no line-level Project Tracking (handled by an explicit, documented rule).
+- Precedence documented in `project-code-resolver.mjs`.
+
+## Note for Goods side (already handled)
+The Goods repo's `grant-content.ts` / Enterprise HQ tracking already treats INV-0303 as Goods and flags the mirror discrepancy. No Goods-side change is blocked by this ticket; it is a data-quality fix for accurate, auditable funder reporting.

--- a/thoughts/shared/plans/2026-05-27-pipeline-consolidation.md
+++ b/thoughts/shared/plans/2026-05-27-pipeline-consolidation.md
@@ -1,0 +1,105 @@
+# Plan: Pipeline consolidation — retire/re-light the legacy pipeline tables (blueprint Phase 4)
+
+> Slug: `pipeline-consolidation`
+> Created: 2026-05-27
+> Status: draft — awaiting Ben's decisions (marked ⬜ below)
+> Owner: Ben + Claude
+> Parent: `thoughts/shared/plans/2026-05-26-act-operating-picture-blueprint.md` §6 Phase 4
+
+## Objective
+
+Blueprint Phase 4 says "retire `relationship_pipeline`/`fundraising_pipeline` → `opportunities_unified`."
+Investigation shows the two legacy tables are in **different situations**, and the naive "merge both into
+opportunities_unified" is only half-right. This plan documents what's actually true and the decisions
+needed before any code moves — because two of the 11 affected routes are **money surfaces**
+(`/finance/runway`, `/business/scoreboard`) where a wrong column mapping = wrong numbers, and the
+schema-contract checker can't catch a semantic mis-map (the columns all exist).
+
+## What's actually true (verified 2026-05-27 against the live shared DB)
+
+**`opportunities_unified` is the canonical, fresh, aggregated READ-model** — 15,549 rows, updated daily by
+`scripts/sync-opportunities-to-unified-pipeline.mjs`. It pulls from 6+ sources:
+
+| source_system / type | rows |
+|---|---|
+| grant_opportunities / grant | 14,326 |
+| grantscope / grant | 685 |
+| ghl_opportunities / deal | 500 |
+| manual / deal+grant+revenue | 21 |
+| **fundraising_pipeline** / donation+grant | **14** |
+| xero / deal | 2 |
+
+**`fundraising_pipeline`** (14 rows, frozen 2026-03-06) — a manual WRITE-model that **already feeds
+opportunities_unified** (its 14 rows are in there as `source_system='fundraising_pipeline'`). So it is
+*not* abandoned-dead; it's a low-volume, stale input. The active funding pipeline today is GHL
+(`ghl_opportunities`, 500 rows in opps_unified).
+
+**`relationship_pipeline`** (1,170 rows, frozen 2026-03-12) — a **different domain**: a relationship-CRM
+kanban with `love_score / money_score / strategic_score / urgency_score / color / next_action`. It is
+**NOT a source of opportunities_unified** and `opportunities_unified` has no score columns. Merging it
+into opportunities would lose its whole reason for existing. This is a "retire the feature or re-light
+its populator" decision, **not** a consolidation.
+
+## Decisions needed (⬜ = needs Ben)
+
+- ⬜ **D1 — fundraising reads → opportunities_unified?** The 6 read routes (below) could read
+  `opportunities_unified` filtered to `source_system='fundraising_pipeline'` (or `opportunity_type IN
+  ('donation','grant','fundraising')`) instead of the raw table, for one canonical pipeline. But the data
+  is 14 stale rows; low payoff. **Recommendation:** yes for consistency, but low priority — do it only as
+  part of a broader "all pipeline reads go through opportunities_unified" pass.
+- ⬜ **D2 — fundraising WRITE model.** `/api/opportunities` + `/api/opportunities/update` are the CRUD for
+  `fundraising_pipeline` (writes then sync to opps_unified). Keep `fundraising_pipeline` as the write-model
+  (recommended — opps_unified is derived, never write to it directly), or migrate fundraising CRUD onto
+  GHL/another store. **Recommendation:** keep as write-model; don't break it.
+- ⬜ **D3 — relationship_pipeline / the `/pipeline` kanban.** Retire the relationship-kanban feature
+  (5 route refs + the `/pipeline` page), OR re-light its populator so the scores refresh. Need to know:
+  is the relationship-kanban still used, or superseded by the `/relationships/*` pages + GHL? **No
+  recommendation without that answer** — it's a product call.
+- ⬜ **D4 — relationship_health** (tracked in trust-map §H, related): recompute (add the unscheduled
+  `relationship-health.mjs update` to PM2 — cheap) vs retire. **Recommendation: recompute.**
+
+## Per-route migration map (the 11 refs)
+
+### fundraising_pipeline (6 refs) — if D1 = yes, repoint reads to opportunities_unified
+opps_unified mapping: `name→title`, `funder→contact_name`, `amount→value_mid`, `status→stage`,
+`probability→probability`, `expected_date→expected_close`, `actual_date→actual_close`,
+`deadline→metadata`, `project_codes→project_codes`, `contact_id→contact_ids[]`, filter
+`source_system='fundraising_pipeline'`.
+
+| Route | Select today | Surface | Action |
+|---|---|---|---|
+| `app/api/opportunities/route.ts:52` | full (`id,name,funder,type,amount,status,probability,expected_date,deadline,project_codes,created_at,contact_id`) | opportunities list | read → opps_unified (or keep raw as the write-model's own list) |
+| `app/api/opportunities/update/route.ts:123` | **WRITE** | CRUD | **keep `fundraising_pipeline`** (write-model, D2) |
+| `app/api/projects/[code]/financials/route.ts:141` | `name,amount,status,project_codes` | project financials | read → opps_unified (⚠️ money surface — verify amount→value_mid) |
+| `app/api/business/scoreboard/route.ts:26` | `*` | **exec scoreboard (money)** | read → opps_unified (⚠️ verify all fields used) |
+| `app/api/finance/runway/route.ts:65` | `name,amount,status,project_codes` | **runway (money)** | read → opps_unified (⚠️ verify amount→value_mid) |
+| `lib/tools/projects.ts:201` | `name,deadline,expected_date,status,project_codes` | bot project tool | read → opps_unified |
+
+### relationship_pipeline (5 refs) — blocked on D3 (retire vs re-light)
+| Route | Action (if RETIRE) | Action (if RE-LIGHT) |
+|---|---|---|
+| `app/api/pipeline/route.ts:13,64` | archive route + `/pipeline` page | re-light populator; no code change |
+| `app/api/pipeline/[id]/route.ts:15,36` | archive | no change |
+| `app/api/pipeline/search/route.ts:46` | drop the rel-pipeline source from search | no change |
+
+## Risks
+- **Money surfaces (runway, scoreboard, project financials):** `amount` (single number) → opps_unified has
+  `value_low/value_mid/value_high`. Mapping `amount→value_mid` must be confirmed per route; a wrong choice
+  shifts displayed pipeline value. The schema-contract test will NOT catch this (all columns exist).
+- **Never write to opportunities_unified** — it's overwritten by the daily sync. Writes go to the source
+  table (fundraising_pipeline).
+- `fundraising_pipeline` data is 14 rows / stale since March → low value; the migration is about *one
+  canonical pipeline*, not fixing live numbers (the live funding pipeline is GHL).
+
+## Recommended sequence (once decisions land)
+1. D4 (relationship_health recompute) — cheapest, isolated PM2 entry.
+2. D3 (relationship_pipeline) — if retire, archive the 3 `/pipeline` routes + page (like the §H archive).
+3. D1/D2 (fundraising reads → opps_unified) — last, lowest payoff; do the money-surface routes one at a
+   time with live-data verification of `amount→value_mid`.
+
+## Provenance
+- Verified vs live shared DB (`tednluwflfhxyucgwigh`) 2026-05-27: table freshness, opps_unified
+  source_system distribution, the 11 route `.from()/.select()` refs, the `ecosystem.config.cjs` cron set.
+- relationship_health populator analysis: `scripts/relationship-health.mjs` (only writer, line 288) is
+  absent from `ecosystem.config.cjs`; `weekly-relationship-review` (Fri 6pm) only reads it.
+- Generated by: Claude (investigation), pending Ben's D1–D4.

--- a/thoughts/shared/plans/2026-05-27-pipeline-consolidation.md
+++ b/thoughts/shared/plans/2026-05-27-pipeline-consolidation.md
@@ -51,12 +51,21 @@ its populator" decision, **not** a consolidation.
   `fundraising_pipeline` (writes then sync to opps_unified). Keep `fundraising_pipeline` as the write-model
   (recommended — opps_unified is derived, never write to it directly), or migrate fundraising CRUD onto
   GHL/another store. **Recommendation:** keep as write-model; don't break it.
-- ⬜ **D3 — relationship_pipeline / the `/pipeline` kanban.** Retire the relationship-kanban feature
-  (5 route refs + the `/pipeline` page), OR re-light its populator so the scores refresh. Need to know:
-  is the relationship-kanban still used, or superseded by the `/relationships/*` pages + GHL? **No
-  recommendation without that answer** — it's a product call.
-- ⬜ **D4 — relationship_health** (tracked in trust-map §H, related): recompute (add the unscheduled
-  `relationship-health.mjs update` to PM2 — cheap) vs retire. **Recommendation: recompute.**
+- ✅ **D3 — DECIDED (Ben 2026-05-27): KEEP the `/pipeline` kanban.** BUT the investigation found there
+  is **no populator** — `relationship_pipeline` was created by migration `20260312000000` (table only,
+  no seed) and **nothing in the codebase writes to it**; its 1,170 rows are a one-time March load,
+  frozen since. So "make it healthy" is not a re-light (there's no light) — it needs a populator
+  **built** (compute `love/money/strategic/urgency` scores per entity from relationship_health +
+  opportunities + comms). That's a net-new design task → see **D3a** below. The kanban stays; it shows
+  the frozen March snapshot until a populator exists.
+- ⬜ **D3a — build a relationship_pipeline populator?** Net-new script that computes the kanban scores
+  on a cadence. Needs the scoring design (what drives love/money/strategic/urgency) — likely derivable
+  from the now-fresh `relationship_health` + `opportunities_unified`, but it's a real feature build, not
+  a config flip. Awaiting Ben's go to scope it.
+- ✅ **D4 — DONE (2026-05-27): relationship_health re-lit.** Ran `relationship-health.mjs update`
+  (refreshed → 1,197 rows, fresh now) + added a daily `15 3 * * *` PM2 cron entry (`relationship-health`)
+  to `ecosystem.config.cjs`, `pm2 start` + `pm2 save`. Root cause was the populator was never scheduled
+  (only the Fri consumer was).
 
 ## Per-route migration map (the 11 refs)
 


### PR DESCRIPTION
Follow-up after #96. Three commits.

## relationship_health re-lit (`cc6b64f`) — operational
Root cause: the populator `scripts/relationship-health.mjs update` was **never in `ecosystem.config.cjs`** (only the Fri consumer `weekly-relationship-review` was), so scores froze ~4 weeks (last Apr 29). Fix: ran it once (→ 1,197 rows fresh) + added a daily `15 3 * * *` cron entry; `pm2 start` + `pm2 save` done locally. Feeds the 7 `/relationships` + intelligence routes + the Fri review.

## Pipeline-consolidation plan (`e763025`) — draft, awaiting decisions
Scoped blueprint Phase 4 against live DB. Key finding: "retire both pipelines → opportunities_unified" is half-wrong — `opportunities_unified` is a daily-synced read-model that `fundraising_pipeline` already feeds (it's a write-model, not dead), and `relationship_pipeline` is a separate CRM-kanban domain (scores) that can't merge into opportunities. Decisions D1–D4 documented; D4 done (above); D3 = keep the kanban (Ben) but it has **no populator** (one-time March migration seed) → needs one built (D3a).

## ⚠️ Rode along: `801b556` — Ben's own Goods Xero tagging work
Authored by Ben (accounts@act.place) earlier today on this branch; additive (2 new files: `scripts/tag-goods-revenue-invoices.py` + a cleanup ticket, +191 lines, no edits to existing code). Unrelated to the schema/cron work but lands here since it was committed to this branch. Flagging for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)