### PR TITLE
Goods: GHL supporter-journey seed + buyer-pipeline cleanup

### DIFF
--- a/scripts/audit-goods-buyer-pipelines.mjs
+++ b/scripts/audit-goods-buyer-pipelines.mjs
@@ -1,0 +1,90 @@
+/**
+ * Audit the two GHL Goods buyer pipelines before cleanup.
+ * Read-only: fetches all opps, categorizes, prints a cleanup plan + writes full JSON.
+ *
+ *   node --env-file=.env.local scripts/audit-goods-buyer-pipelines.mjs
+ *
+ * Categories:
+ *   TEST            - test/example records (tag test-submission or @example.com)
+ *   DUP_IN_BUYER    - same contact present in BOTH pipelines, Buyer copy still unworked
+ *                     (Outreach Queued) → per model, remove the Buyer-pipeline copy
+ *   GENERIC_SIGNAL  - "52 beds, 6 washers" templated demand (real-vs-noise review)
+ *   REAL            - everything else (keep / work)
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+import fs from 'node:fs';
+
+const DEMAND = { id: 'UQsrmuqzxMSdCTklxEcG', name: 'Demand Register' };
+const BUYER  = { id: 'FjMyJM3YzWQFmKqR9fur', name: 'Buyer Pipeline' };
+const OUTREACH_QUEUED = 'e5220eb2-be40-4e79-9571-6acae12285c7'; // Buyer Pipeline stage 0
+
+const slim = (o) => ({
+  id: o.id,
+  name: o.name,
+  value: o.monetaryValue || 0,
+  stageId: o.pipelineStageId,
+  contactId: o.contactId,
+  contactName: o.contact?.name || o.contact?.companyName || null,
+  email: o.contact?.email || null,
+  tags: o.contact?.tags || [],
+});
+
+async function main() {
+  const ghl = createGHLService();
+  const demand = (await ghl.getOpportunities(DEMAND.id, { limit: 100 })).map(slim);
+  const buyer  = (await ghl.getOpportunities(BUYER.id,  { limit: 100 })).map(slim);
+
+  const demandContacts = new Set(demand.map((o) => o.contactId));
+
+  const isTest = (o) =>
+    o.tags.includes('test-submission') || (o.email || '').includes('example.com');
+  const isGeneric = (o) => /52 beds, 6 washers/i.test(o.name);
+
+  // Buyer-pipeline categorization
+  const buyerCats = { TEST: [], DUP_IN_BUYER: [], GENERIC_SIGNAL: [], REAL: [] };
+  for (const o of buyer) {
+    if (isTest(o)) buyerCats.TEST.push(o);
+    else if (demandContacts.has(o.contactId) && o.stageId === OUTREACH_QUEUED)
+      buyerCats.DUP_IN_BUYER.push(o);
+    else if (isGeneric(o)) buyerCats.GENERIC_SIGNAL.push(o);
+    else buyerCats.REAL.push(o);
+  }
+
+  // Demand-register categorization
+  const demandCats = { TEST: [], GENERIC_SIGNAL: [], REAL: [] };
+  for (const o of demand) {
+    if (isTest(o)) demandCats.TEST.push(o);
+    else if (isGeneric(o)) demandCats.GENERIC_SIGNAL.push(o);
+    else demandCats.REAL.push(o);
+  }
+
+  const out = '/tmp/goods-buyer-audit.json';
+  fs.writeFileSync(out, JSON.stringify({ demand, buyer, buyerCats, demandCats }, null, 2));
+
+  const line = (o) => `    ${o.name}  [${o.id}]  $${o.value}  contact:${o.contactName || o.contactId}`;
+
+  console.log(`\n══ DEMAND REGISTER — ${demand.length} opps ══`);
+  console.log(`  GENERIC_SIGNAL (52 beds/6 washers, review real-vs-noise): ${demandCats.GENERIC_SIGNAL.length}`);
+  console.log(`  REAL (non-templated): ${demandCats.REAL.length}`);
+  demandCats.REAL.forEach((o) => console.log(line(o)));
+  if (demandCats.TEST.length) { console.log(`  TEST: ${demandCats.TEST.length}`); demandCats.TEST.forEach((o) => console.log(line(o))); }
+
+  console.log(`\n══ BUYER PIPELINE — ${buyer.length} opps ══`);
+  console.log(`  TEST (remove): ${buyerCats.TEST.length}`);
+  buyerCats.TEST.forEach((o) => console.log(line(o)));
+  console.log(`  DUP_IN_BUYER (signal copy, unworked → remove from Buyer, keep in Demand): ${buyerCats.DUP_IN_BUYER.length}`);
+  buyerCats.DUP_IN_BUYER.forEach((o) => console.log(line(o)));
+  console.log(`  GENERIC_SIGNAL in Buyer: ${buyerCats.GENERIC_SIGNAL.length}`);
+  buyerCats.GENERIC_SIGNAL.forEach((o) => console.log(line(o)));
+  console.log(`  REAL (keep / work): ${buyerCats.REAL.length}`);
+  buyerCats.REAL.forEach((o) => console.log(line(o)));
+
+  const removeCount = buyerCats.TEST.length + buyerCats.DUP_IN_BUYER.length;
+  console.log(`\n── Proposed cleanup ──`);
+  console.log(`  Remove from Buyer Pipeline: ${removeCount} (TEST ${buyerCats.TEST.length} + DUP ${buyerCats.DUP_IN_BUYER.length})`);
+  console.log(`  Review for real-vs-noise (Demand): ${demandCats.GENERIC_SIGNAL.length} generic signals`);
+  console.log(`  Full detail written to ${out}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/cleanup-goods-buyer-pipeline.mjs
+++ b/scripts/cleanup-goods-buyer-pipeline.mjs
@@ -1,0 +1,122 @@
+/**
+ * Clean up the GHL "Goods — Buyer Pipeline" → commercial buyers only.
+ * Approved by Ben 2026-05-27 (Buyer = commercial-only; safe cleanup go).
+ *
+ *   node --env-file=.env.local scripts/cleanup-goods-buyer-pipeline.mjs            # dry-run
+ *   node --env-file=.env.local scripts/cleanup-goods-buyer-pipeline.mjs --apply    # writes
+ *
+ * Before any delete (--apply), writes a RESTORE file with the full slim records
+ * so every removal is reversible (recreatable in the Buyer pipeline).
+ *
+ * Actions:
+ *   - delete 11 from Buyer: 1 test (GD2) + 10 dup signal-copies (also in Demand Register)
+ *   - delete 10 funder/grant product-line records (relationship lives in Supporter Journey + Xero)
+ *   - Malala fix: delete the stub contact + the bad Supporter-Journey opp created earlier
+ *     (real contact Mala'la Health Service `Z6POQ8e2wtBKSWDuPLEx`; seeder re-creates it linked)
+ * NOT touched (flagged for Ben): PICC Stretch Bed, "Remote job forecast", NLC Gapuwiyak (keep).
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+import fs from 'node:fs';
+
+// Flag-selected sets so each authorization runs independently (no re-deleting done records).
+const APPLY = process.argv.includes('--apply');
+const DO_SAFE = process.argv.includes('--safe');       // 11 test+dups (done 2026-05-27)
+const DO_FUNDERS = process.argv.includes('--funders');  // 10 funder product-lines
+const DO_EXTRAS = process.argv.includes('--extras');    // PICC + stray
+const DO_MALALA = process.argv.includes('--malala');    // Malala stub/opp fix (done 2026-05-27)
+const BUYER_PIPELINE = 'FjMyJM3YzWQFmKqR9fur';
+
+// --- Buyer pipeline opp IDs to delete ---
+const SAFE_REMOVE = [
+  ['qLaDvOyq1yOHZGOAKHrS', 'GD2 test record'],
+  ['7Fn2JOclc2CoNWfgaMqB', 'dup THULKURR'],
+  ['y8w1eSUJMhQlYM0ecMco', 'dup NEW MERINEE'],
+  ['fpdvQF3YmXvoAs3fmYGA', 'dup GUNUN WOONAM'],
+  ['It2t2mhn6S6azbnW0r0Z', 'dup SHIPTON FLATS'],
+  ['bxKLejbl23aP51J7dbvy', 'dup FORDY FARM'],
+  ['gA2WqhVUiMuF0svfZYkv', 'dup AAYKA'],
+  ['idpLpcz5sG76y2s8X1aI', 'dup LINGARA'],
+  ['IKxXaIXbQFhXHieao0EI', 'dup THAANGKUNH-NHIIN'],
+  ['N95Z3uJMg8nrIYhVhlet', 'dup BANNICK BURN'],
+  ['nAcEQ7QM1gD1rxG2eSW4', 'dup JILUNDARINA'],
+];
+const FUNDER_REMOVE = [
+  ['TFFJR5Tnm62kBHR9pdvb', 'OCS Basket Bed'],
+  ['FPckXyGg46VuHmyj2Rdu', 'OCS Washing Machine'],
+  ['euhcwgBRlGIBar7U4QUs', 'Rotary Greate Bed'],
+  ['JrbJMR3rSyijKrFp21AI', "Mala'la Basket Bed"],
+  ['Ln5qUxl2w9o2gjp0w2Py', 'Centrecorp Plant'],
+  ['DM0gItqBcftcPFO4Qwj3', 'Centrecorp Basket Bed'],
+  ['lLkkIHMSpnvGPRxQu1vH', 'Centrecorp Weave Bed'],
+  ['sgGa5u8ehHHPFy6wq6PQ', 'Homeland Washing Machine'],
+  ['RPVzkVGszff6indJ3GDJ', 'Red Dust Basket Bed'],
+  ['mqWa6wCGCZUDK8bQs2L8', 'Julalikari Washing Machine'],
+];
+
+const EXTRA_REMOVE = [
+  ['KoXLnuCmAxIp8Nrpeb0W', 'PICC Stretch Bed (not Goods / ACT-PI)'],
+  ['sogR69LPK8oNQzS2u7WC', 'Remote job forecast (stray $0)'],
+];
+
+// --- Malala fix ---
+const MALALA_BAD_OPP = 'WhMkunwtIU6ug12rtApN';       // Supporter Journey opp linked to stub
+const MALALA_STUB_CONTACT = 'J4iGAZJY70veM2FjqkzD';  // duplicate stub I created
+
+async function main() {
+  const ghl = createGHLService();
+  const allDeletes = [
+    ...(DO_SAFE ? SAFE_REMOVE : []),
+    ...(DO_FUNDERS ? FUNDER_REMOVE : []),
+    ...(DO_EXTRAS ? EXTRA_REMOVE : []),
+  ];
+
+  if (!allDeletes.length && !DO_MALALA) {
+    console.log('Nothing selected. Pass one or more of: --safe --funders --extras --malala (+ --apply).');
+    return;
+  }
+
+  // restore snapshot from the audit JSON (full slim records for recreate)
+  let audit = {};
+  try { audit = JSON.parse(fs.readFileSync('/tmp/goods-buyer-audit.json', 'utf8')); } catch {}
+  const byId = new Map([...(audit.buyer || [])].map((o) => [o.id, o]));
+  const restore = {
+    pipelineId: BUYER_PIPELINE,
+    removedAt: new Date().toISOString(),
+    sets: { safe: DO_SAFE, funders: DO_FUNDERS, extras: DO_EXTRAS, malala: DO_MALALA },
+    records: allDeletes.map(([id, why]) => ({ why, ...(byId.get(id) || { id }) })),
+    ...(DO_MALALA ? { malalaBadOpp: MALALA_BAD_OPP, malalaStubContact: MALALA_STUB_CONTACT } : {}),
+  };
+
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN'}`);
+  console.log(`Sets: safe=${DO_SAFE} funders=${DO_FUNDERS} extras=${DO_EXTRAS} malala=${DO_MALALA}`);
+  console.log(`Buyer deletes selected: ${allDeletes.length}\n`);
+
+  if (!APPLY) {
+    allDeletes.forEach(([id, why]) => console.log(`  would delete  ${id}  (${why})`));
+    if (DO_MALALA) console.log(`  would fix Malala: delete opp ${MALALA_BAD_OPP} + stub contact ${MALALA_STUB_CONTACT}`);
+    console.log(`\n(Dry-run. Re-run with --apply. A restore file is written on apply.)`);
+    return;
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const restorePath = `/Users/benknight/Code/act-global-infrastructure/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed-${stamp}.json`;
+  fs.writeFileSync(restorePath, JSON.stringify(restore, null, 2));
+  console.log(`Restore snapshot written: ${restorePath}\n`);
+
+  let ok = 0, fail = 0;
+  for (const [id, why] of allDeletes) {
+    try { await ghl.deleteOpportunity(id); console.log(`✓ deleted opp ${id}  (${why})`); ok++; }
+    catch (e) { console.error(`✗ opp ${id} (${why}): ${e.message}`); fail++; }
+  }
+  if (DO_MALALA) {
+    try { await ghl.deleteOpportunity(MALALA_BAD_OPP); console.log(`✓ deleted Malala bad opp ${MALALA_BAD_OPP}`); ok++; }
+    catch (e) { console.error(`✗ Malala opp: ${e.message}`); fail++; }
+    try { await ghl.deleteContact(MALALA_STUB_CONTACT); console.log(`✓ deleted Malala stub contact ${MALALA_STUB_CONTACT}`); ok++; }
+    catch (e) { console.error(`✗ Malala stub contact: ${e.message}`); fail++; }
+  }
+
+  console.log(`\n── Done ── ok:${ok} fail:${fail}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/seed-goods-supporter-journey.mjs
+++ b/scripts/seed-goods-supporter-journey.mjs
@@ -1,0 +1,134 @@
+/**
+ * Seed the GHL "Goods — Supporter Journey" pipeline with the 13 Goods funders.
+ *
+ * Pipeline must be created in the GHL UI first (API cannot create pipelines).
+ * Stages expected (any order): Identified, Qualified, Cultivating, Ask made,
+ * Committed, Delivering, Stewarding / Reporting, Renewing, Lapsed, Declined / Parked.
+ *
+ * Idempotent: skips a funder if an opportunity with the same name already exists
+ * in the pipeline. Re-runnable.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/seed-goods-supporter-journey.mjs            # dry-run
+ *   node --env-file=.env.local scripts/seed-goods-supporter-journey.mjs --apply    # writes
+ *
+ * Source of truth for $ values + stage/band mapping:
+ *   memory enterprise_hq_build.md "▶ RESUME HERE" + Grade→GHL playbook (2026-05-27).
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const PIPELINE_NAME = 'Supporter Journey'; // matched via getPipelineByName (substring, case-insensitive)
+
+// stage name -> normalized key for loose matching against GHL stage names
+const norm = (s) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+// The 13 funders. contactId = null means no GHL contact found (opportunity created contact-less).
+const FUNDERS = [
+  { name: 'Snow Foundation',                       value: 402930, stage: 'Stewarding / Reporting', band: 'goods-hot',     contactId: 'laCUDrYPbaEP5rC9UEcf' },
+  { name: 'Centrecorp Foundation',                 value: 123332, stage: 'Stewarding / Reporting', band: 'goods-hot',     contactId: 'ehnCEv62bCaGNTd1QuGp' },
+  { name: 'Homeland School Company',               value: 44000,  stage: 'Committed',              band: 'goods-steady',  contactId: 'hv7tFXO8UGDq3dMc98SG' },
+  { name: 'Our Community Shed',                     value: 20265,  stage: 'Renewing',               band: 'goods-steady',  contactId: 'SYhvJjn05QVkvbFJPhGv' },
+  { name: 'Julalikari Council Aboriginal Corp',     value: 19800,  stage: 'Renewing',               band: 'goods-steady',  contactId: 'OSWHIOCG3vHdyAEHot6F' },
+  { name: 'Vincent Fairfax Family Foundation',      value: 50000,  stage: 'Cultivating',            band: 'goods-cooling', contactId: 'G4vUZfUSQadk1R4KGRZC' },
+  { name: 'QIC',                                    value: 12000,  stage: 'Cultivating',            band: 'goods-cooling', contactId: '0ShRsxG5CBklEgpCIQQU' },
+  { name: 'Red Dust',                               value: 15950,  stage: 'Cultivating',            band: 'goods-cooling', contactId: '3v2RCOhzU5fCgsxEDgff' },
+  // "Malala" = Mala'la Health Service Aboriginal Corporation (apostrophe broke earlier search).
+  { name: "Mala'la Health Service Aboriginal Corp", value: 5434,   stage: 'Cultivating',            band: 'goods-cooling', contactId: 'Z6POQ8e2wtBKSWDuPLEx' },
+  { name: 'The Funding Network',                    value: 130000, stage: 'Cultivating',            band: 'goods-cooling', contactId: 'eCzgIXkVKLh3B413GVde' },
+  { name: 'FRRR',                                   value: 50000,  stage: 'Cultivating',            band: 'goods-cooling', contactId: 'j7hi3rlHwmIuDKNSIdTs' },
+  { name: 'AMP Foundation',                         value: 21900,  stage: 'Cultivating',            band: 'goods-cooling', contactId: 'wJXLZamvwqPSXxjtd6CC' },
+  { name: 'Rotary Eclub Outback Australia',         value: 82500,  stage: 'Lapsed',                 band: 'goods-cold',    contactId: 'huXguIGvyFHkixustqey' },
+];
+
+async function main() {
+  const ghl = createGHLService();
+
+  const pipeline = await ghl.getPipelineByName(PIPELINE_NAME);
+  if (!pipeline) {
+    console.error(`✗ Pipeline matching "${PIPELINE_NAME}" not found. Create "Goods — Supporter Journey" in the GHL UI first.`);
+    process.exit(1);
+  }
+  console.log(`Pipeline: "${pipeline.name}" (${pipeline.id}) — ${pipeline.stages.length} stages`);
+
+  // build stage-name -> id map (loose match)
+  const stageByKey = new Map(pipeline.stages.map((s) => [norm(s.name), s]));
+  const resolveStage = (wantName) => stageByKey.get(norm(wantName));
+
+  // fail fast if any required stage name is missing
+  const missing = [...new Set(FUNDERS.map((f) => f.stage))].filter((s) => !resolveStage(s));
+  if (missing.length) {
+    console.error(`✗ Pipeline is missing required stages: ${missing.join(', ')}`);
+    console.error(`  Stages present: ${pipeline.stages.map((s) => s.name).join(' | ')}`);
+    process.exit(1);
+  }
+
+  // existing opportunities (idempotency)
+  const existing = await ghl.getOpportunities(pipeline.id, { limit: 100 });
+  const existingNames = new Set(existing.map((o) => norm(o.name || '')));
+  console.log(`Existing opportunities in pipeline: ${existing.length}`);
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  const results = { created: [], skipped: [], tagged: [], errors: [] };
+
+  for (const f of FUNDERS) {
+    const stage = resolveStage(f.stage);
+    const line = `${f.name}  $${f.value.toLocaleString()}  → ${stage.name}  [${f.band}]  contact:${f.contactId || 'NONE'}`;
+
+    if (existingNames.has(norm(f.name))) {
+      console.log(`= SKIP (exists)  ${line}`);
+      results.skipped.push(f.name);
+      continue;
+    }
+
+    if (!APPLY) {
+      const note = !f.contactId && f.createContact ? '  (will create contact)' : '';
+      console.log(`+ WOULD CREATE  ${line}${note}`);
+      continue;
+    }
+
+    try {
+      // Create a contact first if none exists and we're configured to (e.g. Malala).
+      let contactId = f.contactId;
+      if (!contactId && f.createContact) {
+        const c = await ghl.createContact({
+          // GHL requires at least one of email/phone/firstName/lastName.
+          firstName: f.createContact.companyName,
+          name: f.createContact.companyName,
+          companyName: f.createContact.companyName,
+          tags: f.createContact.tags,
+          source: 'Goods Supporter Journey seed',
+        });
+        contactId = c.id || c.contact?.id;
+        console.log(`  ↳ created contact ${contactId} for ${f.name}`);
+      }
+
+      const opp = await ghl.createOpportunity({
+        pipelineId: pipeline.id,
+        stageId: stage.id,
+        name: f.name,
+        monetaryValue: f.value,
+        status: 'open',
+        ...(contactId ? { contactId } : {}),
+      });
+      console.log(`+ CREATED  ${line}  (opp ${opp.id})`);
+      results.created.push(f.name);
+
+      if (contactId) {
+        await ghl.addTagToContact(contactId, f.band);
+        results.tagged.push(`${f.name}:${f.band}`);
+      }
+    } catch (err) {
+      console.error(`✗ ERROR  ${f.name}: ${err.message}`);
+      results.errors.push(`${f.name}: ${err.message}`);
+    }
+  }
+
+  console.log(`\n── Summary ──`);
+  console.log(`Created: ${results.created.length}  | Skipped(existing): ${results.skipped.length}  | Tagged: ${results.tagged.length}  | Errors: ${results.errors.length}`);
+  if (results.errors.length) console.log(`Errors:\n  ${results.errors.join('\n  ')}`);
+  if (!APPLY) console.log(`\n(Dry-run. Re-run with --apply to write.)`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed-2026-05-27T05-44-26-758Z.json
+++ b/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed-2026-05-27T05-44-26-758Z.json
@@ -1,0 +1,226 @@
+{
+  "pipelineId": "FjMyJM3YzWQFmKqR9fur",
+  "removedAt": "2026-05-27T05:44:26.755Z",
+  "sets": {
+    "safe": false,
+    "funders": true,
+    "extras": true,
+    "malala": false
+  },
+  "records": [
+    {
+      "why": "OCS Basket Bed",
+      "id": "TFFJR5Tnm62kBHR9pdvb",
+      "name": "Our Community Shed Incorporated — Goods Basket Bed v1.3",
+      "value": 13500,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "SYhvJjn05QVkvbFJPhGv",
+      "contactName": "Coordinator — Our Community Shed",
+      "email": "coordinator@ourshed.org",
+      "tags": [
+        "goods",
+        "goods-partner",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "OCS Washing Machine",
+      "id": "FPckXyGg46VuHmyj2Rdu",
+      "name": "Our Community Shed Incorporated — Goods Indestructible Washing Machine v1",
+      "value": 6765,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "SYhvJjn05QVkvbFJPhGv",
+      "contactName": "Coordinator — Our Community Shed",
+      "email": "coordinator@ourshed.org",
+      "tags": [
+        "goods",
+        "goods-partner",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "Rotary Greate Bed",
+      "id": "euhcwgBRlGIBar7U4QUs",
+      "name": "Rotary Eclub Outback Australia, Division 9560, — Goods Greate Bed v1",
+      "value": 82500,
+      "stageId": "835065e8-c952-4cfe-9228-5e8625d100ae",
+      "contactId": "huXguIGvyFHkixustqey",
+      "contactName": "Accounts Rotary Eclub Outback Australia, Division 9560",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd",
+        "goods-cold"
+      ]
+    },
+    {
+      "why": "Mala'la Basket Bed",
+      "id": "JrbJMR3rSyijKrFp21AI",
+      "name": "Mala’la Health Service Aboriginal Corporation — Goods Basket Bed v2.1",
+      "value": 5434,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "Z6POQ8e2wtBKSWDuPLEx",
+      "contactName": "Accounts Mala’la Health Service Aboriginal Corporation",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "Centrecorp Plant",
+      "id": "Ln5qUxl2w9o2gjp0w2Py",
+      "name": "Centrecorp Foundation — Goods Production Plant part 1",
+      "value": 84700,
+      "stageId": "e23847c3-5f74-4da6-a907-6c3d6d45008c",
+      "contactId": "ehnCEv62bCaGNTd1QuGp",
+      "contactName": "Randle Walker",
+      "email": "randle@centrecorp.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "project:act-ca",
+        "goods-hot"
+      ]
+    },
+    {
+      "why": "Centrecorp Basket Bed",
+      "id": "DM0gItqBcftcPFO4Qwj3",
+      "name": "Centrecorp Foundation — Goods Basket Bed v1.3",
+      "value": 37620,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "ehnCEv62bCaGNTd1QuGp",
+      "contactName": "Randle Walker",
+      "email": "randle@centrecorp.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "project:act-ca",
+        "goods-hot"
+      ]
+    },
+    {
+      "why": "Centrecorp Weave Bed",
+      "id": "lLkkIHMSpnvGPRxQu1vH",
+      "name": "Centrecorp Foundation — Goods Weave Bed v2.3 - Utopia Homelands",
+      "value": 85712,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "ehnCEv62bCaGNTd1QuGp",
+      "contactName": "Randle Walker",
+      "email": "randle@centrecorp.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "project:act-ca",
+        "goods-hot"
+      ]
+    },
+    {
+      "why": "Homeland Washing Machine",
+      "id": "sgGa5u8ehHHPFy6wq6PQ",
+      "name": "Homeland School Company — Goods. Indestructible Washing Machine v1.1",
+      "value": 4950,
+      "stageId": "835065e8-c952-4cfe-9228-5e8625d100ae",
+      "contactId": "hv7tFXO8UGDq3dMc98SG",
+      "contactName": "Accounts Homeland School Company",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "Red Dust Basket Bed",
+      "id": "RPVzkVGszff6indJ3GDJ",
+      "name": "Red Dust Role Models Limited — Goods Basket Bed v1",
+      "value": 15950,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "3v2RCOhzU5fCgsxEDgff",
+      "contactName": "Fiona Scicluna",
+      "email": "fiona@reddust.org.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-cooling"
+      ]
+    },
+    {
+      "why": "Julalikari Washing Machine",
+      "id": "mqWa6wCGCZUDK8bQs2L8",
+      "name": "Julalikari Council Aboriginal Corporation — Goods Indestructible Washing Machine v1",
+      "value": 19800,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "OSWHIOCG3vHdyAEHot6F",
+      "contactName": "GM Corporate — Julalikari",
+      "email": "gmcorporate@julalikari.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "PICC Stretch Bed (not Goods / ACT-PI)",
+      "id": "KoXLnuCmAxIp8Nrpeb0W",
+      "name": "Palm Island Community Company Limited (PICC) — Goods Stretch Bed v2.3",
+      "value": 36300,
+      "stageId": "835065e8-c952-4cfe-9228-5e8625d100ae",
+      "contactId": "f8sbjgfZo1oD0Je0yArk",
+      "contactName": "Accounts Palm Island Community Company Limited (PICC)",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "Remote job forecast (stray $0)",
+      "id": "sogR69LPK8oNQzS2u7WC",
+      "name": "Remote job forecast opportunities",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "0kEs9BJmkmi7ZUc5haEX",
+      "contactName": "Kristy Bloomfield",
+      "email": "kristy.bloomfield@oonchiumpa.com.au",
+      "tags": [
+        "goods-newsletter",
+        "justicehub",
+        "partner",
+        "act-gd",
+        "act-jh",
+        "project:act-hv",
+        "project:act-gd"
+      ]
+    }
+  ]
+}

--- a/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed.json
+++ b/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed.json
@@ -1,0 +1,194 @@
+{
+  "pipelineId": "FjMyJM3YzWQFmKqR9fur",
+  "removedAt": "2026-05-27T05:40:36.853Z",
+  "records": [
+    {
+      "why": "GD2 test record",
+      "id": "qLaDvOyq1yOHZGOAKHrS",
+      "name": "GD2 - flagship-inquiry",
+      "value": 0,
+      "stageId": "1fd317ec-f8f1-4837-b324-e48c22956cdd",
+      "contactId": "bP4jEBSns3be5KnonIro",
+      "contactName": "GD2",
+      "email": "opp-v2-gd@example.com",
+      "tags": [
+        "test-submission",
+        "act-regenerative-studio",
+        "act-gd",
+        "flagship-inquiry"
+      ]
+    },
+    {
+      "why": "dup THULKURR",
+      "id": "7Fn2JOclc2CoNWfgaMqB",
+      "name": "Goods Buyer: THULKURR — Unmet demand: THULKURR (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "7sp5Zwueh0OKblAKQirR",
+      "contactName": "THULKURR QLD",
+      "email": "thulkurr@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup NEW MERINEE",
+      "id": "y8w1eSUJMhQlYM0ecMco",
+      "name": "Goods Buyer: NEW MERINEE — Unmet demand: NEW MERINEE (NSW) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "xBxaigCAdO1v8ARO1lo2",
+      "contactName": "NEW MERINEE NSW",
+      "email": "new-merinee@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup GUNUN WOONAM",
+      "id": "fpdvQF3YmXvoAs3fmYGA",
+      "name": "Goods Buyer: GUNUN WOONAM — Unmet demand: GUNUN WOONAM (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "gPxPrnGkA01DbSigTaYM",
+      "contactName": "GUNUN WOONAM QLD",
+      "email": "gunun-woonam@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup SHIPTON FLATS",
+      "id": "It2t2mhn6S6azbnW0r0Z",
+      "name": "Goods Buyer: SHIPTON FLATS — Unmet demand: SHIPTON FLATS (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "dYbBIH1H5deXDEerV5HE",
+      "contactName": "SHIPTON FLATS QLD",
+      "email": "shipton-flats@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup FORDY FARM",
+      "id": "bxKLejbl23aP51J7dbvy",
+      "name": "Goods Buyer: FORDY FARM — Unmet demand: FORDY FARM (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "fm0tdDRDfl3EFTOg1JS7",
+      "contactName": "FORDY FARM QLD",
+      "email": "fordy-farm@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-fm"
+      ]
+    },
+    {
+      "why": "dup AAYKA",
+      "id": "gA2WqhVUiMuF0svfZYkv",
+      "name": "Goods Buyer: AAYKA — Unmet demand: AAYKA (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "jkXvzq4QJDPKCur8akIX",
+      "contactName": "AAYKA QLD",
+      "email": "aayka@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup LINGARA",
+      "id": "idpLpcz5sG76y2s8X1aI",
+      "name": "Goods Buyer: LINGARA — Unmet demand: LINGARA (NT) — 17 beds, 2 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "ZC6OOSxs3h5ZOGPm4Qgr",
+      "contactName": "LINGARA NT",
+      "email": "lingara@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup THAANGKUNH-NHIIN",
+      "id": "IKxXaIXbQFhXHieao0EI",
+      "name": "Goods Buyer: THAANGKUNH-NHIIN — Unmet demand: THAANGKUNH-NHIIN (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "cAt1QstivkhGfT2ShFAc",
+      "contactName": "THAANGKUNH-NHIIN QLD",
+      "email": "thaangkunh-nhiin@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup BANNICK BURN",
+      "id": "N95Z3uJMg8nrIYhVhlet",
+      "name": "Goods Buyer: BANNICK BURN — Unmet demand: BANNICK BURN (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "wu6SihnJXkEkKrUYtheG",
+      "contactName": "BANNICK BURN QLD",
+      "email": "bannick-burn@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup JILUNDARINA",
+      "id": "nAcEQ7QM1gD1rxG2eSW4",
+      "name": "Goods Buyer: JILUNDARINA — Unmet demand: JILUNDARINA (NT) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "Q0HsirXpDJJ3vLpNIKmj",
+      "contactName": "JILUNDARINA NT",
+      "email": "jilundarina@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    }
+  ],
+  "malalaBadOpp": "WhMkunwtIU6ug12rtApN",
+  "malalaStubContact": "J4iGAZJY70veM2FjqkzD"
+}


### PR DESCRIPTION
GHL pipeline tooling for the Goods enterprise CRM. Writes applied during the session; this PR is the tooling + restore record.

## What's here
- **seed-goods-supporter-journey.mjs** — seed 13 funders into the GHL "Goods — Supporter Journey" pipeline at warmth-mapped stages with `goods-<band>` tags. Idempotent.
- **audit-goods-buyer-pipelines.mjs** — read-only categoriser for the two buyer pipelines.
- **cleanup-goods-buyer-pipeline.mjs** — flag-gated cleanup to commercial-only (removes test/dup/funder records); restore snapshot first.
- **thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed*.json** — restore snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)