### PR TITLE
feat(db): contact_project_links.ghl_contact_id — schema baseline 2→0 (fully strict)

### DIFF
--- a/config/schema-contract-baseline.json
+++ b/config/schema-contract-baseline.json
@@ -1,9 +1,6 @@
 {
   "_doc": "Known schema-contract violations accepted as of the date below. The test fails on any violation NOT in this list. Burn this down (archive dead-table routes, fix drifted columns) until empty, then delete the file for full strictness. Regenerate: node scripts/check-schema-contract.mjs --baseline",
-  "generatedAt": "2026-05-27T00:33:53.112Z",
-  "count": 2,
-  "accepted": [
-    "apps/command-center/src/app/api/contacts/[id]/link-project/route.ts::contact_project_links::ghl_contact_id",
-    "apps/command-center/src/app/api/intelligence/actions/route.ts::contact_project_links::ghl_contact_id"
-  ]
+  "generatedAt": "2026-05-27T03:32:30.045Z",
+  "count": 0,
+  "accepted": []
 }

--- a/config/schema-snapshot.json
+++ b/config/schema-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-26T21:08:07.180Z",
+  "generatedAt": "2026-05-27T03:31:49.960Z",
   "db": "tednluwflfhxyucgwigh (shared)",
   "tables": {
     "abr_registry": [
@@ -2781,6 +2781,7 @@
       "confidence",
       "created_at",
       "entity_id",
+      "ghl_contact_id",
       "id",
       "project_code",
       "source"
@@ -7718,6 +7719,16 @@
       "suggested_title",
       "suggested_type",
       "wiki_page_id"
+    ],
+    "pending_form_submissions": [
+      "additional_tags",
+      "created_at",
+      "fields",
+      "form_type",
+      "id",
+      "project_code",
+      "source",
+      "synced"
     ],
     "pending_proposals": [
       "agent_id",

--- a/supabase/migrations/20260527000000_contact_project_links_ghl_contact_id.sql
+++ b/supabase/migrations/20260527000000_contact_project_links_ghl_contact_id.sql
@@ -1,0 +1,35 @@
+-- Add per-GHL-contact linking to contact_project_links.
+--
+-- The command-center already WRITES and READS ghl_contact_id (apps/command-center/src/app/api/
+-- contacts/[id]/link-project + api/intelligence/actions) but the column never existed — the table
+-- keyed only on the canonical entity_id. Per Ben's 2026-05-27 decision the link is per GHL contact.
+-- Keep entity_id (FK → canonical_entities) for the canonical relationship; add ghl_contact_id with
+-- its own unique key so the upsert onConflict ('ghl_contact_id,project_code') works.
+--
+-- Backfill verified against live data: all 487 existing rows map to a primary ghl_id via
+-- ghl_contacts.canonical_entity_id, producing 0 duplicate (ghl_contact_id, project_code) pairs.
+
+BEGIN;
+
+ALTER TABLE contact_project_links ADD COLUMN IF NOT EXISTS ghl_contact_id text;
+
+-- Each canonical entity → its primary (earliest-created) GHL contact's ghl_id.
+UPDATE contact_project_links cpl
+SET ghl_contact_id = sub.ghl_id
+FROM (
+  SELECT DISTINCT ON (canonical_entity_id) canonical_entity_id, ghl_id
+  FROM ghl_contacts
+  WHERE canonical_entity_id IS NOT NULL AND ghl_id IS NOT NULL
+  ORDER BY canonical_entity_id, created_at
+) sub
+WHERE cpl.entity_id = sub.canonical_entity_id
+  AND cpl.ghl_contact_id IS NULL;
+
+-- NULLs are distinct in a multi-column UNIQUE, so any unmapped legacy rows (none today) don't collide.
+ALTER TABLE contact_project_links
+  ADD CONSTRAINT contact_project_links_ghl_contact_id_project_code_key
+  UNIQUE (ghl_contact_id, project_code);
+
+CREATE INDEX IF NOT EXISTS idx_cpl_ghl_contact_id ON contact_project_links (ghl_contact_id);
+
+COMMIT;

--- a/thoughts/shared/plans/2026-05-27-command-center-p3-honest-by-construction.md
+++ b/thoughts/shared/plans/2026-05-27-command-center-p3-honest-by-construction.md
@@ -223,6 +223,23 @@ bad contact↔project links. Needs Ben's call: add `ghl_contact_id` to the table
 canonical-entity mapping. **Baseline 12 → 2.**
 **Cumulative P3 result: schema-contract baseline 87 → 2.**
 
+### 2026-05-27 — Baseline burned to 0 — FULLY STRICT
+**Objective:** Close the last 2 violations (`contact_project_links.ghl_contact_id`) and remove the
+baseline grace so the checker fails on ANY drift.
+**Decision (Ben):** the link is **per GHL contact** → add a `ghl_contact_id` column (the code already
+wrote/read it; the table only had the canonical `entity_id`).
+**Changed:** migration `supabase/migrations/20260527000000_contact_project_links_ghl_contact_id.sql`
+applied to the shared DB (`apply_migration`, verified instance) — `ALTER TABLE … ADD COLUMN
+ghl_contact_id text`, backfilled all 487 rows from `ghl_contacts.canonical_entity_id → ghl_id`
+(pre-checked: 0 dup `(ghl_contact_id, project_code)` pairs), added the matching UNIQUE constraint +
+index. `entity_id` (FK → canonical_entities) kept. Refreshed `config/schema-snapshot.json` (781 tables)
+and **emptied `config/schema-contract-baseline.json` (count 0)** = full strictness.
+**Verified vs live DB:** column present, 487/487 backfilled, unique constraint present; checker = "schema
+contract holds — no dead tables or columns anywhere"; 20/20 tests pass strict; `/api/intelligence/actions`
+200 (reads the column); link-project upsert `onConflict('ghl_contact_id,project_code')` idempotent.
+**Result: schema-contract baseline 87 → 0. The command-center is honest by construction, enforced**
+(both `Verify schema contract` + `Type Check & Lint` are required branch-protection checks on `main`).
+
 ---
 
 ## Provenance


### PR DESCRIPTION
Closes the last 2 schema-contract violations and removes the baseline grace — the checker is now **fully strict** (fails on ANY drift). Cumulative: **baseline 87 → 0**.

## What
Per Ben's call, contact_project_links links **per GHL contact**. The code already wrote/read `ghl_contact_id` (contacts/[id]/link-project + intelligence/actions) but the column never existed — the table only keyed on the canonical `entity_id`.

Migration `20260527000000_contact_project_links_ghl_contact_id.sql` (applied to the shared DB):
- `ADD COLUMN ghl_contact_id text` + `UNIQUE (ghl_contact_id, project_code)` (for the upsert onConflict) + index
- Backfilled all **487** rows from `ghl_contacts.canonical_entity_id → ghl_id` (pre-checked: 0 dup pairs)
- Kept `entity_id` (FK → canonical_entities)

Then refreshed `schema-snapshot.json` (781 tables) and **emptied the baseline** (count 0).

## Verified vs live DB
Column present · 487/487 backfilled · unique constraint present · checker = "schema contract holds, no dead tables or columns anywhere" · 20/20 tests strict · `/api/intelligence/actions` 200 · link-project upsert `onConflict('ghl_contact_id,project_code')` idempotent.

The command-center is now honest by construction **and enforced** (both `Verify schema contract` + `Type Check & Lint` required on main).

Plan: command-center-p3-honest-by-construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)