### PR TITLE
fix: /finance/overview cash (two-account) + /pipeline row-cap

### DIFF
--- a/apps/command-center/src/app/api/finance/overview/route.ts
+++ b/apps/command-center/src/app/api/finance/overview/route.ts
@@ -14,6 +14,7 @@ import {
   type HealthLevel,
 } from '@/lib/finance'
 import { aggregateProjectBudgets } from '@/lib/finance/budgets'
+import { isActBankAccount } from '@/lib/finance/ledger'
 
 export const dynamic = 'force-dynamic'
 
@@ -132,8 +133,13 @@ async function computeOverview() {
   const totalReceivables = receivables.reduce((s, r) => s + Number(r.amount_due || 0), 0)
   const totalPayables = payables.reduce((s, p) => s + Math.abs(Number(p.amount_due || 0)), 0)
 
-  const cashInBank = bankAccounts.length > 0
-    ? bankAccounts.reduce((sum, a) => sum + Number(a.current_balance || 0), 0)
+  // Two-account rule: ACT cash = ACT Everyday + NAB Visa #8815 only. Exclude NM Personal / Maximiser
+  // (else the figure was contaminated, e.g. −$245,844 incl. Nic's personal vs the true ~$130K).
+  const actBankAccounts = bankAccounts.filter(
+    (a) => isActBankAccount(a.name) && a.current_balance != null,
+  )
+  const cashInBank = actBankAccounts.length > 0
+    ? actBankAccounts.reduce((sum, a) => sum + Number(a.current_balance || 0), 0)
     : null
 
   const cashForRunway = cashInBank ?? Math.max(0, fyRevenue - fyExpenses + totalReceivables)

--- a/apps/command-center/src/app/api/pipeline/route.ts
+++ b/apps/command-center/src/app/api/pipeline/route.ts
@@ -9,20 +9,28 @@ export async function GET(request: NextRequest) {
     const minUrgency = searchParams.get('min_urgency')
     const search = searchParams.get('q')
 
-    let query = supabase
-      .from('relationship_pipeline')
-      .select('*')
-      .order('urgency_score', { ascending: false })
-      .order('updated_at', { ascending: false })
+    // Paginate past the PostgREST 1,000-row cap — relationship_pipeline has ~1,458 rows, so a
+    // single .select('*') silently dropped ~458 entries (foundations off the board). Page in 1,000s.
+    const PAGE = 1000
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any[] = []
+    for (let from = 0; ; from += PAGE) {
+      let query = supabase
+        .from('relationship_pipeline')
+        .select('*')
+        .order('urgency_score', { ascending: false })
+        .order('updated_at', { ascending: false })
 
-    if (entityType) query = query.eq('entity_type', entityType)
-    if (stage) query = query.eq('stage', stage)
-    if (minUrgency) query = query.gte('urgency_score', parseInt(minUrgency))
-    if (search) query = query.ilike('entity_name', `%${search}%`)
+      if (entityType) query = query.eq('entity_type', entityType)
+      if (stage) query = query.eq('stage', stage)
+      if (minUrgency) query = query.gte('urgency_score', parseInt(minUrgency))
+      if (search) query = query.ilike('entity_name', `%${search}%`)
 
-    const { data, error } = await query
-
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+      const { data: page, error } = await query.range(from, from + PAGE - 1)
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+      data.push(...(page || []))
+      if (!page || page.length < PAGE) break
+    }
 
     // Group by stage for board view
     const stages = ['cold', 'warm', 'engaged', 'active', 'partner', 'dormant', 'lost']

--- a/apps/command-center/src/app/api/pipeline/route.ts
+++ b/apps/command-center/src/app/api/pipeline/route.ts
@@ -12,7 +12,6 @@ export async function GET(request: NextRequest) {
     // Paginate past the PostgREST 1,000-row cap — relationship_pipeline has ~1,458 rows, so a
     // single .select('*') silently dropped ~458 entries (foundations off the board). Page in 1,000s.
     const PAGE = 1000
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any[] = []
     for (let from = 0; ; from += PAGE) {
       let query = supabase


### PR DESCRIPTION
Two bugs the production smoke-check surfaced (both pre-existing, not from the prior PRs):

1. **`/finance/overview` cashInBank was −\$245,844** — it summed *all* active xero_bank_accounts including NM Personal (Nic's, −\$376K). Filtered to ACT accounts via `isActBankAccount` (ACT Everyday + NAB Visa #8815) → **+\$130,147**, matching `/business/overview`. Verified vs live (`?live=true`, bypassing the 6h cache).
2. **`/api/pipeline` dropped ~458 of 1,458 rows** — `.select('*')` hit the PostgREST 1,000-row cap (foundations showed 170 not 628). Paginated in 1,000s → **total 1,458, foundation 628** confirmed.

tsc clean. Verified both locally against the working tree.

Note: after deploy I'll hit `/api/finance/overview?live=true` once to bust the stale 6h cache.

Plan: pipeline-consolidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)