### PR TITLE
ci: Type Check & Lint runs on every PR (prereq for required check)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/command-center/**'
-      - 'packages/**'
-      - 'pnpm-lock.yaml'
+  # Runs on EVERY PR (no path filter) so "Type Check & Lint" can be a REQUIRED status check —
+  # a path-filtered check skips unrelated PRs, leaving the required context stuck "pending" and
+  # blocking the merge forever. Type check + lint are cheap.
   pull_request:
-    paths:
-      - 'apps/command-center/**'
-      - 'packages/**'
-      - 'pnpm-lock.yaml'
 
 jobs:
   typecheck-and-lint:


### PR DESCRIPTION
Removes the path filter so 'Type Check & Lint' runs on every PR — required to make it a blocking branch-protection check (path-filtered checks stick pending on unrelated PRs). Matches the schema-contract change. Then it'll be added to required checks alongside 'Verify schema contract'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)