### PR TITLE
fix: real bank balance + ALMA naming + supporters sort (+ verified all changed routes render)

### DIFF
--- a/apps/command-center/src/app/api/business/overview/route.ts
+++ b/apps/command-center/src/app/api/business/overview/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 import { fetchAllRows } from '@/lib/finance/query'
-import { getMonthlyPL } from '@/lib/finance/ledger'
+import { getMonthlyPL, getCashPosition } from '@/lib/finance/ledger'
 
 /**
  * GET /api/business/overview
@@ -62,11 +62,10 @@ export async function GET() {
     else if (tx.type === 'SPEND') recentOut += amt
   }
 
-  // Bank balance: xero_transactions has no running_balance column and there is no bank-balance
-  // feed table in the shared DB, so there is no source to read a live balance from here. Left null
-  // (downstream handles null → bankBalance/runway null) rather than fabricate one. The CEO bank
-  // position lives on the rebuilt /company page (lib/finance ledger).
-  const latestBalance = null as { running_balance: number | null } | null
+  // Bank balance: the live ACT cash position = the two ACT operating accounts (ACT Everyday + NAB
+  // Visa #8815, two-account rule), summed from xero_bank_accounts (synced daily by xero-bank-balances).
+  // Reuse the canonical ledger helper so this matches /company.
+  const cashPosition = await getCashPosition()
 
   // Subscriptions total
   const { data: subs } = await supabase
@@ -305,12 +304,14 @@ export async function GET() {
       netFlow: Math.round(recentIn - recentOut),
     },
     currentPosition: {
-      bankBalance: latestBalance?.running_balance ? Math.round(Number(latestBalance.running_balance)) : null,
+      bankBalance: cashPosition.ok ? cashPosition.cash : null,
+      bankBalanceAsOf: cashPosition.asOf,
+      bankBalanceStale: cashPosition.stale,
       receivables: Math.round(receivables),
       monthlySubscriptions: Math.round(monthlySubscriptions),
       burnRate: Math.round(monthExpenses),
-      runway: monthExpenses > 0 && latestBalance?.running_balance
-        ? Math.round(Number(latestBalance.running_balance) / monthExpenses)
+      runway: monthExpenses > 0 && cashPosition.ok
+        ? Math.round(cashPosition.cash / monthExpenses)
         : null,
     },
   }

--- a/apps/command-center/src/app/compendium/[project]/page.tsx
+++ b/apps/command-center/src/app/compendium/[project]/page.tsx
@@ -128,7 +128,7 @@ const projectData: Record<string, {
       {
         title: 'ALMA',
         icon: Zap,
-        content: 'Accountable Listening and Meaningful Action (ALMA) is ACT\'s governed process for moving from story to responsible action with consent, authority, provenance, and review.',
+        content: 'Australian Living Map of Alternatives (ALMA) is ACT\'s governed process for moving from story to responsible action with consent, authority, provenance, and review.',
       },
     ],
   },

--- a/apps/command-center/src/app/projects/[code]/page.tsx
+++ b/apps/command-center/src/app/projects/[code]/page.tsx
@@ -1009,7 +1009,7 @@ export default function ProjectPage({ params, searchParams }: PageParams) {
             <div className="glass-card p-6">
               <h3 className="font-semibold text-white mb-3">About ALMA</h3>
               <p className="text-sm text-white/50 leading-relaxed">
-                Accountable Listening and Meaningful Action (ALMA) reviews project readiness
+                Australian Living Map of Alternatives (ALMA) reviews project readiness
                 through four dimensions that reflect ACT's commitment to community-led development.
               </p>
               <div className="mt-4 space-y-3 text-sm">

--- a/apps/command-center/src/app/supporters/page.tsx
+++ b/apps/command-center/src/app/supporters/page.tsx
@@ -127,9 +127,20 @@ export default function SupportersPage() {
     refetchOnWindowFocus: false,
   })
 
+  type SortKey =
+    | 'name' | 'tier' | 'totalPaidAud' | 'outstandingAud'
+    | 'openOppValueAud' | 'lastTouchAt' | 'in30out' | 'waiting' | 'projects'
+  const [sortKey, setSortKey] = useState<SortKey>('outstandingAud')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) setSortDir(sortDir === 'asc' ? 'desc' : 'asc')
+    else { setSortKey(key); setSortDir(key === 'name' || key === 'tier' || key === 'projects' ? 'asc' : 'desc') }
+  }
+
   const filtered = useMemo(() => {
     if (!data?.supporters) return []
-    let rows = data.supporters
+    let rows = [...data.supporters]
     if (tierFilter !== 'all') rows = rows.filter((s) => s.tier === tierFilter)
     if (projectFilter !== 'all') rows = rows.filter((s) => s.projects?.includes(projectFilter))
     if (needsReplyOnly) rows = rows.filter((s) => s.needsReply)
@@ -142,8 +153,44 @@ export default function SupportersPage() {
           (s.primaryContact || '').toLowerCase().includes(q),
       )
     }
+    // Sort
+    const sign = sortDir === 'asc' ? 1 : -1
+    rows.sort((a, b) => {
+      let av: any, bv: any
+      switch (sortKey) {
+        case 'name': av = a.name.toLowerCase(); bv = b.name.toLowerCase(); break
+        case 'tier': av = a.tier; bv = b.tier; break
+        case 'totalPaidAud': av = a.totalPaidAud; bv = b.totalPaidAud; break
+        case 'outstandingAud': av = a.outstandingAud; bv = b.outstandingAud; break
+        case 'openOppValueAud': av = a.openOppValueAud; bv = b.openOppValueAud; break
+        case 'lastTouchAt': av = a.lastTouchAt ? new Date(a.lastTouchAt).getTime() : 0; bv = b.lastTouchAt ? new Date(b.lastTouchAt).getTime() : 0; break
+        case 'in30out': av = (a.in30d + a.out30d); bv = (b.in30d + b.out30d); break
+        case 'waiting': av = a.waitingForResponseCount; bv = b.waitingForResponseCount; break
+        case 'projects': av = (a.projects || []).join(','); bv = (b.projects || []).join(','); break
+      }
+      if (av < bv) return -1 * sign
+      if (av > bv) return 1 * sign
+      return 0
+    })
     return rows
-  }, [data, tierFilter, projectFilter, needsReplyOnly, search])
+  }, [data, tierFilter, projectFilter, needsReplyOnly, search, sortKey, sortDir])
+
+  function SortBtn({ k, label, align = 'left' }: { k: SortKey; label: string; align?: 'left' | 'right' }) {
+    const active = sortKey === k
+    return (
+      <button
+        onClick={() => toggleSort(k)}
+        className={cn(
+          'inline-flex items-center gap-1 hover:text-white transition-colors',
+          align === 'right' && 'justify-end',
+          active && 'text-white',
+        )}
+      >
+        {label}
+        <span className={cn('text-[8px]', active ? 'opacity-100' : 'opacity-20')}>{active && sortDir === 'asc' ? '▲' : '▼'}</span>
+      </button>
+    )
+  }
 
   const allProjects = useMemo(() => {
     if (!data?.supporters) return []
@@ -308,15 +355,15 @@ export default function SupportersPage() {
           <table className="w-full text-sm">
             <thead className="bg-white/5 text-xs text-white/40 uppercase tracking-wider">
               <tr>
-                <th className="text-left p-3">Supporter</th>
-                <th className="text-left p-3">Tier</th>
-                <th className="text-right p-3">$ Paid</th>
-                <th className="text-right p-3">$ Outstanding</th>
-                <th className="text-right p-3">Open Opps</th>
-                <th className="text-left p-3">Last Touch</th>
-                <th className="text-right p-3">In/Out 30d</th>
-                <th className="text-right p-3">Waiting</th>
-                <th className="text-left p-3">Projects</th>
+                <th className="text-left p-3"><SortBtn k="name" label="Supporter" /></th>
+                <th className="text-left p-3"><SortBtn k="tier" label="Tier" /></th>
+                <th className="text-right p-3"><SortBtn k="totalPaidAud" label="$ Paid" align="right" /></th>
+                <th className="text-right p-3"><SortBtn k="outstandingAud" label="$ Outstanding" align="right" /></th>
+                <th className="text-right p-3"><SortBtn k="openOppValueAud" label="Open Opps" align="right" /></th>
+                <th className="text-left p-3"><SortBtn k="lastTouchAt" label="Last Touch" /></th>
+                <th className="text-right p-3"><SortBtn k="in30out" label="In/Out 30d" align="right" /></th>
+                <th className="text-right p-3"><SortBtn k="waiting" label="Waiting" align="right" /></th>
+                <th className="text-left p-3"><SortBtn k="projects" label="Projects" /></th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Closes the three gaps from the session audit.

## Bank balance — was null, now real (`fc22071`)
Earlier I set `/business/overview` bankBalance to null ("no source") — but `xero_bank_accounts` is synced daily and `lib/finance/ledger.ts#getCashPosition` already sums the two ACT operating accounts (ACT Everyday + NAB Visa #8815, two-account rule). Reused it. **Verified live: bankBalance = $130,147** (matches /company), `stale:false`, runway now computes off real cash.

## ALMA naming + supporters sort (`4f86006`)
Ships finished work that sat uncommitted in the tree since before the session:
- ALMA expanded correctly as "Australian Living Map of Alternatives" (was the wrong "Accountable Listening and Meaningful Action") on compendium + projects/[code] — per the CLAUDE.md ALMA rule.
- Sortable supporters table columns.

## Verified all changed routes render (the #1 gap)
Smoke-tested **19 changed API routes against a running dev server** — all 200, zero 500s, sane data:
- Shape-changers confirmed: `finance/projects` annualBudget=100000 (project_budgets aggregation), `system/usage` cost from llm_usage, `agent/insights`+`proposals/stats` from agent_proposals (pending=321), `business/overview` bank=$130,147 + subs=$271, reports show knowledge counts, inbox/pipeline work.
- Genuinely-gone routes degrade gracefully (cashflow-explained→`{months:[]}`, receipts/score→0 but real pending intact).

This was the verification I'd skipped — loosely-typed Supabase results meant a shape mismatch could've rendered blank without tsc/schema-checker catching it. None did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)