### PR TITLE
ci: schema-contract runs on every PR (prereq for required check)

### DIFF
--- a/.github/workflows/schema-contract.yml
+++ b/.github/workflows/schema-contract.yml
@@ -5,20 +5,12 @@ name: Schema Contract
 # Passes today via a burn-down baseline (config/schema-contract-baseline.json); fails on NEW drift.
 
 on:
+  # Runs on EVERY PR (no path filter) so it can be a REQUIRED status check in branch
+  # protection — a path filter would skip docs-only PRs, leaving the required check stuck
+  # "pending" and blocking the merge forever. The check itself is fast (snapshot/live diff).
   pull_request:
-    paths:
-      - 'apps/command-center/src/**'
-      - 'scripts/lib/schema-contract.mjs'
-      - 'scripts/check-schema-contract.mjs'
-      - 'scripts/tests/schema-contract.test.mjs'
-      - 'config/schema-contract-allowlist.json'
-      - 'config/schema-contract-baseline.json'
-      - 'config/schema-snapshot.json'
-      - '.github/workflows/schema-contract.yml'
   push:
     branches: [main]
-    paths:
-      - 'apps/command-center/src/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Removes the path filter so 'Verify schema contract' runs on every PR — required for making it a blocking branch-protection check (path-filtered checks stick pending on unrelated PRs). Prereq for enabling branch protection on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)