### PR TITLE
docs(civic-os): Civic Operating System reframe + ALMA spell-out (+ goods GHL seed)

### DIFF
--- a/.claude/skills/act-brand-alignment/SKILL.md
+++ b/.claude/skills/act-brand-alignment/SKILL.md
@@ -38,7 +38,7 @@ Listen → Curiosity → Action → Art
 | JusticeHub | Justice innovation, forkable models | `projects-ecosystem.md` |
 | Empathy Ledger | Ethical storytelling, consent, sovereignty | `projects-ecosystem.md` |
 | The Harvest | CSA, community gatherings | `land-practice.md` |
-| Goods on Country | Circular economy, waste-to-product | `projects-ecosystem.md` |
+| Goods on Country | Circular economy, waste-to-product, comms agent system | `goods.md` |
 | Art | Art as revolution, cultural production | `projects-ecosystem.md` |
 
 ## Voice Guardrails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 
 Always spell out ALMA on first use:
 
-Accountable Listening and Meaningful Action (ALMA)
+Australian Living Map of Alternatives (ALMA)
 
 Do not describe ALMA as:
 - the Soul
@@ -23,7 +23,7 @@ Do not describe ALMA as:
 - a replacement for human or community authority
 
 Describe ALMA as:
-ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.
+ACT's catalogue of community-led alternatives, evidence-graded with cultural authority.
 
 ## Git Hygiene
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 Always spell out ALMA on first use:
 
-Accountable Listening and Meaningful Action (ALMA)
+Australian Living Map of Alternatives (ALMA)
 
 Do not describe ALMA as:
 - the soul
@@ -16,7 +16,7 @@ Do not describe ALMA as:
 - a replacement for human or community authority
 
 Describe ALMA as:
-ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.
+ACT's catalogue of community-led alternatives, evidence-graded with cultural authority.
 
 ## Database & Environment
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - **Soul** - the origin layer of ACT.
 - **LCAA** - Listen, Curiosity, Action, Art; ACT's practice loop.
-- **ALMA** - Accountable Listening and Meaningful Action; ACT's governed sensemaking process.
+- **ALMA** - Australian Living Map of Alternatives; ACT's evidence-graded catalogue of community-led alternatives.
 - **Governed Proof** - the evidence, review, and publication layer.
 
 ---

--- a/STEERING.md
+++ b/STEERING.md
@@ -27,7 +27,7 @@ The rule: root-level files orient agents and developers; `wiki/` holds the canon
 | Soul | `wiki/concepts/soul.md` | Why Ben and Nic do this work. The upstream file. |
 | Identity | `wiki/concepts/act-identity.md` | What A Curious Tractor is. |
 | Method | `wiki/concepts/lcaa-method.md` | Listen, Curiosity, Action, Art as operating practice. |
-| Accountable action | `wiki/concepts/alma.md` | Accountable Listening and Meaningful Action: the governed listening-to-action process. |
+| Accountable action | `wiki/concepts/alma.md` | Australian Living Map of Alternatives: the governed listening-to-action process. |
 | Governed proof | `wiki/concepts/governed-proof.md` | Evidence, review, confidence, publication, and audit trails. |
 | Obsolescence | `wiki/concepts/beautiful-obsolescence.md` | The handover discipline. |
 | Economy | `wiki/concepts/four-lanes.md` | To Us, To Down, To Grow, To Others. |

--- a/apps/command-center/public/ask.html
+++ b/apps/command-center/public/ask.html
@@ -370,7 +370,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr><td><strong>Circle One &middot; data spine</strong> (CivicGraph + JusticeHub + Accountable Listening and Meaningful Action (ALMA) review + AI agent tools)</td><td><span class="yes">Yes &middot; 3 years</span></td><td><span class="yes">Yes &middot; Year 1</span></td><td><span class="yes">Yes &middot; 3 years</span></td></tr>
+        <tr><td><strong>Circle One &middot; data spine</strong> (CivicGraph + JusticeHub + Australian Living Map of Alternatives (ALMA) review + AI agent tools)</td><td><span class="yes">Yes &middot; 3 years</span></td><td><span class="yes">Yes &middot; Year 1</span></td><td><span class="yes">Yes &middot; 3 years</span></td></tr>
         <tr><td><strong>Circle Two &middot; the seven anchors</strong> (community partnerships, storytelling team)</td><td><span class="yes">Yes &middot; all 7, all 3 years</span></td><td><span class="partial">Year 1 only &middot; subject to renewal</span></td><td><span class="no">No &middot; assemble separately</span></td></tr>
         <tr><td><strong>Circle Three &middot; ecosystem + artefact</strong> (international tour, documentary, library, journals, exhibition, installations)</td><td><span class="yes">Yes &middot; full delivery in 2028</span></td><td><span class="partial">Foundation laid &middot; full delivery contingent</span></td><td><span class="no">No &middot; assemble separately</span></td></tr>
         <tr><td><strong>Minderoo on the artefact</strong> (cover, convening, framework launch)</td><td><span class="yes">Yes &middot; named on all three</span></td><td><span class="partial">Year 1 acknowledgement &middot; cover contingent</span></td><td><span class="partial">Centre acknowledgement only</span></td></tr>

--- a/apps/command-center/public/system.html
+++ b/apps/command-center/public/system.html
@@ -109,7 +109,7 @@
     <div class="arch-frame">
       <svg class="arch-svg" viewBox="0 0 1200 920" role="img" aria-labelledby="arch-title arch-desc">
         <title id="arch-title">Three Circles system architecture diagram</title>
-        <desc id="arch-desc">A vertical flow diagram. At the top, public data inputs feed into a CivicGraph entity-resolution layer. CivicGraph feeds into JusticeHub through Accountable Listening and Meaningful Action review via the Australian Business Number bridge. Both feed into Empathy Ledger v2 via storyteller and organisation IDs. From the layered spine, outputs flow to community organisations, advocacy work, government engagement, philanthropy coordination, magistrates, journalists, researchers and lived experience.</desc>
+        <desc id="arch-desc">A vertical flow diagram. At the top, public data inputs feed into a CivicGraph entity-resolution layer. CivicGraph feeds into JusticeHub through Australian Living Map of Alternatives review via the Australian Business Number bridge. Both feed into Empathy Ledger v2 via storyteller and organisation IDs. From the layered spine, outputs flow to community organisations, advocacy work, government engagement, philanthropy coordination, magistrates, journalists, researchers and lived experience.</desc>
 
         <defs>
           <linearGradient id="gradCG" x1="0" y1="0" x2="0" y2="1">
@@ -447,7 +447,7 @@
       </div>
       <div class="overlap-row">
         <div class="priority">Generation One<span class="priority-tag">Indigenous economic participation</span></div>
-        <div class="answer">CivicGraph resolves 7,500 ORIC Indigenous corporations and the social-enterprise registers. JusticeHub uses Accountable Listening and Meaningful Action (ALMA) review to keep intervention evidence tied to consent, authority, provenance, and community value return. Empathy Ledger v2 enforces OCAP at the data layer. Generation One&rsquo;s economic and social work runs on the same rails. When the seven young people walk into work instead of remand, this is where they walk into.</div>
+        <div class="answer">CivicGraph resolves 7,500 ORIC Indigenous corporations and the social-enterprise registers. JusticeHub uses Australian Living Map of Alternatives (ALMA) review to keep intervention evidence tied to consent, authority, provenance, and community value return. Empathy Ledger v2 enforces OCAP at the data layer. Generation One&rsquo;s economic and social work runs on the same rails. When the seven young people walk into work instead of remand, this is where they walk into.</div>
       </div>
       <div class="overlap-row">
         <div class="priority">Disability inclusion<span class="priority-tag">NDIS layer</span></div>

--- a/apps/command-center/public/tractorpedia.html
+++ b/apps/command-center/public/tractorpedia.html
@@ -3528,7 +3528,7 @@ These rules apply to every surface, regardless of cluster:
 
 1. **Voice (Curtis method).** Name the room, name the body, load the abstract noun, stop the line before the explanation. From \`writing-voice.md\`.
 2. **AI-tells blocklist.** Never use: delve, crucial, pivotal, tapestry, underscore, "not just X but Y", rule-of-three adjective padding, em-dashes (in any ACT-facing writing), "challenges and future prospects", "-ing" significance tails.
-3. **Naming.** "Accountable Listening and Meaningful Action (ALMA)" needs first-use expansion and should not be used bare. Call the intervention map "JusticeHub evidence map" or "ALMA-governed JusticeHub evidence", not ALMA. "Listen · Curiosity · Action · Art" never bare "LCAA". Indigenous place names always; colonial in brackets only.
+3. **Naming.** "Australian Living Map of Alternatives (ALMA)" needs first-use expansion and should not be used bare. Call the intervention map "JusticeHub evidence map" or "ALMA-governed JusticeHub evidence", not ALMA. "Listen · Curiosity · Action · Art" never bare "LCAA". Indigenous place names always; colonial in brackets only.
 4. **LCAA imprint.** Every project should be reachable from the LCAA framing — Listen, Curiosity, Action, Art — visually OR narratively. Some lean Listen (EL v2), some Action (JH), some Art (Studio), some all four (Farm). State which.
 5. **Indigenous protocols.** Cultural-protocols-true projects (PICC, Oonchiumpa, BG Fit, Mounty Yarns) require OCAP-style consent before any storyteller content lands publicly. From \`wiki/projects/...\` per-project notes + \`project_wiki_story_sync.md\` memory.
 
@@ -3717,7 +3717,7 @@ Full list: \`config/project-codes.json\` (v1.8.0, 74 projects, all with canonica
 
 ## Naming & voice (always apply)
 
-- **"Accountable Listening and Meaningful Action (ALMA)"** — spell out on first use; never use bare "ALMA" in external copy
+- **"Australian Living Map of Alternatives (ALMA)"** — spell out on first use; never use bare "ALMA" in external copy
 - **"JusticeHub evidence map"** or **"ALMA-governed JusticeHub evidence"** — use this for the intervention map; do not call the map "ALMA"
 - **"Listen · Curiosity · Action · Art"** — never bare acronym "LCAA" in external copy
 - **Indigenous place names always**, colonial in brackets only
@@ -5574,7 +5574,7 @@ Marchesi Family Trust ─┘    │
                             ├──► Empathy Ledger v2 (project + future spinout candidate)
                             ├──► JusticeHub (project)
                             ├──► CivicGraph / Civic World Model (project)
-                            └──► ALMA (governed sensemaking process)
+                            └──► ALMA (the catalogue, evidence-graded)
 
 Nicholas Marchesi T/as A Curious Tractor (sole trader, ABN 21 591 780 066)
     Stops trading 30 June 2026
@@ -7145,7 +7145,7 @@ This thesis maps directly to ACT's methodology:
 
 ## Overview
 
-ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect [[alma|Accountable Listening and Meaningful Action (ALMA)]]: consent, authority, provenance, and review before action. Efficiency is never a sufficient reason to bypass these constraints.
+ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect [[alma|Australian Living Map of Alternatives (ALMA)]]: consent, authority, provenance, and review before action. Efficiency is never a sufficient reason to bypass these constraints.
 
 This article covers the ethical framework, the internal agent roles, and what AI can and cannot do within ACT systems.
 
@@ -7161,7 +7161,7 @@ This article covers the ethical framework, the internal agent roles, and what AI
 
 ## AI Under ALMA Review
 
-ALMA is not an AI agent or a technical gatekeeper. It is the governed sensemaking process AI tools must remain subordinate to:
+ALMA is not an AI agent or a technical gatekeeper. It is the evidence-graded catalogue AI tools must remain subordinate to:
 
 \`\`\`
 User/Community Input
@@ -7240,7 +7240,7 @@ For any new AI feature:
 | Check | Required |
 |-------|----------|
 | OCAP principles respected? | Yes |
-| Accountable Listening and Meaningful Action (ALMA) respected? | Yes |
+| Australian Living Map of Alternatives (ALMA) respected? | Yes |
 | Individual profiling prevented? | Yes |
 | Sacred content hard-blocked? | Yes |
 | Community authority preserved? | Yes |
@@ -7259,7 +7259,7 @@ As AI capabilities grow, ACT maintains:
 
 ## Backlinks
 
-- [[alma|ALMA]] — governed sensemaking process AI must remain subordinate to
+- [[alma|ALMA]] — evidence-graded catalogue whose cultural-authority and scoring methodology AI must respect
 - [[governance-consent|Governance & Consent]] — consent architecture AI must respect
 - [[empathy-ledger|Empathy Ledger]] — the platform where AI consent settings live
 - [[ai-community-engagement|AI Community Engagement]] — broader AI use in community contexts
@@ -7480,16 +7480,16 @@ Allan Palm Island helps explain a recurring ACT pattern: cultural authority trav
   },
   "alma": {
     slug: "alma",
-    title: "ALMA - Accountable Listening and Meaningful Action",
+    title: "ALMA - Australian Living Map of Alternatives",
     domain: "concepts",
     links: ["soul","lcaa-method","governed-proof","empathy-ledger","governance-consent","ai-ethics","beautiful-obsolescence","glossary","transcript-analysis-method","ways-of-working","roadmap-2026"],
-    content: `# ALMA - Accountable Listening and Meaningful Action
+    content: `# ALMA - Australian Living Map of Alternatives
 
 > Listening becomes action only when consent, authority, provenance, and review are clear.
 
 ## One-Line Definition
 
-Accountable Listening and Meaningful Action (ALMA) is ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.
+Australian Living Map of Alternatives (ALMA) is ACT's catalogue of community-led alternatives, evidence-graded with cultural authority.
 
 ## Where ALMA Sits
 
@@ -7598,7 +7598,7 @@ These fields can support ALMA. They are not ALMA itself.
 Always spell out the first mention:
 
 \`\`\`text
-Accountable Listening and Meaningful Action (ALMA)
+Australian Living Map of Alternatives (ALMA)
 \`\`\`
 
 Do not use the acronym alone in public-facing writing unless it has already been defined on that page.
@@ -7612,13 +7612,13 @@ ALMA will assess community signals and generate recommendations.
 Better:
 
 \`\`\`text
-Accountable Listening and Meaningful Action (ALMA) helps ACT and community partners decide what can be acted on, shared, funded, reviewed, or held back after listening.
+Australian Living Map of Alternatives (ALMA) helps ACT and community partners decide what can be acted on, shared, funded, reviewed, or held back after listening.
 \`\`\`
 
 Best:
 
 \`\`\`text
-Accountable Listening and Meaningful Action (ALMA) is not an AI deciding for people. It is ACT's governed sensemaking process: listening first, checking consent and authority, tracing evidence, then supporting meaningful action.
+Australian Living Map of Alternatives (ALMA) is not an AI deciding for people. It is ACT's evidence-graded catalogue: listening first, checking consent and authority, tracing evidence, then supporting meaningful action.
 \`\`\`
 
 ## Backlinks
@@ -9103,7 +9103,7 @@ ON ANY NEW DESIGN WORK in any ACT repo
 ### Communications + Public-facing writing
 - **Voice rules**: \`.claude/skills/act-brand-alignment/references/writing-voice.md\` (Curtis method + AI-tells blocklist)
 - **Identity**: \`.claude/skills/act-brand-alignment/references/brand-core.md\` (LCAA, voice, project narratives)
-- **Naming rules**: in act-core-facts.md (first-use Accountable Listening and Meaningful Action (ALMA); call the intervention map JusticeHub evidence; no bare "LCAA"; Indigenous place names always; no em-dashes)
+- **Naming rules**: in act-core-facts.md (first-use Australian Living Map of Alternatives (ALMA); call the intervention map JusticeHub evidence; no bare "LCAA"; Indigenous place names always; no em-dashes)
 - **Daily action**: nothing — this surfaces only when you write
 - **Whenever drafting**: load both writing-voice.md + brand-core.md before composing (every Claude session in any ACT repo already has the pointers via CLAUDE.md)
 
@@ -16158,8 +16158,8 @@ ACT's methodology for ethical innovation:
 
 See [[lcaa-method|LCAA Method]].
 
-### Accountable Listening and Meaningful Action (ALMA)
-ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review. ALMA is not the Soul, an AI personality, a dashboard, or a ranking engine. See [[alma|ALMA]].
+### Australian Living Map of Alternatives (ALMA)
+ACT's catalogue of community-led alternatives, evidence-graded with cultural authority. ALMA is not the Soul, an AI personality, a dashboard, or a ranking engine. See [[alma|ALMA]].
 
 ### Power Take-Off (PTO)
 A tractor mechanism that transfers engine power to implements. ACT's founding metaphor: we provide power that communities direct, not the other way around.
@@ -16304,7 +16304,7 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 | Acronym | Meaning |
 |---------|---------|
 | ACT | A Curious Tractor |
-| ALMA | Accountable Listening and Meaningful Action |
+| ALMA | Australian Living Map of Alternatives |
 | BCV | Black Cockatoo Valley |
 | CSA | Community Supported Agriculture |
 | GHL | GoHighLevel (CRM platform) |
@@ -16876,7 +16876,7 @@ Every project should be able to answer:
 
 ## Definition
 
-Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits after [[alma|Accountable Listening and Meaningful Action (ALMA)]].
+Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits after [[alma|Australian Living Map of Alternatives (ALMA)]].
 
 ALMA helps decide whether listening can become action. Governed Proof records what happened next, what supports it, who reviewed it, what confidence it carries, and what can be shared.
 
@@ -19998,7 +19998,7 @@ JusticeHub needs **$500K** to scale nationally.
 
 ## ALMA-Governed Evidence Records
 
-The "what works" layer sitting on top of funding data, governed by [[alma|Accountable Listening and Meaningful Action (ALMA)]]:
+The "what works" layer sitting on top of funding data, governed by [[alma|Australian Living Map of Alternatives (ALMA)]]:
 - Evidence-based interventions mapped by topic and geography
 - 9 topic domains: child-protection, community-led, diversion, family-services, indigenous, legal-services, ndis, prevention, youth-justice
 - Cross-referenced with CivicGraph entity graph (56% linkage rate)
@@ -20635,7 +20635,7 @@ Every project, every piece of art, every community relationship can be tagged wi
 - [[civicgraph|CivicGraph]]: Curiosity
 - [[picc|PICC]]: spans all four phases
 - [[third-reality|The Third Reality]]: the synthesis LCAA produces
-- [[alma|ALMA]]: governed sensemaking process that turns listening into accountable action
+- [[alma|ALMA]]: evidence-graded catalogue of what works across community-led alternatives
 - [[governed-proof|Governed Proof]]: evidence and review layer after action
 - [[ai-community-engagement|AI and Community Engagement]]: administrative compression that protects time for relational work
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the Action phase discipline
@@ -28014,7 +28014,7 @@ This is a seasonal map, not a fixed plan. ACT chooses readiness over deadlines a
 | Finalise compendium and align project language to core model | In Progress |
 | Stabilise Harvest operations and maker pathways in Witta | In Progress |
 | Confirm Goods production readiness and support pathways | Planning |
-| Align AI agent guardrails to Accountable Listening and Meaningful Action (ALMA) and Empathy Ledger | Complete |
+| Align AI agent guardrails to Australian Living Map of Alternatives (ALMA) and Empathy Ledger | Complete |
 | JusticeHub vision and path to externalise | Planning |
 | ACT regular communication (1-to-some and 1-to-many via GHL) | In Progress |
 
@@ -29062,7 +29062,7 @@ Soul is why ACT exists.
 
 ALMA is not the soul.
 
-[[alma|Accountable Listening and Meaningful Action (ALMA)]] is one downstream process that helps ACT move from listening to responsible action without bypassing consent, authority, provenance, or human and community review.
+[[alma|Australian Living Map of Alternatives (ALMA)]] is one downstream process that helps ACT move from listening to responsible action without bypassing consent, authority, provenance, or human and community review.
 
 ---
 
@@ -34446,7 +34446,7 @@ This method is the answer.
     links: ["alma","governed-proof","vignette-workflows","governance-consent","act-architecture","transcript-analysis-method"],
     content: `# Descript Transcription & ALMA Review Workflow
 
-> How transcribed stories move from Descript into Empathy Ledger and through Accountable Listening and Meaningful Action review.
+> How transcribed stories move from Descript into Empathy Ledger and through Australian Living Map of Alternatives review.
 
 ## Overview
 

--- a/apps/command-center/public/wiki/README.md
+++ b/apps/command-center/public/wiki/README.md
@@ -2,6 +2,6 @@
 
 This folder is a generated legacy mirror of the canonical repo-root wiki at `/wiki`.
 
-- Generated: `2026-05-18T03:37:13.699Z`
+- Generated: `2026-05-25T19:37:27.398Z`
 - Use `node scripts/wiki-sync-command-center-snapshot.mjs` to regenerate it.
 - Do not edit these files as the source of truth.

--- a/apps/command-center/public/wiki/act/ai-ethics.md
+++ b/apps/command-center/public/wiki/act/ai-ethics.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/ai-ethics.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # AI Ethics & Agent Strategy
 
@@ -13,7 +13,13 @@ status: Active
 
 ## Overview
 
-ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect [[alma|Accountable Listening and Meaningful Action (ALMA)]]: consent, authority, provenance, and review before action. Efficiency is never a sufficient reason to bypass these constraints.
+ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect three composed gatekeepers, each owned by a different layer of the [[civic-operating-system|civic operating system]]:
+
+- **Consent** lives in [[empathy-ledger|Empathy Ledger]] (consent state, AI-use ledger, audit trail)
+- **Cultural authority and evidence quality** live in [[alma|Australian Living Map of Alternatives (ALMA)]] scoring methodology (the six dimensions; cultural-authority verification before any score is set)
+- **Publication discipline** lives in [[governed-proof|Governed Proof]] (confidence rating, review trail, what can be shared with whom)
+
+Efficiency is never a sufficient reason to bypass any of these. This is the operational expression of the [[civic-reflex-automation|Civic Reflex Automation]] thesis: gatekeeping reflexes are automated and verifiable; the human work (cultural authority, judgment, relationship) stays human.
 
 This article covers the ethical framework, the internal agent roles, and what AI can and cannot do within ACT systems.
 
@@ -27,18 +33,17 @@ This article covers the ethical framework, the internal agent roles, and what AI
 | **Community authority highest weight** | Overrides efficiency in decision paths |
 | **Consent before analysis** | No opt-out model, explicit opt-in only |
 
-## AI Under ALMA Review
+## AI Under the Composed Gatekeepers
 
-ALMA is not an AI agent or a technical gatekeeper. It is the governed sensemaking process AI tools must remain subordinate to:
+ALMA is the catalogue, not the gatekeeping process. The three gates above (consent, cultural authority and evidence quality, publication discipline) are each owned by a different layer and composed at runtime. The flow:
 
 ```
 User/Community Input
         ↓
-   Governed Review
-   - Consent verified?
-   - Cultural sensitivity flagged?
-   - Authority confirmed?
-   - Provenance clear?
+   Composed Gate (at intake)
+   - Consent verified?         (Empathy Ledger)
+   - Cultural authority?       (ALMA scoring methodology)
+   - Evidence supported?       (ALMA scoring methodology)
         ↓
    AI Processing (if permitted)
         ↓
@@ -47,8 +52,15 @@ User/Community Input
    - Individual profiling avoided?
    - Value returned to community?
         ↓
-   Output
+   Composed Gate (at output)
+   - Publication permitted?    (Governed Proof)
+   - Confidence rating set?    (Governed Proof)
+   - Audit trail written?      (Empathy Ledger AI-use ledger)
+        ↓
+   Output (with provenance, written to audit trail)
 ```
+
+Each gate is a real check enforced by code in the relevant layer, not an aspirational principle. See [[civic-operating-system|the Civic Operating System concept page]] for how the layers compose.
 
 ## What AI Can Do
 
@@ -108,7 +120,7 @@ For any new AI feature:
 | Check | Required |
 |-------|----------|
 | OCAP principles respected? | Yes |
-| Accountable Listening and Meaningful Action (ALMA) respected? | Yes |
+| Australian Living Map of Alternatives (ALMA) respected? | Yes |
 | Individual profiling prevented? | Yes |
 | Sacred content hard-blocked? | Yes |
 | Community authority preserved? | Yes |
@@ -127,8 +139,11 @@ As AI capabilities grow, ACT maintains:
 
 ## Backlinks
 
-- [[alma|ALMA]] — governed sensemaking process AI must remain subordinate to
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture this ethics framework composes across
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis these principles operationalise (automate the boring, amplify the art, never replace judgment)
+- [[alma|ALMA]] — the catalogue layer; AI must respect its cultural authority and evidence-scoring methodology
+- [[empathy-ledger|Empathy Ledger]] — the consent + audit + AI-use ledger layer
+- [[governed-proof|Governed Proof]] — the publication gate AI outputs pass through
 - [[governance-consent|Governance & Consent]] — consent architecture AI must respect
-- [[empathy-ledger|Empathy Ledger]] — the platform where AI consent settings live
 - [[ai-community-engagement|AI Community Engagement]] — broader AI use in community contexts
 - [[transcript-analysis-method|Transcript Analysis Method]] — the concrete guardrail set for AI transcription and theme extraction

--- a/apps/command-center/public/wiki/act/alma.md
+++ b/apps/command-center/public/wiki/act/alma.md
@@ -1,39 +1,66 @@
 ---
-title: ALMA - Accountable Listening and Meaningful Action
+title: ALMA - Australian Living Map of Alternatives
 status: Active
+source_of_truth: wiki/concepts/soul.md
+reframed_by: wiki/decisions/2026-05-25-civic-cerebellum-reframe.md
+rewritten: 2026-05-25
 ---
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/alma.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
-# ALMA - Accountable Listening and Meaningful Action
+# ALMA - Australian Living Map of Alternatives
 
-> Listening becomes action only when consent, authority, provenance, and review are clear.
+> The Living Map. A catalogue of community-led alternatives to detention, dependency, and extractive systems, each scored by evidence quality and cultural authority. A noun, not a verb.
 
-## One-Line Definition
+> This concept sits downstream of [[soul|Soul]]. If anything on this page contradicts soul, soul is right. It was rewritten on 2026-05-25 as part of the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe]] cleanup, after the name "Australian Living Map of Alternatives" was made canonical and the older "sensemaking process" framing was retired.
 
-Accountable Listening and Meaningful Action (ALMA) is ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.
+## What ALMA Is
+
+Australian Living Map of Alternatives (ALMA) is ACT's catalogue of community-led interventions that work, do not work, or are still being learned. Today it holds 1,112 interventions from 507 organisations across the youth justice, child protection, family services, and adjacent fields. Each intervention is scored on six dimensions and tied back to evidence, source, cultural authority, and target cohort.
+
+ALMA is **the map**. It is not a process, not a dashboard, not an AI agent. It is the curated reference that other parts of the civic operating system draw on when they need to answer "what works, and how do we know."
+
+The map lives in the database: `alma_interventions`, `alma_evidence`, `alma_outcomes`. The catalogue is the canonical artifact. Any concept page or pitch deck that disagrees with what is actually in those tables is wrong; the tables are right.
+
+## The Six Scoring Dimensions (the methodology)
+
+Every intervention in ALMA is scored on six dimensions. The scoring methodology is what makes the map *governed* rather than just a list.
+
+| Dimension | What it asks |
+|---|---|
+| **Evidence strength** | Is the claim sourced and reliable? What kind of evidence supports it (research, practice records, lived-experience accounts)? |
+| **Community authority** | Who has the right to speak about this? Has cultural authority been verified? |
+| **Harm risk** | What could go wrong if this is funded, replicated, or scaled? |
+| **Implementation capability** | Can this be done responsibly now, with the people and infrastructure available? |
+| **Option value** | Does adopting this open or close future possibilities? |
+| **Community value return** | Does value flow back to the people and place involved, or only outward to funders and institutions? |
+
+These six dimensions **are** ALMA's methodology. They are not external supports for some other thing called ALMA. The dimensions plus the catalogue plus the scoring records together are the Map.
 
 ## Where ALMA Sits
 
-ALMA is downstream of [[soul|Soul]] and [[lcaa-method|LCAA Method]]. It is not the soul of ACT, the founder voice, an AI personality, or a dashboard.
+The conceptual lineage, updated to match the post-reframe architecture:
 
 ```text
 Soul
-Why this exists before ACT
+  Why ACT exists
 
-LCAA
-How ACT practises: Listen, Curiosity, Action, Art
+LCAA Method
+  How ACT practises: Listen, Curiosity, Action, Art
 
 ALMA
-How listening becomes accountable action
+  The catalogue of community-led alternatives, evidence-graded and cultural-authority-verified
+
+Empathy Ledger
+  The consent infrastructure that protects the stories and storytellers feeding into evidence
 
 Governed Proof
-How action becomes evidence, review, confidence, and publication
+  The audit + review + publication layer that gates which claims from ALMA can be shared, and with what confidence
 
-Projects
-Harvest, JusticeHub, Empathy Ledger, Community Capital, CONTAINED
+JusticeHub
+  The practice layer. JusticeHub Atlas surfaces ALMA publicly; JusticeHub Practice draws on ALMA when partner orgs do the work
 ```
 
 The short version:
@@ -41,120 +68,90 @@ The short version:
 ```text
 Soul tells us why.
 LCAA tells us how we practise.
-ALMA tells us how listening becomes accountable action.
-Governed Proof tells us how action becomes evidence.
-Harvest shows whether any of it is real.
+ALMA holds what we have learned about what works.
+Empathy Ledger protects the consent of the people whose work and stories feed it.
+Governed Proof gates what can be published and at what confidence.
+JusticeHub is where the map gets used in the real world.
 ```
 
-## What ALMA Does
+## How ALMA Connects to the Civic Operating System
 
-ALMA helps ACT and community partners decide what can be acted on, shared, funded, reviewed, held back, handed over, or refused after listening.
+Per the [[civic-operating-system|Civic Operating System]] architecture, ALMA is the **evidence catalogue** layer that the practice and intelligence layers draw on. Specifically:
 
-It does this by asking:
+- **[[justicehub|JusticeHub]] Atlas** is the public surface where ALMA is read. The Atlas is the user-facing brand; ALMA is the data layer behind it. In external copy, prefer "JusticeHub evidence map" or "the evidence catalogue" over bare "ALMA" (see [[../decisions/act-brand-alignment-map|brand alignment map]] line 196).
+- **[[justicehub|JusticeHub]] Practice** queries ALMA when a partner organisation is doing operational work, to surface "what has worked for this cohort in this region."
+- **[[civicgraph|CivicGraph]]** holds the financial and structural context (who funds whom, who contracts with whom). When CivicGraph and ALMA are composed, the question "what works AND who actually funds it" becomes answerable.
+- **[[empathy-ledger|Empathy Ledger]]** holds the consented stories that feed evidence into ALMA. Stories do not enter ALMA without consent flowing through Empathy Ledger first.
+- **[[governed-proof|Governed Proof]]** gates publication. A claim from ALMA does not become a public statement without Governed Proof's confidence rating, review status, and audit trail attached.
 
-- What did we hear?
-- Who holds authority here?
-- What does consent allow?
-- Where did this evidence come from?
-- What action would be meaningful to the people, place, or system involved?
-- What should be reviewed, held back, handed over, or refused?
+## How the Map Gets Curated
 
-## The ALMA Movement
+ALMA is a *Living* Map for a reason: the catalogue is added to, scored, and re-reviewed continuously, not built once. The curation process draws on the [[lcaa-method|LCAA Method]]:
 
-ALMA is the bridge between listening and action.
+- **Listen** — new interventions enter the catalogue from practitioner accounts, lived-experience interviews, sector research, [[empathy-ledger|Empathy Ledger]] stories with consent, and partner-org self-reports. The intake is broad; the scoring is what filters.
+- **Curiosity** — every new entry is scored on the six dimensions by a reviewer with cultural authority appropriate to the intervention. Indigenous-led interventions are scored by Indigenous reviewers; lived-experience interventions are scored with lived-experience input.
+- **Action** — entries with sufficient confidence are surfaced through [[justicehub|JusticeHub]] Atlas, used in commissioned briefs, and quoted in sector publications. Low-confidence entries stay in the map but are flagged.
+- **Art** — the map itself is published as a public artifact (the Atlas) and as a periodic State-of-the-Field synthesis. The art is in the curation, not in concealing the work.
 
-```text
-Listen
-  receive what is offered
-  resist the urge to arrive with a fix
+Curation is a continuous practice, not a quarterly project. The map gets re-scored when new evidence arrives or when the cultural-authority assessment of a prior entry needs updating.
 
-Meaning
-  check authority, consent, context, provenance, and consequence
-  decide whether the signal is ready for action
-
-Action
-  act, review, publish, fund, hold back, hand over, or refuse
-```
-
-The working sentence is:
-
-> We listened. We checked who has authority. We checked what consent allows. We traced the evidence. We asked what action would be meaningful. We either acted, reviewed, held back, or handed over.
-
-That is ALMA.
-
-## What ALMA Does Not Do
+## What ALMA Is Not
 
 ALMA is not:
 
-- the Soul
-- the founder voice
-- an AI personality
-- a dashboard
-- a product brand
-- a ranking engine
-- a measurement dashboard
-- a replacement for community authority
-- a way to make extraction sound ethical
-- permission to publish without review
-- permission to make AI sovereign
-
-## Operational Records
-
-Some legacy schemas and reports use fields named `alma_signals`, `ALMA score`, or `ALMA interventions`. Keep those as internal record names where changing them would break data lineage.
-
-Do not let those fields redefine ALMA.
-
-The six review fields are prompts inside the governed process, not the public meaning of ALMA:
-
-| Review field | What it slows down |
-| --- | --- |
-| Evidence strength | Is the claim sourced and reliable? |
-| Community authority | Who has the right to speak or decide? |
-| Harm risk | What could go wrong if we act or share? |
-| Implementation capability | Can this be done responsibly now? |
-| Option value | Does this open or close future possibilities? |
-| Community value return | Does value flow back to the people or place involved? |
-
-These fields can support ALMA. They are not ALMA itself.
+- **A process.** ALMA is the map; the process of curating it draws on LCAA, and the process of publishing from it draws on Governed Proof. Don't conflate the noun with the verbs that act on it.
+- **An AI agent.** ALMA does not "decide" anything. Reviewers with cultural authority do the scoring. Software helps the recording, the lookups, and the visualisations.
+- **A ranking engine.** ALMA scores interventions on six dimensions; it does not produce a single "ALMA score" that ranks every intervention against every other. The dimensions are intentionally multi-axis to resist single-number ranking.
+- **A measurement dashboard.** ALMA is the catalogue; impact dashboards built on top of it are derivative outputs, not ALMA itself.
+- **The Soul.** [[soul|Soul]] is upstream. ALMA is downstream of Soul and LCAA.
+- **A replacement for community authority.** ALMA records the community authority that scored each entry; it does not substitute for that authority.
+- **A way to make extraction sound ethical.** Putting cultural-authority and evidence-confidence scores on extractive interventions does not redeem them. Low scores are honest; low scores are also a signal to stop funding the intervention.
+- **Permission to publish without review.** Publication from ALMA goes through [[governed-proof|Governed Proof]]. The map is a reference, not a publication licence.
+- **A user-facing brand.** Public copy prefers "JusticeHub evidence map" or "the evidence catalogue." ALMA is the internal name for the system behind the surface (see [[../decisions/act-brand-alignment-map|brand alignment map]]).
 
 ## First-Use Rule
 
-Always spell out the first mention:
+Always spell out the first mention on any page:
 
 ```text
-Accountable Listening and Meaningful Action (ALMA)
+Australian Living Map of Alternatives (ALMA)
 ```
 
-Do not use the acronym alone in public-facing writing unless it has already been defined on that page.
+Do not use the bare acronym in public-facing writing unless it has already been defined on that page.
 
-Bad:
+In external copy, prefer the user-facing brand:
 
 ```text
-ALMA will assess community signals and generate recommendations.
+JusticeHub evidence map (drawn from ACT's Australian Living Map of Alternatives, ALMA)
 ```
 
-Better:
+Never use the older expansion ("Accountable Listening and Meaningful Action"). That expansion was retired on 2026-05-25 because it described a process the name did not match. If you find it in any surface, fix it.
 
-```text
-Accountable Listening and Meaningful Action (ALMA) helps ACT and community partners decide what can be acted on, shared, funded, reviewed, or held back after listening.
-```
+## Composing ALMA into Impact Reporting
 
-Best:
+Impact reporting at ACT is not a separate system. It is what comes out when ALMA, [[empathy-ledger|Empathy Ledger]], [[civicgraph|CivicGraph]], and [[governed-proof|Governed Proof]] are composed correctly. A funder report draws on:
 
-```text
-Accountable Listening and Meaningful Action (ALMA) is not an AI deciding for people. It is ACT's governed sensemaking process: listening first, checking consent and authority, tracing evidence, then supporting meaningful action.
-```
+- ALMA for "which interventions are working and how confident are we"
+- Empathy Ledger for the consented stories that put faces and voices to the evidence
+- CivicGraph for the funding flows, contracts, and structural context that the interventions sit inside
+- Governed Proof for the confidence rating, the audit trail, and the publication boundaries
+
+See [[evidence-as-by-product|Evidence as a By-Product of the Work]] for the longer treatment of how reporting composes from the layers, why "evidence as a separate reporting task" is the wrong frame, and what funder/sector/internal reports look like in the composed architecture.
 
 ## Backlinks
 
-- [[soul|Soul]] - the upstream why; ALMA is downstream, never the soul
-- [[lcaa-method|LCAA Method]] - the practice loop that ALMA serves
-- [[governed-proof|Governed Proof]] - the evidence, review, and publication layer after action
-- [[empathy-ledger|Empathy Ledger]] - the story and consent infrastructure ALMA must respect
-- [[governance-consent|Governance & Consent]] - consent and authority rules ALMA depends on
-- [[ai-ethics|AI Ethics & Agent Strategy]] - AI support must remain subordinate to ALMA's consent, authority, provenance, and review checks
-- [[beautiful-obsolescence|Beautiful Obsolescence]] - handover discipline for any action ALMA supports
-- [[glossary|Glossary]] - shared language entry for ALMA across the ecosystem
-- [[transcript-analysis-method|Transcript Analysis Method]] - story analysis process that can feed ALMA review
-- [[ways-of-working|Ways of Working]] - daily rhythm for applying ALMA in planning, meetings, and review
-- [[roadmap-2026|2026 Roadmap]] - annual plan that anchors story, consent, evidence, and action
+- [[soul|Soul]] — the upstream why
+- [[lcaa-method|LCAA Method]] — the practice loop that curates the map
+- [[empathy-ledger|Empathy Ledger]] — the consent infrastructure that feeds ALMA
+- [[governed-proof|Governed Proof]] — the audit and publication gate downstream of ALMA
+- [[justicehub|JusticeHub]] — the surface where ALMA gets used (Atlas as public read, Practice as operational draw-down)
+- [[civicgraph|CivicGraph]] — the financial and structural context ALMA composes with
+- [[civic-operating-system|Civic Operating System]] — the architecture ALMA sits inside
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how impact reporting composes from ALMA + EL + CivicGraph + Governed Proof
+- [[governance-consent|Governance & Consent]] — the consent and authority rules ALMA depends on
+- [[ai-ethics|AI Ethics]] — AI support remains subordinate to ALMA's consent, authority, evidence, and review rules
+- [[beautiful-obsolescence|Beautiful Obsolescence]] — handover discipline for the catalogue
+- [[transcript-analysis-method|Transcript Analysis Method]] — the story-analysis process that can feed ALMA review
+- [[glossary|Glossary]] — shared language entry across the ecosystem
+- [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] — the decision that prompted this rewrite
+- [[../decisions/act-brand-alignment-map|Brand Alignment Map]] — naming rules including the "JusticeHub evidence map" preference for external copy

--- a/apps/command-center/public/wiki/act/appendices/alma-template.md
+++ b/apps/command-center/public/wiki/act/appendices/alma-template.md
@@ -1,6 +1,6 @@
 ---
 status: generated
-generated_at: 2026-05-18T03:37:13.699Z
+generated_at: 2026-05-25T19:37:27.398Z
 canonical_source: wiki/concepts/alma.md
 ---
 

--- a/apps/command-center/public/wiki/act/appendices/glossary.md
+++ b/apps/command-center/public/wiki/act/appendices/glossary.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/glossary.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Glossary
 
@@ -31,8 +31,17 @@ ACT's methodology for ethical innovation:
 
 See [[lcaa-method|LCAA Method]].
 
-### Accountable Listening and Meaningful Action (ALMA)
-ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review. ALMA is not the Soul, an AI personality, a dashboard, or a ranking engine. See [[alma|ALMA]].
+### Australian Living Map of Alternatives (ALMA)
+ACT's catalogue of community-led interventions that work, scored on six dimensions (evidence strength, community authority, harm risk, implementation capability, option value, community value return). The catalogue lives in the `alma_interventions`, `alma_evidence`, and `alma_outcomes` database tables. ALMA is the map, not a process, not an AI agent, not a ranking engine. See [[alma|ALMA]].
+
+### Civic Operating System
+The three-layer architecture for ACT's product work: [[civicgraph|CivicGraph]] (intelligence, sees the field), [[justicehub|JusticeHub]] (practice, supports the work), [[empathy-ledger|Empathy Ledger]] (accountability, holds the trust). The three call each other in code. See [[civic-operating-system|Civic Operating System]].
+
+### Civic Reflex Automation
+ACT's AI thesis: automate the boring (tagging, matching, syncing, reporting, reminders, audits), amplify the art (storytelling, design, engagement), never replace human judgment on relationships, consent, or creative direction. See [[civic-reflex-automation|Civic Reflex Automation]].
+
+### Evidence as a By-Product of the Work
+The principle that impact reporting composes from the existing layers (Empathy Ledger, ALMA, CivicGraph, Governed Proof) rather than running as a separate reporting workstream. Every intake, story, consent, referral, audit, and review writes to the evidence base; the report at the end of the quarter is generated from the ledger, not re-collected from memory. See [[evidence-as-by-product|Evidence as a By-Product of the Work]].
 
 ### Power Take-Off (PTO)
 A tractor mechanism that transfers engine power to implements. ACT's founding metaphor: we provide power that communities direct, not the other way around.
@@ -93,14 +102,14 @@ Standardized `/api/registry` endpoint exposed by each project. Enables ecosystem
 
 ---
 
-## ALMA Review Fields
+## ALMA Scoring Dimensions
 
-Some legacy schemas use `alma_signals` fields. Treat these as review prompts inside [[alma|ALMA]], not as the public definition of ALMA.
+The six dimensions every intervention in [[alma|ALMA]] is scored on. These dimensions **are** ALMA's methodology, not external supports for some other thing called ALMA. The catalogue plus the dimensions plus the scoring records together are the Map.
 
-| Review Field | What It Checks |
+| Scoring Dimension | What It Checks |
 |--------|-----------------|
 | Evidence Strength | Is the claim sourced and reliable? |
-| Community Authority | Who holds authority? Is consent in place? |
+| Community Authority | Who holds authority? Has cultural authority been verified? |
 | Harm Risk | What could go wrong if this is acted on or shared? |
 | Implementation Capability | Can this be acted on responsibly now? |
 | Option Value | Does this open or close future possibilities? |
@@ -177,7 +186,7 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 | Acronym | Meaning |
 |---------|---------|
 | ACT | A Curious Tractor |
-| ALMA | Accountable Listening and Meaningful Action |
+| ALMA | Australian Living Map of Alternatives |
 | BCV | Black Cockatoo Valley |
 | CSA | Community Supported Agriculture |
 | GHL | GoHighLevel (CRM platform) |
@@ -195,7 +204,10 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 ## Backlinks
 
 - [[lcaa-method|LCAA Method]] — core methodology
-- [[alma|ALMA]] — governed listening-to-action process
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture for ACT's product work
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis underneath the civic OS
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — the impact reporting principle
+- [[alma|ALMA]] — the catalogue of community-led alternatives, evidence-graded with cultural authority
 - [[governed-proof|Governed Proof]] — evidence, review, confidence, publication, and audit trail
 - [[consent-as-infrastructure|Consent as Infrastructure]] — OCAP architecture
 - [[beautiful-obsolescence|Beautiful Obsolescence]] — handover design principle

--- a/apps/command-center/public/wiki/act/appendices/roadmap-2026.md
+++ b/apps/command-center/public/wiki/act/appendices/roadmap-2026.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/decisions/roadmap-2026.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # 2026 Roadmap
 
@@ -24,7 +24,7 @@ This is a seasonal map, not a fixed plan. ACT chooses readiness over deadlines a
 | Finalise compendium and align project language to core model | In Progress |
 | Stabilise Harvest operations and maker pathways in Witta | In Progress |
 | Confirm Goods production readiness and support pathways | Planning |
-| Align AI agent guardrails to Accountable Listening and Meaningful Action (ALMA) and Empathy Ledger | Complete |
+| Align AI agent guardrails to Australian Living Map of Alternatives (ALMA) and Empathy Ledger | Complete |
 | JusticeHub vision and path to externalise | Planning |
 | ACT regular communication (1-to-some and 1-to-many via GHL) | In Progress |
 

--- a/apps/command-center/public/wiki/act/appendices/tech-architecture.md
+++ b/apps/command-center/public/wiki/act/appendices/tech-architecture.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/technical/act-architecture.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # ACT Technical Architecture
 

--- a/apps/command-center/public/wiki/act/appendices/transcription-workflow.md
+++ b/apps/command-center/public/wiki/act/appendices/transcription-workflow.md
@@ -5,11 +5,11 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/technical/transcription-workflow.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Descript Transcription & ALMA Review Workflow
 
-> How transcribed stories move from Descript into Empathy Ledger and through Accountable Listening and Meaningful Action review.
+> How transcribed stories move from Descript into Empathy Ledger and through Australian Living Map of Alternatives review.
 
 ## Overview
 

--- a/apps/command-center/public/wiki/act/appendices/vignette-workflows.md
+++ b/apps/command-center/public/wiki/act/appendices/vignette-workflows.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/technical/vignette-workflows.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Vignette & Media Workflows
 

--- a/apps/command-center/public/wiki/act/appendices/visual-system.md
+++ b/apps/command-center/public/wiki/act/appendices/visual-system.md
@@ -11,7 +11,7 @@ image_model: gemini-3-pro-image-preview via mcp__gemini-image__create_asset
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/visual-system.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # ACT Visual System
 

--- a/apps/command-center/public/wiki/act/beautiful-obsolescence.md
+++ b/apps/command-center/public/wiki/act/beautiful-obsolescence.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/beautiful-obsolescence.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Beautiful Obsolescence
 

--- a/apps/command-center/public/wiki/act/governance.md
+++ b/apps/command-center/public/wiki/act/governance.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/governance-consent.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Governance & Consent (Operational)
 

--- a/apps/command-center/public/wiki/act/governed-proof.md
+++ b/apps/command-center/public/wiki/act/governed-proof.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/governed-proof.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Governed Proof
 
@@ -13,9 +13,11 @@ status: Active
 
 ## Definition
 
-Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits after [[alma|Accountable Listening and Meaningful Action (ALMA)]].
+Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits alongside [[alma|Australian Living Map of Alternatives (ALMA)]] (the catalogue of what works) and downstream of the practice (LCAA, Empathy Ledger, JusticeHub).
 
-ALMA helps decide whether listening can become action. Governed Proof records what happened next, what supports it, who reviewed it, what confidence it carries, and what can be shared.
+ALMA holds the evidence-graded catalogue. Governed Proof gates which claims drawn from ALMA, or from any other ACT source, can be published, with what confidence, to what audience, and under what review trail.
+
+Together they answer two different questions. ALMA: "what do we know about what works?" Governed Proof: "what are we ready to say in public, and how do we stand behind it?"
 
 ## Where It Sits
 
@@ -49,12 +51,14 @@ Governed Proof does not replace consent, community authority, Elder review, or r
 
 ## Backlinks
 
-- [[alma|ALMA]] - the listening-to-action process upstream of governed proof
-- [[soul|Soul]] - upstream why; governed proof is downstream, not the source of meaning
-- [[ways-of-working|Ways of Working]] - daily operational rhythm that applies review and publication discipline
-- [[governance-consent|Governance & Consent]] - consent and authority model
-- [[consent-as-infrastructure|Consent as Infrastructure]] - technical architecture for consent
-- [[empathy-ledger|Empathy Ledger]] - source of consented story records
-- [[justicehub|JusticeHub]] - public evidence and action surface
-- [[transcript-analysis-method|Transcript Analysis Method]] - pipeline that creates reviewable story evidence
-- [[vignette-workflows|Vignette Workflows]] - story evidence workflow
+- [[alma|ALMA]] — the evidence catalogue this layer composes with for publication
+- [[soul|Soul]] — upstream why; governed proof is downstream, not the source of meaning
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how Governed Proof composes with ALMA, Empathy Ledger, and CivicGraph to produce impact reports
+- [[civic-operating-system|Civic Operating System]] — the architecture this layer sits inside
+- [[ways-of-working|Ways of Working]] — daily operational rhythm that applies review and publication discipline
+- [[governance-consent|Governance & Consent]] — consent and authority model
+- [[consent-as-infrastructure|Consent as Infrastructure]] — technical architecture for consent
+- [[empathy-ledger|Empathy Ledger]] — source of consented story records
+- [[justicehub|JusticeHub]] — practice and public-evidence surface
+- [[transcript-analysis-method|Transcript Analysis Method]] — pipeline that creates reviewable story evidence
+- [[vignette-workflows|Vignette Workflows]] — story evidence workflow

--- a/apps/command-center/public/wiki/act/identity/lcaa-methodology.md
+++ b/apps/command-center/public/wiki/act/identity/lcaa-methodology.md
@@ -1,6 +1,6 @@
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/lcaa-method.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # LCAA Method
 
 > Listen. Curiosity. Action. Art.
@@ -164,8 +164,11 @@ Every project, every piece of art, every community relationship can be tagged wi
 - [[civicgraph|CivicGraph]]: Curiosity
 - [[picc|PICC]]: spans all four phases
 - [[third-reality|The Third Reality]]: the synthesis LCAA produces
-- [[alma|ALMA]]: governed sensemaking process that turns listening into accountable action
+- [[alma|ALMA]]: the catalogue of community-led alternatives, evidence-graded with cultural authority; what gets curated through LCAA's Curiosity phase
 - [[governed-proof|Governed Proof]]: evidence and review layer after action
+- [[civic-operating-system|Civic Operating System]]: the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) that operationalises LCAA at the product level
+- [[civic-reflex-automation|Civic Reflex Automation]]: the AI thesis that protects LCAA's human work by automating only the boring reflex tasks
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]]: how impact reporting composes from LCAA's outputs without becoming a separate task
 - [[ai-community-engagement|AI and Community Engagement]]: administrative compression that protects time for relational work
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the Action phase discipline
 - [[place-land-practice|Place & Land Practice]]: Country and land practice as the pace-setting context for the whole method

--- a/apps/command-center/public/wiki/act/identity/mission.md
+++ b/apps/command-center/public/wiki/act/identity/mission.md
@@ -1,6 +1,6 @@
 ---
 status: generated
-generated_at: 2026-05-18T03:37:13.699Z
+generated_at: 2026-05-25T19:37:27.398Z
 canonical_source: wiki/concepts/act-identity.md
 ---
 

--- a/apps/command-center/public/wiki/act/identity/principles.md
+++ b/apps/command-center/public/wiki/act/identity/principles.md
@@ -1,6 +1,6 @@
 ---
 status: generated
-generated_at: 2026-05-18T03:37:13.699Z
+generated_at: 2026-05-25T19:37:27.398Z
 canonical_source: wiki/concepts/act-identity.md
 ---
 

--- a/apps/command-center/public/wiki/act/identity/voice-guide.md
+++ b/apps/command-center/public/wiki/act/identity/voice-guide.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/voice-guide.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # ACT Voice Guide
 

--- a/apps/command-center/public/wiki/act/index.md
+++ b/apps/command-center/public/wiki/act/index.md
@@ -6,7 +6,7 @@ source_of_truth: wiki/concepts/soul.md
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/act-identity.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # A Curious Tractor (ACT)
 
@@ -52,6 +52,14 @@ Every ACT project, relationship, and piece of infrastructure can be tagged with 
 > "If we cannot hand it over, we are still in Curiosity."
 
 The test for any ACT project: can the community run this without us? Can they modify it? Can they export their data? If any answer is no, the work is not finished.
+
+## The Civic Operating System
+
+ACT's product work is organised as one civic operating system with three layers: [[civicgraph|CivicGraph]] sees the field (intelligence), [[justicehub|JusticeHub]] supports the work (practice), [[empathy-ledger|Empathy Ledger]] holds the trust (accountability). They share one architecture, one ethics, and one set of reflex primitives (intake, consent, triage, referral, follow-up, audit, evidence). They are not three independent products; they are three layers of one system.
+
+The AI thesis underneath is [[civic-reflex-automation|Civic Reflex Automation]]: automate the boring, amplify the art, never replace human judgment on relationships, consent, or creative direction. Impact reporting follows the [[evidence-as-by-product|Evidence as a By-Product]] principle, where reporting composes from the layers rather than running as a separate workstream.
+
+See [[civic-operating-system|the Civic Operating System concept page]] for the architecture, and the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] for the decision that established it.
 
 ## How ACT Differs from a Typical NGO
 

--- a/apps/command-center/public/wiki/act/lcaa.md
+++ b/apps/command-center/public/wiki/act/lcaa.md
@@ -1,6 +1,6 @@
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/lcaa-method.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # LCAA Method
 
 > Listen. Curiosity. Action. Art.
@@ -164,8 +164,11 @@ Every project, every piece of art, every community relationship can be tagged wi
 - [[civicgraph|CivicGraph]]: Curiosity
 - [[picc|PICC]]: spans all four phases
 - [[third-reality|The Third Reality]]: the synthesis LCAA produces
-- [[alma|ALMA]]: governed sensemaking process that turns listening into accountable action
+- [[alma|ALMA]]: the catalogue of community-led alternatives, evidence-graded with cultural authority; what gets curated through LCAA's Curiosity phase
 - [[governed-proof|Governed Proof]]: evidence and review layer after action
+- [[civic-operating-system|Civic Operating System]]: the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) that operationalises LCAA at the product level
+- [[civic-reflex-automation|Civic Reflex Automation]]: the AI thesis that protects LCAA's human work by automating only the boring reflex tasks
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]]: how impact reporting composes from LCAA's outputs without becoming a separate task
 - [[ai-community-engagement|AI and Community Engagement]]: administrative compression that protects time for relational work
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the Action phase discipline
 - [[place-land-practice|Place & Land Practice]]: Country and land practice as the pace-setting context for the whole method

--- a/apps/command-center/public/wiki/act/ways-of-working.md
+++ b/apps/command-center/public/wiki/act/ways-of-working.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/ways-of-working.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Ways of Working
 

--- a/apps/command-center/public/wiki/empathy-ledger/index.md
+++ b/apps/command-center/public/wiki/empathy-ledger/index.md
@@ -16,7 +16,7 @@ empathy_ledger_key: empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/empathy-ledger.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Empathy Ledger
 

--- a/apps/command-center/public/wiki/goods/index.md
+++ b/apps/command-center/public/wiki/goods/index.md
@@ -16,7 +16,7 @@ empathy_ledger_key: goods
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/goods.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Goods on Country
 

--- a/apps/command-center/public/wiki/justicehub/index.md
+++ b/apps/command-center/public/wiki/justicehub/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/justicehub/justicehub.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # JusticeHub
 
@@ -93,7 +93,7 @@ JusticeHub needs **$500K** to scale nationally.
 
 ## ALMA-Governed Evidence Records
 
-The "what works" layer sitting on top of funding data, governed by [[alma|Accountable Listening and Meaningful Action (ALMA)]]:
+The "what works" layer sitting on top of funding data, governed by [[alma|Australian Living Map of Alternatives (ALMA)]]:
 - Evidence-based interventions mapped by topic and geography
 - 9 topic domains: child-protection, community-led, diversion, family-services, indigenous, legal-services, ndis, prevention, youth-justice
 - Cross-referenced with CivicGraph entity graph (56% linkage rate)

--- a/apps/command-center/public/wiki/place/black-cockatoo-valley.md
+++ b/apps/command-center/public/wiki/place/black-cockatoo-valley.md
@@ -16,7 +16,7 @@ empathy_ledger_key: black-cockatoo-valley
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/act-farm/black-cockatoo-valley.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Black Cockatoo Valley
 

--- a/apps/command-center/public/wiki/place/index.md
+++ b/apps/command-center/public/wiki/place/index.md
@@ -1,6 +1,6 @@
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/place-land-practice.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Place & Land Practice
 
 ACT's work is grounded in place. Land practice is central to everything — not an add-on or afterthought, but the foundation that shapes how we work.

--- a/apps/command-center/public/wiki/snapshot-meta.json
+++ b/apps/command-center/public/wiki/snapshot-meta.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-18T03:37:13.699Z",
+  "generated_at": "2026-05-25T19:37:27.398Z",
   "canonical_root": "wiki/",
   "direct_mappings": 24,
   "wrapper_pages": 4,

--- a/apps/command-center/public/wiki/stories/a-guarded-to-self-advocate.md
+++ b/apps/command-center/public/wiki/stories/a-guarded-to-self-advocate.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/a-guarded-to-self-advocate.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # A: From Guarded and Disengaged to Articulate Self-Advocate
 

--- a/apps/command-center/public/wiki/stories/atnarpa-boys-trip.md
+++ b/apps/command-center/public/wiki/stories/atnarpa-boys-trip.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/atnarpa-boys-trip.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Atnarpa Station Cultural Learning - Boys Trip
 

--- a/apps/command-center/public/wiki/stories/atnarpa-girls-trip.md
+++ b/apps/command-center/public/wiki/stories/atnarpa-girls-trip.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/atnarpa-girls-trip.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Atnarpa Homestead Cultural Exchange - Girls Trip
 

--- a/apps/command-center/public/wiki/stories/bg-fit-ben-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-ben-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-ben-recording.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Ben - Recording
 
 > Ben

--- a/apps/command-center/public/wiki/stories/bg-fit-benji-youth-day-yarn.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-benji-youth-day-yarn.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-benji-youth-day-yarn.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Benji - Youth Day Yarn
 
 > Benji - Young Person

--- a/apps/command-center/public/wiki/stories/bg-fit-danielle-germaine-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-danielle-germaine-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-danielle-germaine-recording.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Danielle Germaine. - Recording
 
 > Danielle Germaine

--- a/apps/command-center/public/wiki/stories/bg-fit-doomadgee-camp-taking-it-remote.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-doomadgee-camp-taking-it-remote.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-doomadgee-camp-taking-it-remote.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Doomadgee Camp — Taking It Remote
 
 > Doomadgee Camp Participant

--- a/apps/command-center/public/wiki/stories/bg-fit-gracie-ryder-youth-police.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-gracie-ryder-youth-police.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-gracie-ryder-youth-police.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Gracie Ryder - Youth Police
 
 > Gracie Ryder

--- a/apps/command-center/public/wiki/stories/bg-fit-jay-young-person-interview.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-jay-young-person-interview.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-jay-young-person-interview.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Jay - Young Person interview
 
 > Jay

--- a/apps/command-center/public/wiki/stories/bg-fit-mount-isa-bush-camp-first-one-on-country.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-mount-isa-bush-camp-first-one-on-country.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-mount-isa-bush-camp-first-one-on-country.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Mount Isa Bush Camp — First One on Country
 
 > Mount Isa Camp Participant

--- a/apps/command-center/public/wiki/stories/bg-fit-rashad-gavin-isaacson-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-rashad-gavin-isaacson-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-rashad-gavin-isaacson-recording.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Rashad Gavin Isaacson - Recording
 
 > Rashad Gavin Isaacson

--- a/apps/command-center/public/wiki/stories/bg-fit-siva-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-siva-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-siva-recording.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Siva - Recording
 
 > Siva

--- a/apps/command-center/public/wiki/stories/bg-fit-spinifex-residential-getting-through-to-the-hard-cases.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-spinifex-residential-getting-through-to-the-hard-cases.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-spinifex-residential-getting-through-to-the-hard-cases.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Spinifex Residential — Getting Through to the Hard Cases
 
 > Spinifex Res Youth

--- a/apps/command-center/public/wiki/stories/bg-fit-tuesday-gym-sessions-building-consistency.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-tuesday-gym-sessions-building-consistency.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-tuesday-gym-sessions-building-consistency.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Tuesday Gym Sessions — Building Consistency
 
 > Flexi Group Voices

--- a/apps/command-center/public/wiki/stories/bg-fit-why-i-started-bg-fit.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-why-i-started-bg-fit.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-why-i-started-bg-fit.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Why I Started BG Fit
 
 > Brodie Germaine

--- a/apps/command-center/public/wiki/stories/building-empathy-ledger.md
+++ b/apps/command-center/public/wiki/stories/building-empathy-ledger.md
@@ -6,7 +6,7 @@ projects: empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/building-empathy-ledger.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Building Empathy Ledger: A Journey of Connection
 

--- a/apps/command-center/public/wiki/stories/cb-cultural-leadership.md
+++ b/apps/command-center/public/wiki/stories/cb-cultural-leadership.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/cb-cultural-leadership.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # CB: Understanding Cultural Responsibility and Leadership
 

--- a/apps/command-center/public/wiki/stories/community-innovation-goods.md
+++ b/apps/command-center/public/wiki/stories/community-innovation-goods.md
@@ -6,7 +6,7 @@ projects: goods, picc-storm-stories
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/community-innovation-goods.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Community Innovation: Beds, Washing Machines, and Orange Sky
 

--- a/apps/command-center/public/wiki/stories/community-recognition-referrals.md
+++ b/apps/command-center/public/wiki/stories/community-recognition-referrals.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/community-recognition-referrals.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Community Recognition and External Referral Requests
 

--- a/apps/command-center/public/wiki/stories/educational-transformation.md
+++ b/apps/command-center/public/wiki/stories/educational-transformation.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/educational-transformation.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Educational Transformation: 72% Return to School
 

--- a/apps/command-center/public/wiki/stories/elders-speak-consulted.md
+++ b/apps/command-center/public/wiki/stories/elders-speak-consulted.md
@@ -6,7 +6,7 @@ projects: picc-storm-stories
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/elders-speak-consulted.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Elders Speak: "We Should Have Been Consulted"
 

--- a/apps/command-center/public/wiki/stories/ellen-friday-fridge.md
+++ b/apps/command-center/public/wiki/stories/ellen-friday-fridge.md
@@ -6,7 +6,7 @@ projects: goods, picc-storm-stories
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/ellen-friday-fridge.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Ellen Friday: Still Waiting for a Fridge
 

--- a/apps/command-center/public/wiki/stories/finke-desert-race.md
+++ b/apps/command-center/public/wiki/stories/finke-desert-race.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/finke-desert-race.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Finke Desert Race Country Experience
 

--- a/apps/command-center/public/wiki/stories/girls-day-out-standley-chasm.md
+++ b/apps/command-center/public/wiki/stories/girls-day-out-standley-chasm.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/girls-day-out-standley-chasm.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Girls Day Out: Cultural Empowerment at Standley Chasm
 

--- a/apps/command-center/public/wiki/stories/healing-journey-country.md
+++ b/apps/command-center/public/wiki/stories/healing-journey-country.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/healing-journey-country.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Healing Journey to Country: Young Men Find Connection at Atnarpa Station
 

--- a/apps/command-center/public/wiki/stories/index.md
+++ b/apps/command-center/public/wiki/stories/index.md
@@ -5,7 +5,7 @@ status: Internal
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/index.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Stories
 

--- a/apps/command-center/public/wiki/stories/jesus-teruel-diagrama.md
+++ b/apps/command-center/public/wiki/stories/jesus-teruel-diagrama.md
@@ -6,7 +6,7 @@ projects: diagrama, justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/jesus-teruel-diagrama.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Jesús Teruel — Diagrama Key Story
 

--- a/apps/command-center/public/wiki/stories/m-homelessness-independent.md
+++ b/apps/command-center/public/wiki/stories/m-homelessness-independent.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/m-homelessness-independent.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # M: From Homelessness to Independent Living
 

--- a/apps/command-center/public/wiki/stories/mounty-yarns-mounty-yarns-in-their-own-words.md
+++ b/apps/command-center/public/wiki/stories/mounty-yarns-mounty-yarns-in-their-own-words.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:mounty-yarns"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/mounty-yarns-mounty-yarns-in-their-own-words.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Mounty Yarns: In Their Own Words
 
 > Mounty Yarns Community

--- a/apps/command-center/public/wiki/stories/ms-future-entrepreneur.md
+++ b/apps/command-center/public/wiki/stories/ms-future-entrepreneur.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/ms-future-entrepreneur.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # MS: From Disconnected Youth to Future Tourism Entrepreneur
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-aunty-bev-and-uncle-tony-s-story.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-aunty-bev-and-uncle-tony-s-story.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-aunty-bev-and-uncle-tony-s-story.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Aunty Bev and Uncle Tony's Story
 
 > Aunty Barb and Uncle Tony

--- a/apps/command-center/public/wiki/stories/oonchiumpa-bringing-kids-back-to-country.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-bringing-kids-back-to-country.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-bringing-kids-back-to-country.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Bringing Kids Back to Country
 
 > Kristy Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-coming-home-to-love-s-creek.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-coming-home-to-love-s-creek.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-coming-home-to-love-s-creek.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Coming Home to Love's Creek
 
 > Henry Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-creating-our-own-history.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-creating-our-own-history.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-creating-our-own-history.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Creating Our Own History
 
 > Kylie Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-fred-xavier-trust.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-fred-xavier-trust.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, trust, case-work, stretch-bed, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-fred-xavier-trust.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # He trusts us. We earned that trust.
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-detention.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-detention.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, detention, young-people, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-jackquann-detention.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Detention. That's not my home.
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-nigel-programs.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-nigel-programs.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, young-people, school, programs, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-jackquann-nigel-programs.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Programs. Go to school every day.
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-kristy-bloomfield-interview-transcript.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-kristy-bloomfield-interview-transcript.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-kristy-bloomfield-interview-transcript.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Kristy Bloomfield - Interview Transcript
 
 > Kristy Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-kristy-tanya-founders.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-kristy-tanya-founders.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, founders, cultural-authority, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-kristy-tanya-founders.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Our young people are just collateral in a bigger issue
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-laquisha-darwin.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-laquisha-darwin.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, detention, darwin, young-people, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-laquisha-darwin.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Court is scary because you don't know whether you're getting out or not
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-nigel-court.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-nigel-court.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, court, young-people, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-nigel-court.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # When I'm talking to the judge, I feel like I'm panicking
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-oonchiumpa-what-happens-when-community-leads.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-oonchiumpa-what-happens-when-community-leads.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-oonchiumpa-what-happens-when-community-leads.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 # Oonchiumpa: What Happens When Community Leads
 
 > Benjamin Knight

--- a/apps/command-center/public/wiki/stories/operation-luna-success.md
+++ b/apps/command-center/public/wiki/stories/operation-luna-success.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/operation-luna-success.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Operation Luna Success: Dramatic Reduction in Youth Offending
 

--- a/apps/command-center/public/wiki/stories/origin-curious-tractor.md
+++ b/apps/command-center/public/wiki/stories/origin-curious-tractor.md
@@ -6,7 +6,7 @@ projects: a-curious-tractor, empathy-ledger, justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/origin-curious-tractor.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # The Origin of A Curious Tractor
 

--- a/apps/command-center/public/wiki/stories/peggy-palm-island.md
+++ b/apps/command-center/public/wiki/stories/peggy-palm-island.md
@@ -6,7 +6,7 @@ projects: picc-photo-kiosk, empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/peggy-palm-island.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Peggy Palm Island's Story
 

--- a/apps/command-center/public/wiki/stories/proud-pita-pita-wayaka-man.md
+++ b/apps/command-center/public/wiki/stories/proud-pita-pita-wayaka-man.md
@@ -6,7 +6,7 @@ projects: bg-fit
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/proud-pita-pita-wayaka-man.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Proud Pita Pita Wayaka Man: My Roots
 

--- a/apps/command-center/public/wiki/stories/returning-home-atnarpa.md
+++ b/apps/command-center/public/wiki/stories/returning-home-atnarpa.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/returning-home-atnarpa.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Returning Home to Atnarpa: The Bloomfield Family's Journey
 

--- a/apps/command-center/public/wiki/stories/school-partnership-success.md
+++ b/apps/command-center/public/wiki/stories/school-partnership-success.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/school-partnership-success.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # School Partnership Success Stories
 

--- a/apps/command-center/public/wiki/stories/storytelling-data-sovereignty.md
+++ b/apps/command-center/public/wiki/stories/storytelling-data-sovereignty.md
@@ -6,7 +6,7 @@ projects: picc-storm-stories, empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/storytelling-data-sovereignty.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Storytelling, Data Sovereignty, and Community Recovery
 

--- a/apps/command-center/public/wiki/stories/uncle-alan-palm-island.md
+++ b/apps/command-center/public/wiki/stories/uncle-alan-palm-island.md
@@ -6,7 +6,7 @@ projects: uncle-allan-palm-island-art, empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/uncle-alan-palm-island.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Uncle Alan Palm Island — Key Story
 

--- a/apps/command-center/public/wiki/stories/uncle-dale-healing-path.md
+++ b/apps/command-center/public/wiki/stories/uncle-dale-healing-path.md
@@ -6,7 +6,7 @@ projects: justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/uncle-dale-healing-path.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Building a Healing Path: Uncle Dale's Vision for Youth Justice Reform
 

--- a/apps/command-center/public/wiki/stories/vignette-template.md
+++ b/apps/command-center/public/wiki/stories/vignette-template.md
@@ -1,6 +1,6 @@
 ---
 status: generated
-generated_at: 2026-05-18T03:37:13.699Z
+generated_at: 2026-05-25T19:37:27.398Z
 canonical_source: wiki/technical/vignette-workflows.md
 ---
 

--- a/apps/command-center/public/wiki/stories/young-fellas-standley-chasm.md
+++ b/apps/command-center/public/wiki/stories/young-fellas-standley-chasm.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/young-fellas-standley-chasm.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Young Fellas Experience Cultural Connection at Standley Chasm
 

--- a/apps/command-center/public/wiki/stories/young-people-murcia.md
+++ b/apps/command-center/public/wiki/stories/young-people-murcia.md
@@ -6,7 +6,7 @@ projects: diagrama, justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/young-people-murcia.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Young People Murcia — Key Story
 

--- a/apps/command-center/public/wiki/stories/young-person-returns-school.md
+++ b/apps/command-center/public/wiki/stories/young-person-returns-school.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/young-person-returns-school.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # Young Person Returns to School After Cultural Healing
 

--- a/apps/command-center/public/wiki/the-farm/index.md
+++ b/apps/command-center/public/wiki/the-farm/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: act-farm
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/act-farm/act-farm.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # ACT Farm
 

--- a/apps/command-center/public/wiki/the-harvest/index.md
+++ b/apps/command-center/public/wiki/the-harvest/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: the-harvest
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/the-harvest/the-harvest.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # The Harvest / Witta Harvest HQ
 

--- a/apps/command-center/public/wiki/the-studio/index.md
+++ b/apps/command-center/public/wiki/the-studio/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: act-studio
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/act-studio/act-studio.md`.
-> Regenerated: `2026-05-18T03:37:13.699Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerated: `2026-05-25T19:37:27.398Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
 
 # ACT Regenerative Studio
 

--- a/apps/website/src/app/impact/page.tsx
+++ b/apps/website/src/app/impact/page.tsx
@@ -23,7 +23,7 @@ export default function ImpactPage() {
                     Ecosystem Impact
                 </h1>
                 <p className="max-w-2xl text-lg text-[#4D3F33] leading-relaxed">
-                    Accountable Listening and Meaningful Action (ALMA) helps ACT review
+                    Australian Living Map of Alternatives (ALMA) helps ACT review
                     regenerative outcomes across Land, Studio, and Harvest contexts with consent,
                     authority, provenance, and care.
                 </p>

--- a/apps/website/src/types/alma.ts
+++ b/apps/website/src/types/alma.ts
@@ -1,5 +1,5 @@
 /**
- * ALMA (Accountable Listening and Meaningful Action) TypeScript Types
+ * ALMA (Australian Living Map of Alternatives) TypeScript Types
  *
  * GOVERNED REVIEW STRUCTURES FOR THE ACT ECOSYSTEM
  * Generalized to cover Land, Studio, Harvest, and Art.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@
 | [Guides](./guides/) | How-to guides for operational tasks |
 | [Integrations](./integrations/) | External system connections (GHL, Notion, etc.) |
 | [Reference](./reference/) | Executive overviews and strategic plans |
-| [ALMA](./alma/) | Accountable Listening and Meaningful Action documentation |
+| [ALMA](./alma/) | Australian Living Map of Alternatives documentation |
 | [Archive](./archive/) | Historical documents and completed phases |
 
 ---
@@ -75,7 +75,7 @@ Strategic and executive documents.
 
 ## ALMA
 
-Documentation for Accountable Listening and Meaningful Action (ALMA), ACT's governed process for moving from listening to meaningful action with consent, authority, provenance, and review.
+Documentation for Australian Living Map of Alternatives (ALMA), ACT's governed process for moving from listening to meaningful action with consent, authority, provenance, and review.
 
 | Document | Description |
 |----------|-------------|
@@ -91,7 +91,7 @@ Documentation for Accountable Listening and Meaningful Action (ALMA), ACT's gove
 
 - **Soul** - the origin layer of ACT.
 - **LCAA** - Listen, Curiosity, Action, Art; ACT's practice loop.
-- **ALMA** - Accountable Listening and Meaningful Action; ACT's governed sensemaking process.
+- **ALMA** - Australian Living Map of Alternatives; ACT's evidence-graded catalogue of community-led alternatives.
 - **Governed Proof** - the evidence, review, and publication layer.
 
 ---

--- a/docs/V2_ROADMAP.md
+++ b/docs/V2_ROADMAP.md
@@ -200,7 +200,7 @@ agents/
 ## ALMA Review Everywhere
 
 **Current:** ALMA exists in Empathy Ledger v2
-**V2 Goal:** Accountable Listening and Meaningful Action (ALMA) review fields on every relevant record
+**V2 Goal:** Australian Living Map of Alternatives (ALMA) review fields on every relevant record
 
 | Entity | ALMA Metric |
 |--------|-------------|

--- a/docs/alma/CHARTER.md
+++ b/docs/alma/CHARTER.md
@@ -1,4 +1,4 @@
-# ALMA - Accountable Listening and Meaningful Action Charter
+# ALMA - Australian Living Map of Alternatives Charter
 
 **Version**: 1.0
 **Date**: December 31, 2025
@@ -8,7 +8,7 @@
 
 ## Purpose
 
-Accountable Listening and Meaningful Action (ALMA) is ACT's governed sensemaking process. It helps move what we hear from people, place, evidence, and systems into responsible action, but only when consent, authority, provenance, and review are clear.
+Australian Living Map of Alternatives (ALMA) is ACT's evidence-graded catalogue of community-led alternatives. It helps move what we hear from people, place, evidence, and systems into responsible action, but only when consent, authority, provenance, and review are clear.
 
 ALMA is downstream of Soul and LCAA.
 
@@ -436,8 +436,8 @@ This charter evolves as ALMA evolves:
 
 ---
 
-**ALMA = Accountable Listening and Meaningful Action.**
+**ALMA = Australian Living Map of Alternatives.**
 
-**ALMA is ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.**
+**ALMA is ACT's catalogue of community-led alternatives, evidence-graded with cultural authority.**
 
 **Built with consent. Governed by community. Powered by evidence. Accountable always.**

--- a/docs/alma/DATA_POSTURE.md
+++ b/docs/alma/DATA_POSTURE.md
@@ -10,7 +10,7 @@
 
 **Default Private, Explicit Consent to Share**
 
-Accountable Listening and Meaningful Action (ALMA) operates on the principle that all knowledge contributions are private by default. Movement from private to community commons to public requires explicit, informed consent from contributors and cultural authority holders.
+Australian Living Map of Alternatives (ALMA) operates on the principle that all knowledge contributions are private by default. Movement from private to community commons to public requires explicit, informed consent from contributors and cultural authority holders.
 
 ---
 

--- a/docs/privacy/empathy-ledger-privacy-policy.md
+++ b/docs/privacy/empathy-ledger-privacy-policy.md
@@ -72,7 +72,7 @@ The Empathy Ledger adheres to the **OCAP** principles for all Indigenous data:
 We use personal information to:
 
 1. **Operate the platform** — display stories, connect storytellers, measure impact
-2. **Review impact evidence** — Accountable Listening and Meaningful Action (ALMA) review fields
+2. **Review impact evidence** — Australian Living Map of Alternatives (ALMA) review fields
 3. **Support community programs** — connect storytellers with relevant projects
 4. **Improve the platform** — understand usage patterns (anonymized)
 5. **Comply with legal obligations** — grant reporting, regulatory requirements

--- a/scripts/audit-goods-buyer-pipelines.mjs
+++ b/scripts/audit-goods-buyer-pipelines.mjs
@@ -1,0 +1,90 @@
+/**
+ * Audit the two GHL Goods buyer pipelines before cleanup.
+ * Read-only: fetches all opps, categorizes, prints a cleanup plan + writes full JSON.
+ *
+ *   node --env-file=.env.local scripts/audit-goods-buyer-pipelines.mjs
+ *
+ * Categories:
+ *   TEST            - test/example records (tag test-submission or @example.com)
+ *   DUP_IN_BUYER    - same contact present in BOTH pipelines, Buyer copy still unworked
+ *                     (Outreach Queued) → per model, remove the Buyer-pipeline copy
+ *   GENERIC_SIGNAL  - "52 beds, 6 washers" templated demand (real-vs-noise review)
+ *   REAL            - everything else (keep / work)
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+import fs from 'node:fs';
+
+const DEMAND = { id: 'UQsrmuqzxMSdCTklxEcG', name: 'Demand Register' };
+const BUYER  = { id: 'FjMyJM3YzWQFmKqR9fur', name: 'Buyer Pipeline' };
+const OUTREACH_QUEUED = 'e5220eb2-be40-4e79-9571-6acae12285c7'; // Buyer Pipeline stage 0
+
+const slim = (o) => ({
+  id: o.id,
+  name: o.name,
+  value: o.monetaryValue || 0,
+  stageId: o.pipelineStageId,
+  contactId: o.contactId,
+  contactName: o.contact?.name || o.contact?.companyName || null,
+  email: o.contact?.email || null,
+  tags: o.contact?.tags || [],
+});
+
+async function main() {
+  const ghl = createGHLService();
+  const demand = (await ghl.getOpportunities(DEMAND.id, { limit: 100 })).map(slim);
+  const buyer  = (await ghl.getOpportunities(BUYER.id,  { limit: 100 })).map(slim);
+
+  const demandContacts = new Set(demand.map((o) => o.contactId));
+
+  const isTest = (o) =>
+    o.tags.includes('test-submission') || (o.email || '').includes('example.com');
+  const isGeneric = (o) => /52 beds, 6 washers/i.test(o.name);
+
+  // Buyer-pipeline categorization
+  const buyerCats = { TEST: [], DUP_IN_BUYER: [], GENERIC_SIGNAL: [], REAL: [] };
+  for (const o of buyer) {
+    if (isTest(o)) buyerCats.TEST.push(o);
+    else if (demandContacts.has(o.contactId) && o.stageId === OUTREACH_QUEUED)
+      buyerCats.DUP_IN_BUYER.push(o);
+    else if (isGeneric(o)) buyerCats.GENERIC_SIGNAL.push(o);
+    else buyerCats.REAL.push(o);
+  }
+
+  // Demand-register categorization
+  const demandCats = { TEST: [], GENERIC_SIGNAL: [], REAL: [] };
+  for (const o of demand) {
+    if (isTest(o)) demandCats.TEST.push(o);
+    else if (isGeneric(o)) demandCats.GENERIC_SIGNAL.push(o);
+    else demandCats.REAL.push(o);
+  }
+
+  const out = '/tmp/goods-buyer-audit.json';
+  fs.writeFileSync(out, JSON.stringify({ demand, buyer, buyerCats, demandCats }, null, 2));
+
+  const line = (o) => `    ${o.name}  [${o.id}]  $${o.value}  contact:${o.contactName || o.contactId}`;
+
+  console.log(`\n══ DEMAND REGISTER — ${demand.length} opps ══`);
+  console.log(`  GENERIC_SIGNAL (52 beds/6 washers, review real-vs-noise): ${demandCats.GENERIC_SIGNAL.length}`);
+  console.log(`  REAL (non-templated): ${demandCats.REAL.length}`);
+  demandCats.REAL.forEach((o) => console.log(line(o)));
+  if (demandCats.TEST.length) { console.log(`  TEST: ${demandCats.TEST.length}`); demandCats.TEST.forEach((o) => console.log(line(o))); }
+
+  console.log(`\n══ BUYER PIPELINE — ${buyer.length} opps ══`);
+  console.log(`  TEST (remove): ${buyerCats.TEST.length}`);
+  buyerCats.TEST.forEach((o) => console.log(line(o)));
+  console.log(`  DUP_IN_BUYER (signal copy, unworked → remove from Buyer, keep in Demand): ${buyerCats.DUP_IN_BUYER.length}`);
+  buyerCats.DUP_IN_BUYER.forEach((o) => console.log(line(o)));
+  console.log(`  GENERIC_SIGNAL in Buyer: ${buyerCats.GENERIC_SIGNAL.length}`);
+  buyerCats.GENERIC_SIGNAL.forEach((o) => console.log(line(o)));
+  console.log(`  REAL (keep / work): ${buyerCats.REAL.length}`);
+  buyerCats.REAL.forEach((o) => console.log(line(o)));
+
+  const removeCount = buyerCats.TEST.length + buyerCats.DUP_IN_BUYER.length;
+  console.log(`\n── Proposed cleanup ──`);
+  console.log(`  Remove from Buyer Pipeline: ${removeCount} (TEST ${buyerCats.TEST.length} + DUP ${buyerCats.DUP_IN_BUYER.length})`);
+  console.log(`  Review for real-vs-noise (Demand): ${demandCats.GENERIC_SIGNAL.length} generic signals`);
+  console.log(`  Full detail written to ${out}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/cleanup-goods-buyer-pipeline.mjs
+++ b/scripts/cleanup-goods-buyer-pipeline.mjs
@@ -1,0 +1,122 @@
+/**
+ * Clean up the GHL "Goods — Buyer Pipeline" → commercial buyers only.
+ * Approved by Ben 2026-05-27 (Buyer = commercial-only; safe cleanup go).
+ *
+ *   node --env-file=.env.local scripts/cleanup-goods-buyer-pipeline.mjs            # dry-run
+ *   node --env-file=.env.local scripts/cleanup-goods-buyer-pipeline.mjs --apply    # writes
+ *
+ * Before any delete (--apply), writes a RESTORE file with the full slim records
+ * so every removal is reversible (recreatable in the Buyer pipeline).
+ *
+ * Actions:
+ *   - delete 11 from Buyer: 1 test (GD2) + 10 dup signal-copies (also in Demand Register)
+ *   - delete 10 funder/grant product-line records (relationship lives in Supporter Journey + Xero)
+ *   - Malala fix: delete the stub contact + the bad Supporter-Journey opp created earlier
+ *     (real contact Mala'la Health Service `Z6POQ8e2wtBKSWDuPLEx`; seeder re-creates it linked)
+ * NOT touched (flagged for Ben): PICC Stretch Bed, "Remote job forecast", NLC Gapuwiyak (keep).
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+import fs from 'node:fs';
+
+// Flag-selected sets so each authorization runs independently (no re-deleting done records).
+const APPLY = process.argv.includes('--apply');
+const DO_SAFE = process.argv.includes('--safe');       // 11 test+dups (done 2026-05-27)
+const DO_FUNDERS = process.argv.includes('--funders');  // 10 funder product-lines
+const DO_EXTRAS = process.argv.includes('--extras');    // PICC + stray
+const DO_MALALA = process.argv.includes('--malala');    // Malala stub/opp fix (done 2026-05-27)
+const BUYER_PIPELINE = 'FjMyJM3YzWQFmKqR9fur';
+
+// --- Buyer pipeline opp IDs to delete ---
+const SAFE_REMOVE = [
+  ['qLaDvOyq1yOHZGOAKHrS', 'GD2 test record'],
+  ['7Fn2JOclc2CoNWfgaMqB', 'dup THULKURR'],
+  ['y8w1eSUJMhQlYM0ecMco', 'dup NEW MERINEE'],
+  ['fpdvQF3YmXvoAs3fmYGA', 'dup GUNUN WOONAM'],
+  ['It2t2mhn6S6azbnW0r0Z', 'dup SHIPTON FLATS'],
+  ['bxKLejbl23aP51J7dbvy', 'dup FORDY FARM'],
+  ['gA2WqhVUiMuF0svfZYkv', 'dup AAYKA'],
+  ['idpLpcz5sG76y2s8X1aI', 'dup LINGARA'],
+  ['IKxXaIXbQFhXHieao0EI', 'dup THAANGKUNH-NHIIN'],
+  ['N95Z3uJMg8nrIYhVhlet', 'dup BANNICK BURN'],
+  ['nAcEQ7QM1gD1rxG2eSW4', 'dup JILUNDARINA'],
+];
+const FUNDER_REMOVE = [
+  ['TFFJR5Tnm62kBHR9pdvb', 'OCS Basket Bed'],
+  ['FPckXyGg46VuHmyj2Rdu', 'OCS Washing Machine'],
+  ['euhcwgBRlGIBar7U4QUs', 'Rotary Greate Bed'],
+  ['JrbJMR3rSyijKrFp21AI', "Mala'la Basket Bed"],
+  ['Ln5qUxl2w9o2gjp0w2Py', 'Centrecorp Plant'],
+  ['DM0gItqBcftcPFO4Qwj3', 'Centrecorp Basket Bed'],
+  ['lLkkIHMSpnvGPRxQu1vH', 'Centrecorp Weave Bed'],
+  ['sgGa5u8ehHHPFy6wq6PQ', 'Homeland Washing Machine'],
+  ['RPVzkVGszff6indJ3GDJ', 'Red Dust Basket Bed'],
+  ['mqWa6wCGCZUDK8bQs2L8', 'Julalikari Washing Machine'],
+];
+
+const EXTRA_REMOVE = [
+  ['KoXLnuCmAxIp8Nrpeb0W', 'PICC Stretch Bed (not Goods / ACT-PI)'],
+  ['sogR69LPK8oNQzS2u7WC', 'Remote job forecast (stray $0)'],
+];
+
+// --- Malala fix ---
+const MALALA_BAD_OPP = 'WhMkunwtIU6ug12rtApN';       // Supporter Journey opp linked to stub
+const MALALA_STUB_CONTACT = 'J4iGAZJY70veM2FjqkzD';  // duplicate stub I created
+
+async function main() {
+  const ghl = createGHLService();
+  const allDeletes = [
+    ...(DO_SAFE ? SAFE_REMOVE : []),
+    ...(DO_FUNDERS ? FUNDER_REMOVE : []),
+    ...(DO_EXTRAS ? EXTRA_REMOVE : []),
+  ];
+
+  if (!allDeletes.length && !DO_MALALA) {
+    console.log('Nothing selected. Pass one or more of: --safe --funders --extras --malala (+ --apply).');
+    return;
+  }
+
+  // restore snapshot from the audit JSON (full slim records for recreate)
+  let audit = {};
+  try { audit = JSON.parse(fs.readFileSync('/tmp/goods-buyer-audit.json', 'utf8')); } catch {}
+  const byId = new Map([...(audit.buyer || [])].map((o) => [o.id, o]));
+  const restore = {
+    pipelineId: BUYER_PIPELINE,
+    removedAt: new Date().toISOString(),
+    sets: { safe: DO_SAFE, funders: DO_FUNDERS, extras: DO_EXTRAS, malala: DO_MALALA },
+    records: allDeletes.map(([id, why]) => ({ why, ...(byId.get(id) || { id }) })),
+    ...(DO_MALALA ? { malalaBadOpp: MALALA_BAD_OPP, malalaStubContact: MALALA_STUB_CONTACT } : {}),
+  };
+
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN'}`);
+  console.log(`Sets: safe=${DO_SAFE} funders=${DO_FUNDERS} extras=${DO_EXTRAS} malala=${DO_MALALA}`);
+  console.log(`Buyer deletes selected: ${allDeletes.length}\n`);
+
+  if (!APPLY) {
+    allDeletes.forEach(([id, why]) => console.log(`  would delete  ${id}  (${why})`));
+    if (DO_MALALA) console.log(`  would fix Malala: delete opp ${MALALA_BAD_OPP} + stub contact ${MALALA_STUB_CONTACT}`);
+    console.log(`\n(Dry-run. Re-run with --apply. A restore file is written on apply.)`);
+    return;
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const restorePath = `/Users/benknight/Code/act-global-infrastructure/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed-${stamp}.json`;
+  fs.writeFileSync(restorePath, JSON.stringify(restore, null, 2));
+  console.log(`Restore snapshot written: ${restorePath}\n`);
+
+  let ok = 0, fail = 0;
+  for (const [id, why] of allDeletes) {
+    try { await ghl.deleteOpportunity(id); console.log(`✓ deleted opp ${id}  (${why})`); ok++; }
+    catch (e) { console.error(`✗ opp ${id} (${why}): ${e.message}`); fail++; }
+  }
+  if (DO_MALALA) {
+    try { await ghl.deleteOpportunity(MALALA_BAD_OPP); console.log(`✓ deleted Malala bad opp ${MALALA_BAD_OPP}`); ok++; }
+    catch (e) { console.error(`✗ Malala opp: ${e.message}`); fail++; }
+    try { await ghl.deleteContact(MALALA_STUB_CONTACT); console.log(`✓ deleted Malala stub contact ${MALALA_STUB_CONTACT}`); ok++; }
+    catch (e) { console.error(`✗ Malala stub contact: ${e.message}`); fail++; }
+  }
+
+  console.log(`\n── Done ── ok:${ok} fail:${fail}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/draft-funder-newsletter.mjs
+++ b/scripts/draft-funder-newsletter.mjs
@@ -196,7 +196,7 @@ INSTRUCTIONS:
    - Stop the line before explanation
 4. FORBIDDEN VOCAB (auto-fail if present): delve, crucial, pivotal, vital, tapestry, intricate, leverage, foster, cultivate, empower, unlock, transformative, journey, dedicated team
 5. Plain English over institutional register. No pitch-deck phrasing. No marketing tone.
-6. ALWAYS spell out "Accountable Listening and Meaningful Action (ALMA)" on first use.
+6. ALWAYS spell out "Australian Living Map of Alternatives (ALMA)" on first use.
 7. Reference specific projects, not abstract ideas.
 8. Cite numbers where they exist (commits, payments, dates).
 9. Sign off as ACT (Ben + Nic). Match the relationship stage's warmth.

--- a/scripts/seed-goods-supporter-journey.mjs
+++ b/scripts/seed-goods-supporter-journey.mjs
@@ -1,0 +1,134 @@
+/**
+ * Seed the GHL "Goods — Supporter Journey" pipeline with the 13 Goods funders.
+ *
+ * Pipeline must be created in the GHL UI first (API cannot create pipelines).
+ * Stages expected (any order): Identified, Qualified, Cultivating, Ask made,
+ * Committed, Delivering, Stewarding / Reporting, Renewing, Lapsed, Declined / Parked.
+ *
+ * Idempotent: skips a funder if an opportunity with the same name already exists
+ * in the pipeline. Re-runnable.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/seed-goods-supporter-journey.mjs            # dry-run
+ *   node --env-file=.env.local scripts/seed-goods-supporter-journey.mjs --apply    # writes
+ *
+ * Source of truth for $ values + stage/band mapping:
+ *   memory enterprise_hq_build.md "▶ RESUME HERE" + Grade→GHL playbook (2026-05-27).
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const PIPELINE_NAME = 'Supporter Journey'; // matched via getPipelineByName (substring, case-insensitive)
+
+// stage name -> normalized key for loose matching against GHL stage names
+const norm = (s) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+// The 13 funders. contactId = null means no GHL contact found (opportunity created contact-less).
+const FUNDERS = [
+  { name: 'Snow Foundation',                       value: 402930, stage: 'Stewarding / Reporting', band: 'goods-hot',     contactId: 'laCUDrYPbaEP5rC9UEcf' },
+  { name: 'Centrecorp Foundation',                 value: 123332, stage: 'Stewarding / Reporting', band: 'goods-hot',     contactId: 'ehnCEv62bCaGNTd1QuGp' },
+  { name: 'Homeland School Company',               value: 44000,  stage: 'Committed',              band: 'goods-steady',  contactId: 'hv7tFXO8UGDq3dMc98SG' },
+  { name: 'Our Community Shed',                     value: 20265,  stage: 'Renewing',               band: 'goods-steady',  contactId: 'SYhvJjn05QVkvbFJPhGv' },
+  { name: 'Julalikari Council Aboriginal Corp',     value: 19800,  stage: 'Renewing',               band: 'goods-steady',  contactId: 'OSWHIOCG3vHdyAEHot6F' },
+  { name: 'Vincent Fairfax Family Foundation',      value: 50000,  stage: 'Cultivating',            band: 'goods-cooling', contactId: 'G4vUZfUSQadk1R4KGRZC' },
+  { name: 'QIC',                                    value: 12000,  stage: 'Cultivating',            band: 'goods-cooling', contactId: '0ShRsxG5CBklEgpCIQQU' },
+  { name: 'Red Dust',                               value: 15950,  stage: 'Cultivating',            band: 'goods-cooling', contactId: '3v2RCOhzU5fCgsxEDgff' },
+  // "Malala" = Mala'la Health Service Aboriginal Corporation (apostrophe broke earlier search).
+  { name: "Mala'la Health Service Aboriginal Corp", value: 5434,   stage: 'Cultivating',            band: 'goods-cooling', contactId: 'Z6POQ8e2wtBKSWDuPLEx' },
+  { name: 'The Funding Network',                    value: 130000, stage: 'Cultivating',            band: 'goods-cooling', contactId: 'eCzgIXkVKLh3B413GVde' },
+  { name: 'FRRR',                                   value: 50000,  stage: 'Cultivating',            band: 'goods-cooling', contactId: 'j7hi3rlHwmIuDKNSIdTs' },
+  { name: 'AMP Foundation',                         value: 21900,  stage: 'Cultivating',            band: 'goods-cooling', contactId: 'wJXLZamvwqPSXxjtd6CC' },
+  { name: 'Rotary Eclub Outback Australia',         value: 82500,  stage: 'Lapsed',                 band: 'goods-cold',    contactId: 'huXguIGvyFHkixustqey' },
+];
+
+async function main() {
+  const ghl = createGHLService();
+
+  const pipeline = await ghl.getPipelineByName(PIPELINE_NAME);
+  if (!pipeline) {
+    console.error(`✗ Pipeline matching "${PIPELINE_NAME}" not found. Create "Goods — Supporter Journey" in the GHL UI first.`);
+    process.exit(1);
+  }
+  console.log(`Pipeline: "${pipeline.name}" (${pipeline.id}) — ${pipeline.stages.length} stages`);
+
+  // build stage-name -> id map (loose match)
+  const stageByKey = new Map(pipeline.stages.map((s) => [norm(s.name), s]));
+  const resolveStage = (wantName) => stageByKey.get(norm(wantName));
+
+  // fail fast if any required stage name is missing
+  const missing = [...new Set(FUNDERS.map((f) => f.stage))].filter((s) => !resolveStage(s));
+  if (missing.length) {
+    console.error(`✗ Pipeline is missing required stages: ${missing.join(', ')}`);
+    console.error(`  Stages present: ${pipeline.stages.map((s) => s.name).join(' | ')}`);
+    process.exit(1);
+  }
+
+  // existing opportunities (idempotency)
+  const existing = await ghl.getOpportunities(pipeline.id, { limit: 100 });
+  const existingNames = new Set(existing.map((o) => norm(o.name || '')));
+  console.log(`Existing opportunities in pipeline: ${existing.length}`);
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  const results = { created: [], skipped: [], tagged: [], errors: [] };
+
+  for (const f of FUNDERS) {
+    const stage = resolveStage(f.stage);
+    const line = `${f.name}  $${f.value.toLocaleString()}  → ${stage.name}  [${f.band}]  contact:${f.contactId || 'NONE'}`;
+
+    if (existingNames.has(norm(f.name))) {
+      console.log(`= SKIP (exists)  ${line}`);
+      results.skipped.push(f.name);
+      continue;
+    }
+
+    if (!APPLY) {
+      const note = !f.contactId && f.createContact ? '  (will create contact)' : '';
+      console.log(`+ WOULD CREATE  ${line}${note}`);
+      continue;
+    }
+
+    try {
+      // Create a contact first if none exists and we're configured to (e.g. Malala).
+      let contactId = f.contactId;
+      if (!contactId && f.createContact) {
+        const c = await ghl.createContact({
+          // GHL requires at least one of email/phone/firstName/lastName.
+          firstName: f.createContact.companyName,
+          name: f.createContact.companyName,
+          companyName: f.createContact.companyName,
+          tags: f.createContact.tags,
+          source: 'Goods Supporter Journey seed',
+        });
+        contactId = c.id || c.contact?.id;
+        console.log(`  ↳ created contact ${contactId} for ${f.name}`);
+      }
+
+      const opp = await ghl.createOpportunity({
+        pipelineId: pipeline.id,
+        stageId: stage.id,
+        name: f.name,
+        monetaryValue: f.value,
+        status: 'open',
+        ...(contactId ? { contactId } : {}),
+      });
+      console.log(`+ CREATED  ${line}  (opp ${opp.id})`);
+      results.created.push(f.name);
+
+      if (contactId) {
+        await ghl.addTagToContact(contactId, f.band);
+        results.tagged.push(`${f.name}:${f.band}`);
+      }
+    } catch (err) {
+      console.error(`✗ ERROR  ${f.name}: ${err.message}`);
+      results.errors.push(`${f.name}: ${err.message}`);
+    }
+  }
+
+  console.log(`\n── Summary ──`);
+  console.log(`Created: ${results.created.length}  | Skipped(existing): ${results.skipped.length}  | Tagged: ${results.tagged.length}  | Errors: ${results.errors.length}`);
+  if (results.errors.length) console.log(`Errors:\n  ${results.errors.join('\n  ')}`);
+  if (!APPLY) console.log(`\n(Dry-run. Re-run with --apply to write.)`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed-2026-05-27T05-44-26-758Z.json
+++ b/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed-2026-05-27T05-44-26-758Z.json
@@ -1,0 +1,226 @@
+{
+  "pipelineId": "FjMyJM3YzWQFmKqR9fur",
+  "removedAt": "2026-05-27T05:44:26.755Z",
+  "sets": {
+    "safe": false,
+    "funders": true,
+    "extras": true,
+    "malala": false
+  },
+  "records": [
+    {
+      "why": "OCS Basket Bed",
+      "id": "TFFJR5Tnm62kBHR9pdvb",
+      "name": "Our Community Shed Incorporated — Goods Basket Bed v1.3",
+      "value": 13500,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "SYhvJjn05QVkvbFJPhGv",
+      "contactName": "Coordinator — Our Community Shed",
+      "email": "coordinator@ourshed.org",
+      "tags": [
+        "goods",
+        "goods-partner",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "OCS Washing Machine",
+      "id": "FPckXyGg46VuHmyj2Rdu",
+      "name": "Our Community Shed Incorporated — Goods Indestructible Washing Machine v1",
+      "value": 6765,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "SYhvJjn05QVkvbFJPhGv",
+      "contactName": "Coordinator — Our Community Shed",
+      "email": "coordinator@ourshed.org",
+      "tags": [
+        "goods",
+        "goods-partner",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "Rotary Greate Bed",
+      "id": "euhcwgBRlGIBar7U4QUs",
+      "name": "Rotary Eclub Outback Australia, Division 9560, — Goods Greate Bed v1",
+      "value": 82500,
+      "stageId": "835065e8-c952-4cfe-9228-5e8625d100ae",
+      "contactId": "huXguIGvyFHkixustqey",
+      "contactName": "Accounts Rotary Eclub Outback Australia, Division 9560",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd",
+        "goods-cold"
+      ]
+    },
+    {
+      "why": "Mala'la Basket Bed",
+      "id": "JrbJMR3rSyijKrFp21AI",
+      "name": "Mala’la Health Service Aboriginal Corporation — Goods Basket Bed v2.1",
+      "value": 5434,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "Z6POQ8e2wtBKSWDuPLEx",
+      "contactName": "Accounts Mala’la Health Service Aboriginal Corporation",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "Centrecorp Plant",
+      "id": "Ln5qUxl2w9o2gjp0w2Py",
+      "name": "Centrecorp Foundation — Goods Production Plant part 1",
+      "value": 84700,
+      "stageId": "e23847c3-5f74-4da6-a907-6c3d6d45008c",
+      "contactId": "ehnCEv62bCaGNTd1QuGp",
+      "contactName": "Randle Walker",
+      "email": "randle@centrecorp.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "project:act-ca",
+        "goods-hot"
+      ]
+    },
+    {
+      "why": "Centrecorp Basket Bed",
+      "id": "DM0gItqBcftcPFO4Qwj3",
+      "name": "Centrecorp Foundation — Goods Basket Bed v1.3",
+      "value": 37620,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "ehnCEv62bCaGNTd1QuGp",
+      "contactName": "Randle Walker",
+      "email": "randle@centrecorp.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "project:act-ca",
+        "goods-hot"
+      ]
+    },
+    {
+      "why": "Centrecorp Weave Bed",
+      "id": "lLkkIHMSpnvGPRxQu1vH",
+      "name": "Centrecorp Foundation — Goods Weave Bed v2.3 - Utopia Homelands",
+      "value": 85712,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "ehnCEv62bCaGNTd1QuGp",
+      "contactName": "Randle Walker",
+      "email": "randle@centrecorp.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "project:act-ca",
+        "goods-hot"
+      ]
+    },
+    {
+      "why": "Homeland Washing Machine",
+      "id": "sgGa5u8ehHHPFy6wq6PQ",
+      "name": "Homeland School Company — Goods. Indestructible Washing Machine v1.1",
+      "value": 4950,
+      "stageId": "835065e8-c952-4cfe-9228-5e8625d100ae",
+      "contactId": "hv7tFXO8UGDq3dMc98SG",
+      "contactName": "Accounts Homeland School Company",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "Red Dust Basket Bed",
+      "id": "RPVzkVGszff6indJ3GDJ",
+      "name": "Red Dust Role Models Limited — Goods Basket Bed v1",
+      "value": 15950,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "3v2RCOhzU5fCgsxEDgff",
+      "contactName": "Fiona Scicluna",
+      "email": "fiona@reddust.org.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-cooling"
+      ]
+    },
+    {
+      "why": "Julalikari Washing Machine",
+      "id": "mqWa6wCGCZUDK8bQs2L8",
+      "name": "Julalikari Council Aboriginal Corporation — Goods Indestructible Washing Machine v1",
+      "value": 19800,
+      "stageId": "0100d504-3108-415c-82fd-85a66192ef1c",
+      "contactId": "OSWHIOCG3vHdyAEHot6F",
+      "contactName": "GM Corporate — Julalikari",
+      "email": "gmcorporate@julalikari.com.au",
+      "tags": [
+        "goods",
+        "goods-supporter",
+        "goods-newsletter",
+        "act-gd",
+        "project:act-gd",
+        "goods-steady"
+      ]
+    },
+    {
+      "why": "PICC Stretch Bed (not Goods / ACT-PI)",
+      "id": "KoXLnuCmAxIp8Nrpeb0W",
+      "name": "Palm Island Community Company Limited (PICC) — Goods Stretch Bed v2.3",
+      "value": 36300,
+      "stageId": "835065e8-c952-4cfe-9228-5e8625d100ae",
+      "contactId": "f8sbjgfZo1oD0Je0yArk",
+      "contactName": "Accounts Palm Island Community Company Limited (PICC)",
+      "email": null,
+      "tags": [
+        "goods",
+        "auto-created-from-xero",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "Remote job forecast (stray $0)",
+      "id": "sogR69LPK8oNQzS2u7WC",
+      "name": "Remote job forecast opportunities",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "0kEs9BJmkmi7ZUc5haEX",
+      "contactName": "Kristy Bloomfield",
+      "email": "kristy.bloomfield@oonchiumpa.com.au",
+      "tags": [
+        "goods-newsletter",
+        "justicehub",
+        "partner",
+        "act-gd",
+        "act-jh",
+        "project:act-hv",
+        "project:act-gd"
+      ]
+    }
+  ]
+}

--- a/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed.json
+++ b/thoughts/shared/finance/2026-05-27-buyer-pipeline-cleanup-removed.json
@@ -1,0 +1,194 @@
+{
+  "pipelineId": "FjMyJM3YzWQFmKqR9fur",
+  "removedAt": "2026-05-27T05:40:36.853Z",
+  "records": [
+    {
+      "why": "GD2 test record",
+      "id": "qLaDvOyq1yOHZGOAKHrS",
+      "name": "GD2 - flagship-inquiry",
+      "value": 0,
+      "stageId": "1fd317ec-f8f1-4837-b324-e48c22956cdd",
+      "contactId": "bP4jEBSns3be5KnonIro",
+      "contactName": "GD2",
+      "email": "opp-v2-gd@example.com",
+      "tags": [
+        "test-submission",
+        "act-regenerative-studio",
+        "act-gd",
+        "flagship-inquiry"
+      ]
+    },
+    {
+      "why": "dup THULKURR",
+      "id": "7Fn2JOclc2CoNWfgaMqB",
+      "name": "Goods Buyer: THULKURR — Unmet demand: THULKURR (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "7sp5Zwueh0OKblAKQirR",
+      "contactName": "THULKURR QLD",
+      "email": "thulkurr@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup NEW MERINEE",
+      "id": "y8w1eSUJMhQlYM0ecMco",
+      "name": "Goods Buyer: NEW MERINEE — Unmet demand: NEW MERINEE (NSW) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "xBxaigCAdO1v8ARO1lo2",
+      "contactName": "NEW MERINEE NSW",
+      "email": "new-merinee@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup GUNUN WOONAM",
+      "id": "fpdvQF3YmXvoAs3fmYGA",
+      "name": "Goods Buyer: GUNUN WOONAM — Unmet demand: GUNUN WOONAM (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "gPxPrnGkA01DbSigTaYM",
+      "contactName": "GUNUN WOONAM QLD",
+      "email": "gunun-woonam@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup SHIPTON FLATS",
+      "id": "It2t2mhn6S6azbnW0r0Z",
+      "name": "Goods Buyer: SHIPTON FLATS — Unmet demand: SHIPTON FLATS (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "dYbBIH1H5deXDEerV5HE",
+      "contactName": "SHIPTON FLATS QLD",
+      "email": "shipton-flats@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup FORDY FARM",
+      "id": "bxKLejbl23aP51J7dbvy",
+      "name": "Goods Buyer: FORDY FARM — Unmet demand: FORDY FARM (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "fm0tdDRDfl3EFTOg1JS7",
+      "contactName": "FORDY FARM QLD",
+      "email": "fordy-farm@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-fm"
+      ]
+    },
+    {
+      "why": "dup AAYKA",
+      "id": "gA2WqhVUiMuF0svfZYkv",
+      "name": "Goods Buyer: AAYKA — Unmet demand: AAYKA (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "jkXvzq4QJDPKCur8akIX",
+      "contactName": "AAYKA QLD",
+      "email": "aayka@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup LINGARA",
+      "id": "idpLpcz5sG76y2s8X1aI",
+      "name": "Goods Buyer: LINGARA — Unmet demand: LINGARA (NT) — 17 beds, 2 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "ZC6OOSxs3h5ZOGPm4Qgr",
+      "contactName": "LINGARA NT",
+      "email": "lingara@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup THAANGKUNH-NHIIN",
+      "id": "IKxXaIXbQFhXHieao0EI",
+      "name": "Goods Buyer: THAANGKUNH-NHIIN — Unmet demand: THAANGKUNH-NHIIN (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "cAt1QstivkhGfT2ShFAc",
+      "contactName": "THAANGKUNH-NHIIN QLD",
+      "email": "thaangkunh-nhiin@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup BANNICK BURN",
+      "id": "N95Z3uJMg8nrIYhVhlet",
+      "name": "Goods Buyer: BANNICK BURN — Unmet demand: BANNICK BURN (QLD) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "wu6SihnJXkEkKrUYtheG",
+      "contactName": "BANNICK BURN QLD",
+      "email": "bannick-burn@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    },
+    {
+      "why": "dup JILUNDARINA",
+      "id": "nAcEQ7QM1gD1rxG2eSW4",
+      "name": "Goods Buyer: JILUNDARINA — Unmet demand: JILUNDARINA (NT) — 52 beds, 6 washers",
+      "value": 0,
+      "stageId": "e5220eb2-be40-4e79-9571-6acae12285c7",
+      "contactId": "Q0HsirXpDJJ3vLpNIKmj",
+      "contactName": "JILUNDARINA NT",
+      "email": "jilundarina@goods.civicgraph.io",
+      "tags": [
+        "goods-signal",
+        "goods-new",
+        "priority-medium",
+        "act-gd",
+        "project:act-gd"
+      ]
+    }
+  ],
+  "malalaBadOpp": "WhMkunwtIU6ug12rtApN",
+  "malalaStubContact": "J4iGAZJY70veM2FjqkzD"
+}

--- a/tools/act-wikipedia.html
+++ b/tools/act-wikipedia.html
@@ -1013,7 +1013,7 @@ a.wikilink:visited {
   <ul style="list-style:none; display:flex; gap:1em; flex-wrap:wrap; color:#72777d;">
     <li>Content is compiled by LLM from raw sources</li>
     <li>Powered by the <a href="#" onclick="navigateTo('llm-knowledge-base'); return false;">LLM Knowledge Base</a> pattern</li>
-    <li>Last compiled: 2026-05-18</li>
+    <li>Last compiled: 2026-05-25</li>
   </ul>
 </div>
 
@@ -1051,7 +1051,7 @@ const EL_CONFIG = {
     "fishers-oysters": {"projectId":"a2a86d3e-54ed-4550-8a0e-4878a257c5a3","orgId":"a2a86d3e-54ed-4550-8a0e-4878a257c5a3","projectName":"Fishers Oysters","name":"Fishers Oysters","count":0,"filenamePattern":null,"orgFallbackId":"d44703a8-78c7-47d9-bac9-b4714bb183c0","orgFallbackName":"Fishers Oysters","storytellers":[{"id":"5bb1c324-659b-4082-8999-52c68139e564","name":"Shaun Fisher","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/shaun_fisher.jpg","location":"Stradbroke","isElder":false}],"stories":[{"id":"940c804a-e52c-4c48-a4fe-6a4d45778a74","title":"After the Flood","excerpt":"How the 2022 floods devastated the oyster leases and how the farming community pulled together to rebuild.","themes":[{"name":"resilience"},{"name":"community"},{"name":"climate"}],"storyteller_id":"5bb1c324-659b-4082-8999-52c68139e564"},{"id":"0576ab6c-4a46-42f5-b497-b9573f118ab6","title":"Grading Day","excerpt":"The art and labour of grading Sydney Rock oysters — teaching the next generation about quality and pride in craft.","themes":[{"name":"craftsmanship"},{"name":"family"},{"name":"aquaculture"}],"storyteller_id":"5bb1c324-659b-4082-8999-52c68139e564"},{"id":"1b26a0b5-5c72-426d-8a0c-2ef88036b7d5","title":"The Morning Tide","excerpt":"Three generations of oyster farming on the river — reading the tides, the seasons, and the signs that nature provides.","themes":[{"name":"sustainability"},{"name":"family heritage"},{"name":"aquaculture"}],"storyteller_id":"5bb1c324-659b-4082-8999-52c68139e564"}]},
     "global-laundry-alliance": {"projectId":"cb0d49d0-db5e-4e47-842e-a3edfaba8c81","orgId":"cb0d49d0-db5e-4e47-842e-a3edfaba8c81","projectName":"Global Laundry Alliance","name":"Global Laundry Alliance","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "gold-phone": {"projectId":"461644e3-cfbe-4708-972c-ba49d4261c2c","orgId":"461644e3-cfbe-4708-972c-ba49d4261c2c","projectName":"Gold.Phone","name":"Gold.Phone","count":53,"filenamePattern":"GoldPhone","orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
-    "goods": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":72,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c","name":"Dianne Stokes","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/dianne_stokes.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":true},{"id":"e0da3338-1a38-4b5a-9a26-73c9873b9242","name":"Cliff Plummer","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/cliff_plummer.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":false}],"stories":[{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"eef3beb7-db31-4d90-b100-1ef37a336a4c","title":"Community Voices — Alice Springs","excerpt":"Alice Springs community voices on quality beds for remote families.","themes":[{"name":"Community Voices"},{"name":"Impact"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"28cb405e-78de-43e3-849c-5c87cbde3760","title":"Where the Country Calls Me Home","excerpt":"Every time I go away from here, it's like it's calling me. Come back home. And when I get home, I feel happy I'm at home.","themes":[{"name":"Connection to Country"},{"name":"Cultural Preservation"},{"name":"Youth Empowerment"},{"name":"Two-Way Learning"},{"name":"Resilience"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"e94f98ed-00f3-42ff-b97c-2430ee4655ab","title":"Pakkimjalki Kari: Beds, Washing Machines, and the Blessings We Share","excerpt":"When a brand-new washing machine arrives at Alba Camp in Tennant Creek, Dianne Stokes can't contain her joy. This is the story of beds, washing machines, and what happens when a community decides that","themes":[{"name":"Community Resilience"},{"name":"Data Sovereignty"},{"name":"Language Preservation"},{"name":"Intergenerational Knowledge"},{"name":"Cultural Protocols"},{"name":"Housing Sovereignty"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"62789c4d-416d-4cc4-8632-388e423403be","title":"The Recycling Plant","excerpt":"Inside the recycling plant where plastic waste becomes Stretch Bed components.","themes":[{"name":"Manufacturing"},{"name":"Recycling"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"0b5d8222-cccc-4a9b-a396-aa53e1f22c50","title":"Stretch Bed Overview","excerpt":"Everything about the Stretch Bed — design, materials, and impact.","themes":[{"name":"Product"},{"name":"Design"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b43026fa-81a1-4f48-865c-3033a8cb0b48","title":"Stretch Bed Timelapse","excerpt":"The Stretch Bed assembles in minutes — no tools needed.","themes":[{"name":"Product"},{"name":"Assembly"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b1fe7941-2ceb-4205-a414-cfe982322a52","title":"Beds & Dignity — Cliff Plummer","excerpt":"Cliff Plummer on what proper beds mean for community dignity.","themes":[{"name":"Community Impact"},{"name":"Dignity"}],"storyteller_id":"e0da3338-1a38-4b5a-9a26-73c9873b9242"},{"id":"ce5cc871-13dc-46c7-b31c-8111221e90fb","title":"On Country Production #2","excerpt":"Turning 20kg of plastic waste into durable bed legs.","themes":[{"name":"Recycling"},{"name":"HDPE"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
+    "goods": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":95,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810","name":"Benjamin Knight","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1778447929801_BK_Photo.jpg","location":"Australia","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false}],"stories":[{"id":"55897065-526b-4c56-8fb7-8a2c3ace4993","title":"Three Days in Utopia, and What the Homelands Asked of Us","excerpt":"Three days with the Oonchiumpa team. The young people who built the beds. The families who asked for them. The trust I was lent for every photograph. What the homelands instructed me to carry home.","themes":[{"name":"Designed in community"},{"name":"On-Country"},{"name":"Director reflection"}],"storyteller_id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810"},{"id":"1c9d1e10-ea5d-4482-87ca-3bc439369fae","title":"Alice Springs build · 20 May 2026 · #103","excerpt":"Alice Springs build session, 20 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f8c697b7-0984-47f9-8641-b0ea334fbb64","title":"Alice Springs build · 19 May 2026 · #069","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"931b286a-3a3d-4b75-9dbe-3c0376966c9a","title":"Alice Springs build · 19 May 2026 · #059","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"042b9538-c392-4239-a1cd-01b783c8ca22","title":"Alice Springs build · 19 May 2026 · #058","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f3445547-692b-43a0-87e5-325012f0a94c","title":"Alice Springs build · 19 May 2026 · #061","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"ccbd3b55-9d25-4dd8-a6cb-76050f2b83d4","title":"Alice Springs build · 18 May 2026 · #001","excerpt":"Alice Springs build session, 18 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"d14556de-d617-4654-8bc2-de60b56c16ac","title":"Alice Springs build · 19 May 2026 · #062","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
     "how-does-empathy-ledger-v2-integrate-with-civicgraph-and-justicehub-to-add-the-h": {"projectId":"2e774118-471c-450b-a6bc-41467a43c0cf","orgId":"2e774118-471c-450b-a6bc-41467a43c0cf","projectName":"JusticeHub","name":"JusticeHub","count":16,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "how-does-justicehub-program-search-connect-postcards-to-real-services-across-aus": {"projectId":"2e774118-471c-450b-a6bc-41467a43c0cf","orgId":"2e774118-471c-450b-a6bc-41467a43c0cf","projectName":"JusticeHub","name":"JusticeHub","count":16,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "how-should-act-apply-the-karpathy-loop-to-justicehub-the-minderoo-pitch-and-the-": {"projectId":"2e774118-471c-450b-a6bc-41467a43c0cf","orgId":"2e774118-471c-450b-a6bc-41467a43c0cf","projectName":"JusticeHub","name":"JusticeHub","count":16,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
@@ -1080,8 +1080,8 @@ const EL_CONFIG = {
     "projects/civicgraph/rd-activity-register.md.provenance": {"projectId":"ec2ad2d8-13d6-4488-87ae-5385ddf73394","orgId":"ec2ad2d8-13d6-4488-87ae-5385ddf73394","projectName":"CivicGraph","name":"CivicGraph","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "projects/empathy-ledger/rd-activity-register": {"projectId":"a2e50220-b02a-445c-9b7b-b354b34e3429","orgId":"a2e50220-b02a-445c-9b7b-b354b34e3429","projectName":"Empathy Ledger","name":"Empathy Ledger","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "projects/empathy-ledger/rd-activity-register.md.provenance": {"projectId":"a2e50220-b02a-445c-9b7b-b354b34e3429","orgId":"a2e50220-b02a-445c-9b7b-b354b34e3429","projectName":"Empathy Ledger","name":"Empathy Ledger","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
-    "projects/goods/rd-activity-register": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":72,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c","name":"Dianne Stokes","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/dianne_stokes.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":true},{"id":"e0da3338-1a38-4b5a-9a26-73c9873b9242","name":"Cliff Plummer","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/cliff_plummer.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":false}],"stories":[{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"eef3beb7-db31-4d90-b100-1ef37a336a4c","title":"Community Voices — Alice Springs","excerpt":"Alice Springs community voices on quality beds for remote families.","themes":[{"name":"Community Voices"},{"name":"Impact"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"28cb405e-78de-43e3-849c-5c87cbde3760","title":"Where the Country Calls Me Home","excerpt":"Every time I go away from here, it's like it's calling me. Come back home. And when I get home, I feel happy I'm at home.","themes":[{"name":"Connection to Country"},{"name":"Cultural Preservation"},{"name":"Youth Empowerment"},{"name":"Two-Way Learning"},{"name":"Resilience"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"e94f98ed-00f3-42ff-b97c-2430ee4655ab","title":"Pakkimjalki Kari: Beds, Washing Machines, and the Blessings We Share","excerpt":"When a brand-new washing machine arrives at Alba Camp in Tennant Creek, Dianne Stokes can't contain her joy. This is the story of beds, washing machines, and what happens when a community decides that","themes":[{"name":"Community Resilience"},{"name":"Data Sovereignty"},{"name":"Language Preservation"},{"name":"Intergenerational Knowledge"},{"name":"Cultural Protocols"},{"name":"Housing Sovereignty"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"62789c4d-416d-4cc4-8632-388e423403be","title":"The Recycling Plant","excerpt":"Inside the recycling plant where plastic waste becomes Stretch Bed components.","themes":[{"name":"Manufacturing"},{"name":"Recycling"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"0b5d8222-cccc-4a9b-a396-aa53e1f22c50","title":"Stretch Bed Overview","excerpt":"Everything about the Stretch Bed — design, materials, and impact.","themes":[{"name":"Product"},{"name":"Design"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b43026fa-81a1-4f48-865c-3033a8cb0b48","title":"Stretch Bed Timelapse","excerpt":"The Stretch Bed assembles in minutes — no tools needed.","themes":[{"name":"Product"},{"name":"Assembly"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b1fe7941-2ceb-4205-a414-cfe982322a52","title":"Beds & Dignity — Cliff Plummer","excerpt":"Cliff Plummer on what proper beds mean for community dignity.","themes":[{"name":"Community Impact"},{"name":"Dignity"}],"storyteller_id":"e0da3338-1a38-4b5a-9a26-73c9873b9242"},{"id":"ce5cc871-13dc-46c7-b31c-8111221e90fb","title":"On Country Production #2","excerpt":"Turning 20kg of plastic waste into durable bed legs.","themes":[{"name":"Recycling"},{"name":"HDPE"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
-    "projects/goods/rd-activity-register.md.provenance": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":72,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c","name":"Dianne Stokes","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/dianne_stokes.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":true},{"id":"e0da3338-1a38-4b5a-9a26-73c9873b9242","name":"Cliff Plummer","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/cliff_plummer.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":false}],"stories":[{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"eef3beb7-db31-4d90-b100-1ef37a336a4c","title":"Community Voices — Alice Springs","excerpt":"Alice Springs community voices on quality beds for remote families.","themes":[{"name":"Community Voices"},{"name":"Impact"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"28cb405e-78de-43e3-849c-5c87cbde3760","title":"Where the Country Calls Me Home","excerpt":"Every time I go away from here, it's like it's calling me. Come back home. And when I get home, I feel happy I'm at home.","themes":[{"name":"Connection to Country"},{"name":"Cultural Preservation"},{"name":"Youth Empowerment"},{"name":"Two-Way Learning"},{"name":"Resilience"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"e94f98ed-00f3-42ff-b97c-2430ee4655ab","title":"Pakkimjalki Kari: Beds, Washing Machines, and the Blessings We Share","excerpt":"When a brand-new washing machine arrives at Alba Camp in Tennant Creek, Dianne Stokes can't contain her joy. This is the story of beds, washing machines, and what happens when a community decides that","themes":[{"name":"Community Resilience"},{"name":"Data Sovereignty"},{"name":"Language Preservation"},{"name":"Intergenerational Knowledge"},{"name":"Cultural Protocols"},{"name":"Housing Sovereignty"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"62789c4d-416d-4cc4-8632-388e423403be","title":"The Recycling Plant","excerpt":"Inside the recycling plant where plastic waste becomes Stretch Bed components.","themes":[{"name":"Manufacturing"},{"name":"Recycling"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"0b5d8222-cccc-4a9b-a396-aa53e1f22c50","title":"Stretch Bed Overview","excerpt":"Everything about the Stretch Bed — design, materials, and impact.","themes":[{"name":"Product"},{"name":"Design"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b43026fa-81a1-4f48-865c-3033a8cb0b48","title":"Stretch Bed Timelapse","excerpt":"The Stretch Bed assembles in minutes — no tools needed.","themes":[{"name":"Product"},{"name":"Assembly"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b1fe7941-2ceb-4205-a414-cfe982322a52","title":"Beds & Dignity — Cliff Plummer","excerpt":"Cliff Plummer on what proper beds mean for community dignity.","themes":[{"name":"Community Impact"},{"name":"Dignity"}],"storyteller_id":"e0da3338-1a38-4b5a-9a26-73c9873b9242"},{"id":"ce5cc871-13dc-46c7-b31c-8111221e90fb","title":"On Country Production #2","excerpt":"Turning 20kg of plastic waste into durable bed legs.","themes":[{"name":"Recycling"},{"name":"HDPE"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
+    "projects/goods/rd-activity-register": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":95,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810","name":"Benjamin Knight","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1778447929801_BK_Photo.jpg","location":"Australia","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false}],"stories":[{"id":"55897065-526b-4c56-8fb7-8a2c3ace4993","title":"Three Days in Utopia, and What the Homelands Asked of Us","excerpt":"Three days with the Oonchiumpa team. The young people who built the beds. The families who asked for them. The trust I was lent for every photograph. What the homelands instructed me to carry home.","themes":[{"name":"Designed in community"},{"name":"On-Country"},{"name":"Director reflection"}],"storyteller_id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810"},{"id":"1c9d1e10-ea5d-4482-87ca-3bc439369fae","title":"Alice Springs build · 20 May 2026 · #103","excerpt":"Alice Springs build session, 20 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f8c697b7-0984-47f9-8641-b0ea334fbb64","title":"Alice Springs build · 19 May 2026 · #069","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"931b286a-3a3d-4b75-9dbe-3c0376966c9a","title":"Alice Springs build · 19 May 2026 · #059","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"042b9538-c392-4239-a1cd-01b783c8ca22","title":"Alice Springs build · 19 May 2026 · #058","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f3445547-692b-43a0-87e5-325012f0a94c","title":"Alice Springs build · 19 May 2026 · #061","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"ccbd3b55-9d25-4dd8-a6cb-76050f2b83d4","title":"Alice Springs build · 18 May 2026 · #001","excerpt":"Alice Springs build session, 18 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"d14556de-d617-4654-8bc2-de60b56c16ac","title":"Alice Springs build · 19 May 2026 · #062","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
+    "projects/goods/rd-activity-register.md.provenance": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":95,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810","name":"Benjamin Knight","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1778447929801_BK_Photo.jpg","location":"Australia","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false}],"stories":[{"id":"55897065-526b-4c56-8fb7-8a2c3ace4993","title":"Three Days in Utopia, and What the Homelands Asked of Us","excerpt":"Three days with the Oonchiumpa team. The young people who built the beds. The families who asked for them. The trust I was lent for every photograph. What the homelands instructed me to carry home.","themes":[{"name":"Designed in community"},{"name":"On-Country"},{"name":"Director reflection"}],"storyteller_id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810"},{"id":"1c9d1e10-ea5d-4482-87ca-3bc439369fae","title":"Alice Springs build · 20 May 2026 · #103","excerpt":"Alice Springs build session, 20 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f8c697b7-0984-47f9-8641-b0ea334fbb64","title":"Alice Springs build · 19 May 2026 · #069","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"931b286a-3a3d-4b75-9dbe-3c0376966c9a","title":"Alice Springs build · 19 May 2026 · #059","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"042b9538-c392-4239-a1cd-01b783c8ca22","title":"Alice Springs build · 19 May 2026 · #058","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f3445547-692b-43a0-87e5-325012f0a94c","title":"Alice Springs build · 19 May 2026 · #061","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"ccbd3b55-9d25-4dd8-a6cb-76050f2b83d4","title":"Alice Springs build · 18 May 2026 · #001","excerpt":"Alice Springs build session, 18 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"d14556de-d617-4654-8bc2-de60b56c16ac","title":"Alice Springs build · 19 May 2026 · #062","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
     "projects/justicehub/README": {"projectId":"2e774118-471c-450b-a6bc-41467a43c0cf","orgId":"2e774118-471c-450b-a6bc-41467a43c0cf","projectName":"JusticeHub","name":"JusticeHub","count":16,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "projects/justicehub/rd-activity-register": {"projectId":"2e774118-471c-450b-a6bc-41467a43c0cf","orgId":"2e774118-471c-450b-a6bc-41467a43c0cf","projectName":"JusticeHub","name":"JusticeHub","count":16,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "projects/justicehub/rd-activity-register.md.provenance": {"projectId":"2e774118-471c-450b-a6bc-41467a43c0cf","orgId":"2e774118-471c-450b-a6bc-41467a43c0cf","projectName":"JusticeHub","name":"JusticeHub","count":16,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
@@ -1106,7 +1106,7 @@ const EL_CONFIG = {
     "stories/bg-fit-tuesday-gym-sessions-building-consistency": {"projectId":"81bdb028-7855-4682-b501-b727f24e0d6d","orgId":"81bdb028-7855-4682-b501-b727f24e0d6d","projectName":"BG Fit","name":"BG Fit","count":25,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"0d69f085-dfc5-4a7e-bf03-f9bdb5099d7f","name":"Uncle George","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/uncle_george.jpg","location":"Mount Isa","isElder":true},{"id":"1b2598cf-80a2-4386-969a-3e9315950b04","name":"Brodie Germaine","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/brodie_germaine.jpg","location":"Mount Isa, Queensland, Australia","isElder":false},{"id":"7130f208-1bae-4739-9a8a-36dc6e8e6a6a","name":"Mount Isa Camp Participant","avatar":"","location":"Mount Isa, QLD","isElder":false},{"id":"aeadcbda-0acc-40b4-a562-8f3121ef661c","name":"Doomadgee Camp Participant","avatar":"","location":"Doomadgee, QLD","isElder":false},{"id":"843b8d1f-77eb-461b-809b-c3aee2ccabbe","name":"Spinifex Res Youth","avatar":"","location":"Mount Isa, QLD","isElder":false}],"stories":[{"id":"f3d6042b-3da8-4ee0-a1bc-f29b57df8ecf","title":"Speak From the Heart and They Will Listen","excerpt":"You've got to learn to speak from the heart. If you speak from the heart and you tell the truth, people listen. I'm here because I care.","themes":[{"name":"Tough Love"},{"name":"Youth Engagement"},{"name":"Community Leadership"},{"name":"Intergenerational Responsibility"},{"name":"Speaking Truth"}],"storyteller_id":"0d69f085-dfc5-4a7e-bf03-f9bdb5099d7f"},{"id":"33d25ec6-2d88-4e00-9291-35df8589f8ab","title":"Why I Started BG Fit","excerpt":"I started BG Fit because I saw too many of our mob going through the justice system and not getting the support they needed.","themes":[{"name":"Youth Justice"},{"name":"Sport as Intervention"},{"name":"Community Building"},{"name":"Cultural Strength"}],"storyteller_id":"1b2598cf-80a2-4386-969a-3e9315950b04"},{"id":"37b2d916-85db-4ef2-ad65-d2e8a6a19ac0","title":"Mount Isa Bush Camp — First One on Country","excerpt":"The Mount Isa bush camp was our first big event. We took 12 young fellas out on country for three days.","themes":[{"name":"Connection to Country"},{"name":"Youth Development"},{"name":"Cultural Connection"},{"name":"Healing on Country"}],"storyteller_id":"7130f208-1bae-4739-9a8a-36dc6e8e6a6a"},{"id":"5f8a774a-6725-4ec0-b2c0-80f88c05e72d","title":"Doomadgee Camp — Taking It Remote","excerpt":"The community welcomed us with open arms. The Elders were so happy to see someone bringing activities for the young people.","themes":[{"name":"Remote Communities"},{"name":"Youth Engagement"},{"name":"Showing Up"},{"name":"Community Need"}],"storyteller_id":"aeadcbda-0acc-40b4-a562-8f3121ef661c"},{"id":"ce620748-6b15-4497-a1f5-baef224d5bf1","title":"Spinifex Residential — Getting Through to the Hard Cases","excerpt":"When we first started going in there, the staff were sceptical. After about the fourth session, the kids started waiting for us at the gate.","themes":[{"name":"Youth Justice"},{"name":"Residential Care"},{"name":"Trust Through Sport"},{"name":"Creating Pathways"}],"storyteller_id":"843b8d1f-77eb-461b-809b-c3aee2ccabbe"},{"id":"31ac3a2c-6517-48b2-9f2b-26b8c5f8faef","title":"When You're at Bush, You Can Be Yourself","excerpt":"When you're at bush, it makes you feel grounded. It gives you peace. We're creating a space where you can be yourself. There's no judgement.","themes":[{"name":"Youth Empowerment"},{"name":"Connection to Country"},{"name":"Role Models"},{"name":"Community Wellbeing"},{"name":"No Judgement"}],"storyteller_id":"1b2598cf-80a2-4386-969a-3e9315950b04"}]},
     "stories/bg-fit-why-i-started-bg-fit": {"projectId":"81bdb028-7855-4682-b501-b727f24e0d6d","orgId":"81bdb028-7855-4682-b501-b727f24e0d6d","projectName":"BG Fit","name":"BG Fit","count":25,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"0d69f085-dfc5-4a7e-bf03-f9bdb5099d7f","name":"Uncle George","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/uncle_george.jpg","location":"Mount Isa","isElder":true},{"id":"1b2598cf-80a2-4386-969a-3e9315950b04","name":"Brodie Germaine","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/brodie_germaine.jpg","location":"Mount Isa, Queensland, Australia","isElder":false},{"id":"7130f208-1bae-4739-9a8a-36dc6e8e6a6a","name":"Mount Isa Camp Participant","avatar":"","location":"Mount Isa, QLD","isElder":false},{"id":"aeadcbda-0acc-40b4-a562-8f3121ef661c","name":"Doomadgee Camp Participant","avatar":"","location":"Doomadgee, QLD","isElder":false},{"id":"843b8d1f-77eb-461b-809b-c3aee2ccabbe","name":"Spinifex Res Youth","avatar":"","location":"Mount Isa, QLD","isElder":false}],"stories":[{"id":"f3d6042b-3da8-4ee0-a1bc-f29b57df8ecf","title":"Speak From the Heart and They Will Listen","excerpt":"You've got to learn to speak from the heart. If you speak from the heart and you tell the truth, people listen. I'm here because I care.","themes":[{"name":"Tough Love"},{"name":"Youth Engagement"},{"name":"Community Leadership"},{"name":"Intergenerational Responsibility"},{"name":"Speaking Truth"}],"storyteller_id":"0d69f085-dfc5-4a7e-bf03-f9bdb5099d7f"},{"id":"33d25ec6-2d88-4e00-9291-35df8589f8ab","title":"Why I Started BG Fit","excerpt":"I started BG Fit because I saw too many of our mob going through the justice system and not getting the support they needed.","themes":[{"name":"Youth Justice"},{"name":"Sport as Intervention"},{"name":"Community Building"},{"name":"Cultural Strength"}],"storyteller_id":"1b2598cf-80a2-4386-969a-3e9315950b04"},{"id":"37b2d916-85db-4ef2-ad65-d2e8a6a19ac0","title":"Mount Isa Bush Camp — First One on Country","excerpt":"The Mount Isa bush camp was our first big event. We took 12 young fellas out on country for three days.","themes":[{"name":"Connection to Country"},{"name":"Youth Development"},{"name":"Cultural Connection"},{"name":"Healing on Country"}],"storyteller_id":"7130f208-1bae-4739-9a8a-36dc6e8e6a6a"},{"id":"5f8a774a-6725-4ec0-b2c0-80f88c05e72d","title":"Doomadgee Camp — Taking It Remote","excerpt":"The community welcomed us with open arms. The Elders were so happy to see someone bringing activities for the young people.","themes":[{"name":"Remote Communities"},{"name":"Youth Engagement"},{"name":"Showing Up"},{"name":"Community Need"}],"storyteller_id":"aeadcbda-0acc-40b4-a562-8f3121ef661c"},{"id":"ce620748-6b15-4497-a1f5-baef224d5bf1","title":"Spinifex Residential — Getting Through to the Hard Cases","excerpt":"When we first started going in there, the staff were sceptical. After about the fourth session, the kids started waiting for us at the gate.","themes":[{"name":"Youth Justice"},{"name":"Residential Care"},{"name":"Trust Through Sport"},{"name":"Creating Pathways"}],"storyteller_id":"843b8d1f-77eb-461b-809b-c3aee2ccabbe"},{"id":"31ac3a2c-6517-48b2-9f2b-26b8c5f8faef","title":"When You're at Bush, You Can Be Yourself","excerpt":"When you're at bush, it makes you feel grounded. It gives you peace. We're creating a space where you can be yourself. There's no judgement.","themes":[{"name":"Youth Empowerment"},{"name":"Connection to Country"},{"name":"Role Models"},{"name":"Community Wellbeing"},{"name":"No Judgement"}],"storyteller_id":"1b2598cf-80a2-4386-969a-3e9315950b04"}]},
     "stories/building-empathy-ledger": {"projectId":"a2e50220-b02a-445c-9b7b-b354b34e3429","orgId":"a2e50220-b02a-445c-9b7b-b354b34e3429","projectName":"Empathy Ledger","name":"Empathy Ledger","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
-    "stories/community-innovation-goods": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":72,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c","name":"Dianne Stokes","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/dianne_stokes.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":true},{"id":"e0da3338-1a38-4b5a-9a26-73c9873b9242","name":"Cliff Plummer","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/cliff_plummer.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":false}],"stories":[{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"eef3beb7-db31-4d90-b100-1ef37a336a4c","title":"Community Voices — Alice Springs","excerpt":"Alice Springs community voices on quality beds for remote families.","themes":[{"name":"Community Voices"},{"name":"Impact"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"28cb405e-78de-43e3-849c-5c87cbde3760","title":"Where the Country Calls Me Home","excerpt":"Every time I go away from here, it's like it's calling me. Come back home. And when I get home, I feel happy I'm at home.","themes":[{"name":"Connection to Country"},{"name":"Cultural Preservation"},{"name":"Youth Empowerment"},{"name":"Two-Way Learning"},{"name":"Resilience"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"e94f98ed-00f3-42ff-b97c-2430ee4655ab","title":"Pakkimjalki Kari: Beds, Washing Machines, and the Blessings We Share","excerpt":"When a brand-new washing machine arrives at Alba Camp in Tennant Creek, Dianne Stokes can't contain her joy. This is the story of beds, washing machines, and what happens when a community decides that","themes":[{"name":"Community Resilience"},{"name":"Data Sovereignty"},{"name":"Language Preservation"},{"name":"Intergenerational Knowledge"},{"name":"Cultural Protocols"},{"name":"Housing Sovereignty"}],"storyteller_id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c"},{"id":"62789c4d-416d-4cc4-8632-388e423403be","title":"The Recycling Plant","excerpt":"Inside the recycling plant where plastic waste becomes Stretch Bed components.","themes":[{"name":"Manufacturing"},{"name":"Recycling"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"0b5d8222-cccc-4a9b-a396-aa53e1f22c50","title":"Stretch Bed Overview","excerpt":"Everything about the Stretch Bed — design, materials, and impact.","themes":[{"name":"Product"},{"name":"Design"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b43026fa-81a1-4f48-865c-3033a8cb0b48","title":"Stretch Bed Timelapse","excerpt":"The Stretch Bed assembles in minutes — no tools needed.","themes":[{"name":"Product"},{"name":"Assembly"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"b1fe7941-2ceb-4205-a414-cfe982322a52","title":"Beds & Dignity — Cliff Plummer","excerpt":"Cliff Plummer on what proper beds mean for community dignity.","themes":[{"name":"Community Impact"},{"name":"Dignity"}],"storyteller_id":"e0da3338-1a38-4b5a-9a26-73c9873b9242"},{"id":"ce5cc871-13dc-46c7-b31c-8111221e90fb","title":"On Country Production #2","excerpt":"Turning 20kg of plastic waste into durable bed legs.","themes":[{"name":"Recycling"},{"name":"HDPE"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
+    "stories/community-innovation-goods": {"projectId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","orgId":"6bd47c8a-e676-456f-aa25-ddcbb5a31047","projectName":"Goods","name":"Goods","count":95,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[{"id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810","name":"Benjamin Knight","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1778447929801_BK_Photo.jpg","location":"Australia","isElder":false},{"id":"ac700001-0000-0000-0000-000000000002","name":"ACT Production Team","avatar":"","location":"Australia","isElder":false},{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false}],"stories":[{"id":"55897065-526b-4c56-8fb7-8a2c3ace4993","title":"Three Days in Utopia, and What the Homelands Asked of Us","excerpt":"Three days with the Oonchiumpa team. The young people who built the beds. The families who asked for them. The trust I was lent for every photograph. What the homelands instructed me to carry home.","themes":[{"name":"Designed in community"},{"name":"On-Country"},{"name":"Director reflection"}],"storyteller_id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810"},{"id":"1c9d1e10-ea5d-4482-87ca-3bc439369fae","title":"Alice Springs build · 20 May 2026 · #103","excerpt":"Alice Springs build session, 20 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"164ebfe0-aabf-4d28-8af7-33ecee776e34","title":"Community Voices — Fred Campbell","excerpt":"Fred Campbell on what a proper bed means for his life.","themes":[{"name":"Community Impact"},{"name":"Wellbeing"}],"storyteller_id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b"},{"id":"e5ae69f9-f212-4467-9ee7-0f7826d09dd3","title":"On Country Production #1","excerpt":"Community members manufacturing bed components from recycled plastic.","themes":[{"name":"Manufacturing"},{"name":"On Country"}],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f8c697b7-0984-47f9-8641-b0ea334fbb64","title":"Alice Springs build · 19 May 2026 · #069","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"931b286a-3a3d-4b75-9dbe-3c0376966c9a","title":"Alice Springs build · 19 May 2026 · #059","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"042b9538-c392-4239-a1cd-01b783c8ca22","title":"Alice Springs build · 19 May 2026 · #058","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"f3445547-692b-43a0-87e5-325012f0a94c","title":"Alice Springs build · 19 May 2026 · #061","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"ccbd3b55-9d25-4dd8-a6cb-76050f2b83d4","title":"Alice Springs build · 18 May 2026 · #001","excerpt":"Alice Springs build session, 18 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"},{"id":"d14556de-d617-4654-8bc2-de60b56c16ac","title":"Alice Springs build · 19 May 2026 · #062","excerpt":"Alice Springs build session, 19 May 2026. Oonchiumpa young people.","themes":[],"storyteller_id":"ac700001-0000-0000-0000-000000000002"}]},
     "stories/mounty-yarns-mounty-yarns-in-their-own-words": {"projectId":"4f4a4eda-82ee-4042-8786-1563adf11dc9","orgId":"4f4a4eda-82ee-4042-8786-1563adf11dc9","projectName":"Mounty Yarns","name":"Mounty Yarns","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "the-buttery": {"projectId":"2cb5ca3a-a6a3-4b16-8711-0f673ee8cd04","orgId":"2cb5ca3a-a6a3-4b16-8711-0f673ee8cd04","projectName":"The Buttery Story","name":"The Buttery Story","count":0,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
     "the-caravan": {"projectId":"62099f56-eb46-4791-8e1b-cf1dcb702da1","orgId":"62099f56-eb46-4791-8e1b-cf1dcb702da1","projectName":"The Caravan","name":"The Caravan","count":25,"filenamePattern":null,"orgFallbackId":null,"orgFallbackName":null,"storytellers":[],"stories":[]},
@@ -1903,7 +1903,7 @@ Review this decision if:
     slug: "2026-04-five-year-plan",
     title: "Five-Year Plan — Voice, Flow, Ground",
     domain: "decisions",
-    links: ["empathy-ledger","civicgraph","act-farm","the-harvest","2026-04-founder-lanes-and-top-two-bets","empathy-ledger/","the-brave-ones/","civicgraph/","justicehub/","goods-on-country/","contained/","act-farm/","the-harvest/","lcaa-method","beautiful-obsolescence","justicehub","goods-on-country","picc","communities/the-buttery","smart-connect","the-brave-ones","strategic-decisions-log","contained","2026-04-act-farm-repositioning","five-year-cashflow-model","rdti-claim-strategy","art/y1-release-program","empathy-ledger/annual-field-service"],
+    links: ["empathy-ledger","civicgraph","act-farm","the-harvest","2026-04-founder-lanes-and-top-two-bets","empathy-ledger/","the-brave-ones/","civicgraph/","justicehub/","goods-on-country/","contained/","act-farm/","the-harvest/","lcaa-method","2026-05-25-civic-cerebellum-reframe","beautiful-obsolescence","justicehub","goods-on-country","picc","communities/the-buttery","smart-connect","the-brave-ones","strategic-decisions-log","contained","2026-04-act-farm-repositioning","five-year-cashflow-model","rdti-claim-strategy","art/y1-release-program","empathy-ledger/annual-field-service"],
     content: `# Five-Year Plan — Voice, Flow, Ground
 
 > Decision: ACT builds a revenue-generating machine over five years across three layers — Voice ([[empathy-ledger|Empathy Ledger]] bespoke storytelling), Flow ([[civicgraph|CivicGraph]] as the commercial trading arm), and Ground ([[act-farm|ACT Farm]] + [[the-harvest|The Harvest]] residency and eco-tourism revenue). Both founders invoice retroactively for FY26 R&D work. CivicGraph is positioned as the exit lever for Years 6–10 art and activism. Founder sustainability is treated as a structural requirement, not a nice-to-have.
@@ -1942,9 +1942,11 @@ $100K each, 95%/40% R&D allocation, through the family trust structures being se
 
 ### 2. CivicGraph is the commercial trading arm
 
+> **_updated 2026-05-25:** This section is amended by [[2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]] (signed off by Ben + Nic, 2026-05-25). The "CivicGraph as strategic exit lever for a Y5 sale" framing is **retired**. CivicGraph is now positioned as the **intelligence layer of the civic operating system**, alongside JusticeHub (practice) and Empathy Ledger (accountability). The Stripe tiers stand. Commissioned intelligence and ACT advisory are added as named revenue flywheels. The five-year revenue arc below is unchanged; the channels through which it arrives are updated. The Beautiful Obsolescence rule is also amended (CivicGraph is infrastructure-inherited, not infrastructure-obsoleted). See the ADR for full detail.
+
 [[civicgraph|CivicGraph]] keeps its Stripe tiers ($79–$1999/mo), grows its data moat (100K entities, 672K contracts, 312K donations), and is explicitly positioned as the product that funds the other products' community handover.
 
-The [[beautiful-obsolescence|Beautiful Obsolescence]] language stays on [[empathy-ledger|Empathy Ledger]], [[justicehub|JusticeHub]], [[goods-on-country|Goods on Country]], [[the-harvest|The Harvest]]. It is never applied to CivicGraph publicly. CivicGraph exists to be commercially valuable and, in Y5, potentially sold to a strategic acquirer ($4–10M EV range at 3–6x ARR) to fund the Years 6–10 art and activism phase.
+The [[beautiful-obsolescence|Beautiful Obsolescence]] language stays on [[empathy-ledger|Empathy Ledger]], [[justicehub|JusticeHub]], [[goods-on-country|Goods on Country]], [[the-harvest|The Harvest]]. It is never applied to CivicGraph publicly. CivicGraph exists to be commercially valuable and, in Y5, potentially sold to a strategic acquirer ($4–10M EV range at 3–6x ARR) to fund the Years 6–10 art and activism phase. *(2026-05-25 — the Y5 sale framing in this paragraph is retired by the [[2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]]. Commercial dimension stands; strategic-exit framing does not.)*
 
 ### 3. Empathy Ledger stays bespoke in Y1
 
@@ -2763,6 +2765,127 @@ When designing any new feature:
 - \`scripts/backfill-ghl-civicgraph-links.mjs\` (in grantscope repo) — proves the bridge already works
 - GrantScope MCP server (\`grantscope/mcp-server/\`)`
   },
+  "2026-05-25-civic-cerebellum-reframe": {
+    slug: "2026-05-25-civic-cerebellum-reframe",
+    title: "Civic Cerebellum Reframe — CivicGraph as Intelligence Layer of the Civic OS",
+    domain: "decisions",
+    links: ["civicgraph","justicehub","empathy-ledger","2026-04-five-year-plan","civic-world-model","act-brand-alignment-map","ai-ethics","oonchiumpa-story-approval","civicgraph/","justicehub/","alma/","empathy-ledger/","picc","communities/the-buttery","smart-connect","beautiful-obsolescence","../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan","civic-operating-system","civic-reflex-automation","../operations/act-operational-thesis"],
+    content: `# Civic Cerebellum Reframe — CivicGraph as Intelligence Layer of the Civic OS
+
+> **Decision:** A Curious Tractor (ACT) is not building artificial CEOs for civil society. ACT is building the **civic cerebellum** — the quiet reflex layer that helps communities, services, and social enterprises get the boring-but-essential work done reliably, ethically, and at scale. The portfolio is one civic operating system with three layers: **[[civicgraph|CivicGraph]] sees the field** (intelligence), **[[justicehub|JusticeHub]] supports the work** (practice), **[[empathy-ledger|Empathy Ledger]] holds the trust** (accountability). CivicGraph is the **intelligence layer of that operating system**, not a sellable vertical SaaS and not a strategic exit asset. CivicGraph remains commercially active, but revenue flows through three deliberate channels (public-good legitimacy, commissioned intelligence, ACT advisory) that compound rather than dilute ACT's authority. Public-good outputs of every layer are non-negotiable and published openly. Commercial customers accept this rule before working with ACT. That rule is a feature, not a friction.
+
+This decision settles a split-brain framing that has been load-bearing in two different directions across [[2026-04-five-year-plan|the five-year plan]], [[civic-world-model|the civic world model concept page]], and the portfolio docs. It does not break the financial arc of the five-year plan. It changes the channels through which that revenue arrives and the authority on which it stands.
+
+## Why This Exists
+
+Three things forced the call.
+
+**One.** Three reviews (act-global-infrastructure, empathy-ledger-v2, JusticeHub) against the cerebellum framing returned the same finding: the values and primitives across all three repos already match a cerebellum thesis, but the portfolio is narrated as three separate products rather than one civic operating system. None of the existing portfolio docs describe the three tools as layers of one OS. The [[act-brand-alignment-map|brand alignment map]] treats them as visual cousins, not as product layers. There is no canonical "one OS" page. The reframe gives the existing work a coherent home without rebuilding any of it.
+
+**Two.** The CivicGraph framing has been split. [[2026-04-five-year-plan|The five-year plan]] (line 48) positions CivicGraph as "explicitly positioned as the product that funds the other products' community handover... in Y5, potentially sold to a strategic acquirer ($4–10M EV range at 3–6x ARR) to fund the Years 6–10 art and activism phase." [[civic-world-model|The civic world model concept]] (line 7) positions CivicGraph as "a replacement for the archaic, top-down hierarchy" — closer to "civic CEO" than to ACT's stated AI ethics ("[[ai-ethics|intelligence without consent is just extraction]]"). Two readings of the same product, both load-bearing, neither resolved. Every downstream decision (funding pitches, brand copy, product roadmap, hiring) has been quietly splitting because of it. The reframe picks one reading and retires the other.
+
+**Three.** The 2026 launch sequence forces the call. JusticeHub launches at the Reintegration Conference (week of 22 June 2026). The Empathy Ledger × [[oonchiumpa-story-approval|Oonchiumpa]] × Flinders University launch lands in Q1 2027. CivicGraph launches at Philanthropy Australia in September 2026. These three launches only compound if they share one narrative. Without a settled reframe, each launch reads as a separate product pitch. With a settled reframe, each launch reads as one civic operating system becoming visible from a different angle.
+
+## The Reframe
+
+ACT builds three tools that share one architecture, one ethics, one publishing cadence, and one set of reflex primitives (intake, consent, triage, referral, follow-up, audit, evidence).
+
+| Layer | Tool | Role | Public-good output | Commissioned output |
+|---|---|---|---|---|
+| Intelligence | [[civicgraph\\|CivicGraph]] | Sees the civic field. Maps money, power, deserts, opportunities. | Funding Deserts Atlas, Revolving Door Explorer, Open API, quarterly State of Civic Money | Foundation deep-dive briefs, place-based intelligence packs, procurement watchlists, dependency-risk audits, M&A intelligence |
+| Practice | [[justicehub\\|JusticeHub]] | Supports community-led justice and social-impact practice. Helps the work happen. | JusticeHub Atlas (evidence map of what works), companion briefs, the [[alma\\|Australian Living Map of Alternatives (ALMA)]] catalogue | JusticeHub Practice (operational reflex layer for partner orgs), program evidence-bundles for funders |
+| Accountability | [[empathy-ledger\\|Empathy Ledger]] | Holds the trust. Consent, audit, AI-use ledger, human-in-the-loop, sovereignty primitives. | Public consent control surfaces, AI-use ledger, accountability API consumed by sibling products | Annual bespoke storytelling engagements ([[picc|PICC]], JCF, [[communities/the-buttery|The Buttery]], [[smart-connect|SMART Recovery]], [[oonchiumpa-story-approval|Oonchiumpa]] × Flinders) |
+
+The three tools call each other. CivicGraph instruments every public chart with provenance events written to Empathy Ledger's accountability API. JusticeHub fetches opportunities from CivicGraph and verifies consent against Empathy Ledger before surfacing any story. Empathy Ledger publishes the trust contracts that every other ACT product is built on. This is what makes "one civic OS" technically real, not a marketing line.
+
+## What This Amends in the Five-Year Plan
+
+[[2026-04-five-year-plan|The five-year plan]] stands. Both founders still invoice retroactively for FY26 R&D. The Voice / Flow / Ground revenue layers stand. The five-year revenue arc stands. The founder sustainability plan stands. Land purchase in the Witta (Maleny region) area remains the personal goal. The financial picture is unchanged.
+
+What is amended:
+
+1. **The "CivicGraph as strategic exit lever" line in §2 (line 48) is retired.** CivicGraph is not for sale to a strategic acquirer in Y5. The Stripe tiers remain. Commissioned work expands. Advisory grows. Y6–10 art and activism phase is funded from the salary + R&D refund recycling that the same five-year plan already shows (line 80) is achievable without exit proceeds.
+
+2. **The [[beautiful-obsolescence|Beautiful Obsolescence]] rule is updated.** The five-year plan said the Beautiful Obsolescence language is never applied to CivicGraph publicly. That stands for the original reason (CivicGraph needs commercial coherence). It is amended for a new reason: CivicGraph is the *infrastructure layer* of the civic OS. Infrastructure layers are not obsoleted; they are inherited. The other layers (JusticeHub, Empathy Ledger, Goods on Country, The Harvest) remain Beautiful-Obsolescence-shaped — built to be handed to communities. CivicGraph remains operated by ACT as the shared intelligence substrate that the handed-over tools draw on.
+
+3. **The Flow layer description is widened.** Flow was named as "where capital, evidence, and attention move" with CivicGraph as the commercial engine. Flow now also names CivicGraph as the **intelligence sensorium** of the civic OS — the layer that makes the other layers' work visible, fundable, and defensible. The commercial engine framing remains; the intelligence-layer framing is added on top.
+
+## The Public-Good Non-Negotiable Rule
+
+This is the load-bearing operational consequence of the reframe.
+
+> Every layer of the civic operating system produces public-good outputs on a published cadence. Those outputs are not gated, not paywalled, not redacted for commercial customers. Commissioned customers accept that ACT publishes the truth either way before any engagement begins.
+
+Three concrete implications:
+
+1. **CivicGraph's Funding Deserts Atlas is published openly even when foundations who pay for commissioned briefs are named as funding deserts.** The commissioned customer's name will appear in public ACT analysis if the data shows it. That is stated up front in every commissioned engagement.
+
+2. **Empathy Ledger publishes accountability primitives as open API.** Sibling ACT products call them. So do partner organisations who are not paying customers. So do researchers and journalists. The trust layer is public infrastructure.
+
+3. **JusticeHub Atlas (the evidence map) stays free.** Commissioned customers buy JusticeHub Practice (the operational reflex layer for their org) or commissioned briefs. The map itself is never sold.
+
+The rule filters customers. The customers it filters out were not going to fund the work ACT exists to do. The customers it lets through are the ones who fund it well and trust it more for the public commitment.
+
+## Three Revenue Flywheels (Replaces "SaaS-to-Exit" Framing)
+
+CivicGraph revenue flows through three named channels that reinforce each other. None of them is a strategic exit. All of them are durable.
+
+| Flywheel                              | Mode                                   | What it trades                                               | What it builds                                                                     |
+| ------------------------------------- | -------------------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| **Public good**                       | Free, open, hosted by ACT              | Effort, opinion, publication cadence                         | Legitimacy, rooms, journalist relationships, defensive moat against vendor framing |
+| **Commissioned intelligence**         | Paid, per-org / per-place / per-sector | CivicGraph data + ACT synthesis, signed by named authors     | Revenue, deep customer relationships, real-world case studies                      |
+| **ACT advisory + thought leadership** | Paid, ACT-as-firm                      | Frameworks, board briefings, residency engagements, keynotes | Authority, partnership invitations, the right to set sector agendas                |
+
+The free public-good work makes the commissioned briefs credible. The commissioned briefs make the advisory rate defensible. The advisory work surfaces the next public-good artifact worth building. Vendors who skip the public-good flywheel never earn the authority. Think tanks who skip the commissioned flywheel never get the data depth.
+
+## What This Does NOT Change
+
+- The four bespoke Empathy Ledger customers in Y1 stand ([[picc|PICC]], JCF, [[communities/the-buttery|The Buttery]], [[smart-connect|SMART Recovery]]).
+- The [[oonchiumpa-story-approval|Oonchiumpa]] × Flinders University Voices of Young People partnership stands. ACT is infrastructure-in-support, not the face.
+- The Voice / Flow / Ground revenue arc stands.
+- Both founders' R&D invoicing strategy stands.
+- The Witta (Maleny) land purchase goal stands.
+- The Goods on Country, ACT Farm, and The Harvest projects are unchanged.
+- The Beautiful Obsolescence framing on Empathy Ledger, JusticeHub, Goods on Country, and The Harvest stands.
+- CivicGraph's Stripe pricing tiers stand.
+
+## Operational Consequences
+
+Three operational tracks follow from this decision and are documented in detail at [[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|the FY27 Launch Operations Plan]]:
+
+1. **Three coordinated launches in 2026/27** — JusticeHub at Reintegration (June), Empathy Ledger Field Trip + Oonchiumpa launch prep (mid-2026 through Q1 2027), CivicGraph at Philanthropy Australia (September 2026). Each launch reads as one civic operating system becoming visible from a different angle.
+2. **Cross-product wiring** — Empathy Ledger publishes the accountability API. CivicGraph instruments every public artifact through it. JusticeHub fetches from both. Per-codebase build prompts are in the FY27 ops plan, §7.
+3. **A named publication** — ACT Field Notes (working name) runs weekly during the Field Trip and continues afterwards. Quarterly State of Civic Money. Annual flagship publication. Published cadence is what makes the launches feel inevitable rather than promotional.
+
+Three companion documentation moves land alongside this ADR:
+
+- [[civic-operating-system]] — new canonical concept page describing the three layers, their shared reflex primitives, and the inter-product calls
+- [[civic-reflex-automation]] — new concept page promoting the existing "Automate the Boring, Amplify the Art" section ([[../operations/act-operational-thesis|operational thesis]] §"Automate the Boring") into a first-class page, with the five fundable build areas as H2 headings
+- [[civic-world-model]] — rewritten to drop the "replacement for top-down hierarchy" framing (too close to civic-CEO positioning) and reframe as "intelligence sensorium that feeds the civic reflex layer"
+
+## Risks Named
+
+- **Commissioned customers may push back on the public-good non-negotiable rule.** Some will. They are not the right customers. The rule is the filter.
+- **The CivicGraph team may read this as "no more commercial focus" and slow product investment.** Counter-read: this expands the commercial surface (commissioned intelligence + advisory are added to Stripe tiers, not subtracted). Product investment continues at the same pace, aimed at the public-good launch products as the credibility engine for everything else.
+- **The Oonchiumpa × Flinders launch may slip if Flinders ethics approval is not started this week.** Ethics for Indigenous research with young people typically takes three to six months. If not started by end of May 2026, Q1 2027 launch slips. This is on the next-14-days list in the FY27 ops plan.
+- **The reframe will be read as a re-brand by some readers.** It is not. It is a renaming of what is already half-built. The cerebellum is real across all three repos. It has not been called one until now.
+
+## Decision Records
+
+**Proposed by:** Ben Knight, 2026-05-25.
+
+**Sign-off required from:**
+
+| Name | Role | Sign-off date | Notes |
+|---|---|---|---|
+| Ben Knight | Co-founder, ACT | 2026-05-25 | Signed |
+| Nicholas Marchesi | Co-founder, ACT | 2026-05-25 | Signed |
+
+**Post-sign-off actions:**
+1. ✅ Frontmatter \`status:\` flipped to "Active working decision" (2026-05-25).
+2. ✅ \`_updated:\` marker added to [[2026-04-five-year-plan|the five-year plan]] §2 (2026-05-25).
+3. → Day 2 of the FY27 ops plan in progress: \`civic-operating-system.md\` companion concept page being drafted; Oonchiumpa + Flinders ethics call on the calendar.`
+  },
   "2026-05-harvest-subsidiary-structure": {
     slug: "2026-05-harvest-subsidiary-structure",
     title: "The Harvest — Subsidiary Structure Decision",
@@ -3371,7 +3494,7 @@ New features: UI goes in \`apps/command-center/\`, API routes in \`apps/command-
     slug: "act-brand-alignment-map",
     title: "ACT Brand Alignment Map — read before designing anything",
     domain: "decisions",
-    links: ["act-core-facts","../../thoughts/shared/plans/act-brain-expansion","../../.claude/skills/act-brand-alignment/references/brand-core","../../.claude/skills/act-brand-alignment/references/writing-voice"],
+    links: ["../concepts/four-lanes","../concepts/civic-operating-system","2026-05-25-civic-cerebellum-reframe","../concepts/civic-reflex-automation","act-core-facts","../../thoughts/shared/plans/act-brain-expansion","../../.claude/skills/act-brand-alignment/references/brand-core","../../.claude/skills/act-brand-alignment/references/writing-voice"],
     content: `# ACT Brand Alignment Map
 
 > **Read this before designing anything.** The map exists so you don't re-decide what's already decided. If a question isn't answered here, the answer is to extend this file, not to design from scratch.
@@ -3381,6 +3504,36 @@ New features: UI goes in \`apps/command-center/\`, API routes in \`apps/command-
 > - \`.claude/skills/act-brand-alignment/references/writing-voice.md\` (Curtis method; AI-tells blocklist)
 > - \`act-regenerative-studio/DESIGN.md\` (parent VISUAL: Bold Documentary + Warm Editorial)
 > - per-sub-brand \`DESIGN.md\` files listed below
+
+---
+
+## The three tools are one civic OS (read this first)
+
+> Before any visual deviation rule below: **CivicGraph, JusticeHub, and Empathy Ledger are not three independent products.** They are three layers of one civic operating system. The visual deviations downstream serve the layer differentiation; they are not branding accidents and they cannot be unified into one look without breaking the product architecture.
+
+ACT builds three tools that share one architecture, one ethics, one publishing cadence, and one set of reflex primitives (intake, consent, triage, referral, follow-up, audit, evidence):
+
+| Layer | Tool | Role |
+|---|---|---|
+| **Intelligence** | CivicGraph (grantscope repo) | Sees the civic field. Maps money, power, opportunities, deserts. |
+| **Practice** | JusticeHub | Supports the work. Reflex layer for community-led justice and social-impact practice. |
+| **Accountability** | Empathy Ledger v2 | Holds the trust. Consent, audit, AI-use ledger, human-in-the-loop, sovereignty primitives. |
+
+The three tools call each other technically (CivicGraph writes provenance events to Empathy Ledger's accountability API; JusticeHub fetches opportunities from CivicGraph and verifies consent against Empathy Ledger). The civic OS is enforced in code, not just in marketing.
+
+**Why the visual deviations below exist:**
+- **CivicGraph wears Civic Bauhaus** because the intelligence layer publishes accountability data (funding deserts, revolving doors, power concentration). Warmth on that surface would undermine the teeth the data has earned.
+- **JusticeHub and Empathy Ledger wear Editorial Warmth** (in different subfamilies) because they are practice and storytelling surfaces for human relationships, lived experience, and cultural authority. Bauhaus on those surfaces would feel extractive.
+- The clusters serve the layers. Don't apply Bauhaus to a story surface. Don't apply Editorial Warmth to a data atlas. If a future surface doesn't clearly belong to one layer, that's a product-architecture question first, a visual question second.
+
+**Not in the civic OS:** Goods on Country, ACT Farm, and The Harvest Witta are separate ACT projects on different revenue lanes (see [[../concepts/four-lanes|The Four Lanes]]). They are part of the wider ACT ecosystem but do not inherit the civic-OS three-layer scheme. The visual cluster choices for those surfaces are made independently, per their own sections below.
+
+**Read before designing in any of the three civic-OS repos:**
+- [[../concepts/civic-operating-system|Civic Operating System concept page]] — the architecture, the shared reflex primitives, the cross-product API calls
+- [[2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR (2026-05-25)]] — the decision that established the architecture
+- [[../concepts/civic-reflex-automation|Civic Reflex Automation]] — the AI thesis that makes the layers coherent
+
+The visual decisions in the rest of this file only make sense once you understand which layer your surface serves.
 
 ---
 
@@ -3528,7 +3681,7 @@ These rules apply to every surface, regardless of cluster:
 
 1. **Voice (Curtis method).** Name the room, name the body, load the abstract noun, stop the line before the explanation. From \`writing-voice.md\`.
 2. **AI-tells blocklist.** Never use: delve, crucial, pivotal, tapestry, underscore, "not just X but Y", rule-of-three adjective padding, em-dashes (in any ACT-facing writing), "challenges and future prospects", "-ing" significance tails.
-3. **Naming.** "Accountable Listening and Meaningful Action (ALMA)" needs first-use expansion and should not be used bare. Call the intervention map "JusticeHub evidence map" or "ALMA-governed JusticeHub evidence", not ALMA. "Listen · Curiosity · Action · Art" never bare "LCAA". Indigenous place names always; colonial in brackets only.
+3. **Naming.** "Australian Living Map of Alternatives (ALMA)" needs first-use expansion and should not be used bare. Call the intervention map "JusticeHub evidence map" or "ALMA-governed JusticeHub evidence", not ALMA. "Listen · Curiosity · Action · Art" never bare "LCAA". Indigenous place names always; colonial in brackets only.
 4. **LCAA imprint.** Every project should be reachable from the LCAA framing — Listen, Curiosity, Action, Art — visually OR narratively. Some lean Listen (EL v2), some Action (JH), some Art (Studio), some all four (Farm). State which.
 5. **Indigenous protocols.** Cultural-protocols-true projects (PICC, Oonchiumpa, BG Fit, Mounty Yarns) require OCAP-style consent before any storyteller content lands publicly. From \`wiki/projects/...\` per-project notes + \`project_wiki_story_sync.md\` memory.
 
@@ -3717,7 +3870,7 @@ Full list: \`config/project-codes.json\` (v1.8.0, 74 projects, all with canonica
 
 ## Naming & voice (always apply)
 
-- **"Accountable Listening and Meaningful Action (ALMA)"** — spell out on first use; never use bare "ALMA" in external copy
+- **"Australian Living Map of Alternatives (ALMA)"** — spell out on first use; never use bare "ALMA" in external copy
 - **"JusticeHub evidence map"** or **"ALMA-governed JusticeHub evidence"** — use this for the intervention map; do not call the map "ALMA"
 - **"Listen · Curiosity · Action · Art"** — never bare acronym "LCAA" in external copy
 - **Indigenous place names always**, colonial in brackets only
@@ -3792,7 +3945,7 @@ The sync script (\`scripts/sync-act-context.mjs\`) generates an "ACT Context" bl
     slug: "act-ecosystem",
     title: "ACT Ecosystem",
     domain: "concepts",
-    links: ["act-identity","empathy-ledger","third-reality","ocap-principles","justicehub","civicgraph","the-harvest","act-farm","black-cockatoo-valley","beautiful-obsolescence","picc","../technical/local-ai-architecture","../communities/mount-isa","goods-on-country","deadlylabs","contained","uncle-allan-palm-island-art","the-confessional","gold-phone","../projects/act-studio","lcaa-method"],
+    links: ["act-identity","empathy-ledger","third-reality","civicgraph","justicehub","four-lanes","civic-operating-system","civic-reflex-automation","evidence-as-by-product","ocap-principles","the-harvest","act-farm","black-cockatoo-valley","beautiful-obsolescence","picc","../technical/local-ai-architecture","../communities/mount-isa","goods-on-country","deadlylabs","contained","uncle-allan-palm-island-art","the-confessional","gold-phone","../projects/act-studio","lcaa-method"],
     content: `# ACT Ecosystem
 
 > Six clusters, one connective tissue, one design principle — a map of how ACT's projects fit together and what holds them.
@@ -3802,6 +3955,14 @@ The sync script (\`scripts/sync-act-context.mjs\`) generates an "ACT Context" bl
 [[act-identity|A Curious Tractor]] is not a portfolio of separate programs. It is an ecosystem — each project feeds the others, shares infrastructure, and contributes to the same end: community sovereignty and the handover of genuine capability.
 
 [[empathy-ledger|Empathy Ledger]] is the connective tissue. It flows stories into The Harvest, evidence into JusticeHub, community voices into PICC's annual report, and cultural knowledge into CivicGraph's picture of the system. Without Empathy Ledger, you have data. With it, you have the [[third-reality|Third Reality]].
+
+## The Civic Operating System (within the ecosystem)
+
+Three of the ecosystem's projects, [[civicgraph|CivicGraph]] (intelligence), [[justicehub|JusticeHub]] (practice), and [[empathy-ledger|Empathy Ledger]] (accountability), form **one civic operating system with three layers**. They share one architecture, share consent and audit primitives, and call each other in code. Together they are the reflex layer of ACT's product work, the cerebellum that makes the boring-but-essential work happen reliably.
+
+The other clusters below (Place, Community Control at Scale, Youth and Justice, Art and Culture) are not part of the civic OS. They sit alongside it on different revenue lanes (see [[four-lanes|The Four Lanes]]). The civic OS gives them intelligence, practice infrastructure, and accountability rails when they want them; it does not absorb them.
+
+See [[civic-operating-system|Civic Operating System]] for the architecture, [[civic-reflex-automation|Civic Reflex Automation]] for the AI thesis, and [[evidence-as-by-product|Evidence as a By-Product]] for how impact reporting composes from the layers.
 
 ## The Clusters
 
@@ -3877,11 +4038,15 @@ The ACT Studio coordinates across all of them. Every project can syndicate conte
 ## Backlinks
 
 - [[act-identity|ACT Identity]] — what ACT is and how it's structured
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) sitting inside this ecosystem
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis underneath the civic OS
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how impact reporting composes from the layers
 - [[empathy-ledger|Empathy Ledger]] — the connective tissue
 - [[the-harvest|The Harvest]] — place cluster anchor
 - [[picc|PICC]] — the proof case
 - [[third-reality|The Third Reality]] — the impact methodology that ties it together
-- [[lcaa-method|LCAA Method]] — the operating framework`
+- [[lcaa-method|LCAA Method]] — the operating framework
+- [[four-lanes|The Four Lanes]] — how money flows through the ecosystem; clarifies which projects sit inside the civic OS and which sit alongside it`
   },
   "act-farm": {
     slug: "act-farm",
@@ -4024,7 +4189,7 @@ Studio revenue funds land care, community wages, and long-term repair. Enterpris
     slug: "act-identity",
     title: "ACT Identity",
     domain: "concepts",
-    links: ["soul","../people/benjamin-knight","../people/nicholas-marchesi","../decisions/act-core-facts","four-lanes","lcaa-method","beautiful-obsolescence","third-reality","act-ecosystem","act-studio","act-monthly-dinners"],
+    links: ["soul","../people/benjamin-knight","../people/nicholas-marchesi","../decisions/act-core-facts","four-lanes","lcaa-method","beautiful-obsolescence","civicgraph","justicehub","empathy-ledger","civic-reflex-automation","evidence-as-by-product","civic-operating-system","../decisions/2026-05-25-civic-cerebellum-reframe","third-reality","act-ecosystem","act-studio","act-monthly-dinners"],
     content: `# A Curious Tractor (ACT)
 
 > Not a charity, not a consultancy, not an NGO. A regenerative innovation ecosystem that powers communities without owning what it builds.
@@ -4069,6 +4234,14 @@ Every ACT project, relationship, and piece of infrastructure can be tagged with 
 > "If we cannot hand it over, we are still in Curiosity."
 
 The test for any ACT project: can the community run this without us? Can they modify it? Can they export their data? If any answer is no, the work is not finished.
+
+## The Civic Operating System
+
+ACT's product work is organised as one civic operating system with three layers: [[civicgraph|CivicGraph]] sees the field (intelligence), [[justicehub|JusticeHub]] supports the work (practice), [[empathy-ledger|Empathy Ledger]] holds the trust (accountability). They share one architecture, one ethics, and one set of reflex primitives (intake, consent, triage, referral, follow-up, audit, evidence). They are not three independent products; they are three layers of one system.
+
+The AI thesis underneath is [[civic-reflex-automation|Civic Reflex Automation]]: automate the boring, amplify the art, never replace human judgment on relationships, consent, or creative direction. Impact reporting follows the [[evidence-as-by-product|Evidence as a By-Product]] principle, where reporting composes from the layers rather than running as a separate workstream.
+
+See [[civic-operating-system|the Civic Operating System concept page]] for the architecture, and the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] for the decision that established it.
 
 ## How ACT Differs from a Typical NGO
 
@@ -5574,7 +5747,7 @@ Marchesi Family Trust ─┘    │
                             ├──► Empathy Ledger v2 (project + future spinout candidate)
                             ├──► JusticeHub (project)
                             ├──► CivicGraph / Civic World Model (project)
-                            └──► ALMA (governed sensemaking process)
+                            └──► ALMA (the catalogue, evidence-graded)
 
 Nicholas Marchesi T/as A Curious Tractor (sole trader, ABN 21 591 780 066)
     Stops trading 30 June 2026
@@ -7138,14 +7311,20 @@ This thesis maps directly to ACT's methodology:
     slug: "ai-ethics",
     title: "AI Ethics & Agent Strategy",
     domain: "concepts",
-    links: ["alma","governance-consent","empathy-ledger","ai-community-engagement","transcript-analysis-method"],
+    links: ["civic-operating-system","empathy-ledger","alma","governed-proof","civic-reflex-automation","governance-consent","ai-community-engagement","transcript-analysis-method"],
     content: `# AI Ethics & Agent Strategy
 
 > The best AI output is the one that gets out of the way and lets the right voice be heard.
 
 ## Overview
 
-ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect [[alma|Accountable Listening and Meaningful Action (ALMA)]]: consent, authority, provenance, and review before action. Efficiency is never a sufficient reason to bypass these constraints.
+ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect three composed gatekeepers, each owned by a different layer of the [[civic-operating-system|civic operating system]]:
+
+- **Consent** lives in [[empathy-ledger|Empathy Ledger]] (consent state, AI-use ledger, audit trail)
+- **Cultural authority and evidence quality** live in [[alma|Australian Living Map of Alternatives (ALMA)]] scoring methodology (the six dimensions; cultural-authority verification before any score is set)
+- **Publication discipline** lives in [[governed-proof|Governed Proof]] (confidence rating, review trail, what can be shared with whom)
+
+Efficiency is never a sufficient reason to bypass any of these. This is the operational expression of the [[civic-reflex-automation|Civic Reflex Automation]] thesis: gatekeeping reflexes are automated and verifiable; the human work (cultural authority, judgment, relationship) stays human.
 
 This article covers the ethical framework, the internal agent roles, and what AI can and cannot do within ACT systems.
 
@@ -7159,18 +7338,17 @@ This article covers the ethical framework, the internal agent roles, and what AI
 | **Community authority highest weight** | Overrides efficiency in decision paths |
 | **Consent before analysis** | No opt-out model, explicit opt-in only |
 
-## AI Under ALMA Review
+## AI Under the Composed Gatekeepers
 
-ALMA is not an AI agent or a technical gatekeeper. It is the governed sensemaking process AI tools must remain subordinate to:
+ALMA is the catalogue, not the gatekeeping process. The three gates above (consent, cultural authority and evidence quality, publication discipline) are each owned by a different layer and composed at runtime. The flow:
 
 \`\`\`
 User/Community Input
         ↓
-   Governed Review
-   - Consent verified?
-   - Cultural sensitivity flagged?
-   - Authority confirmed?
-   - Provenance clear?
+   Composed Gate (at intake)
+   - Consent verified?         (Empathy Ledger)
+   - Cultural authority?       (ALMA scoring methodology)
+   - Evidence supported?       (ALMA scoring methodology)
         ↓
    AI Processing (if permitted)
         ↓
@@ -7179,8 +7357,15 @@ User/Community Input
    - Individual profiling avoided?
    - Value returned to community?
         ↓
-   Output
+   Composed Gate (at output)
+   - Publication permitted?    (Governed Proof)
+   - Confidence rating set?    (Governed Proof)
+   - Audit trail written?      (Empathy Ledger AI-use ledger)
+        ↓
+   Output (with provenance, written to audit trail)
 \`\`\`
+
+Each gate is a real check enforced by code in the relevant layer, not an aspirational principle. See [[civic-operating-system|the Civic Operating System concept page]] for how the layers compose.
 
 ## What AI Can Do
 
@@ -7240,7 +7425,7 @@ For any new AI feature:
 | Check | Required |
 |-------|----------|
 | OCAP principles respected? | Yes |
-| Accountable Listening and Meaningful Action (ALMA) respected? | Yes |
+| Australian Living Map of Alternatives (ALMA) respected? | Yes |
 | Individual profiling prevented? | Yes |
 | Sacred content hard-blocked? | Yes |
 | Community authority preserved? | Yes |
@@ -7259,9 +7444,12 @@ As AI capabilities grow, ACT maintains:
 
 ## Backlinks
 
-- [[alma|ALMA]] — governed sensemaking process AI must remain subordinate to
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture this ethics framework composes across
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis these principles operationalise (automate the boring, amplify the art, never replace judgment)
+- [[alma|ALMA]] — the catalogue layer; AI must respect its cultural authority and evidence-scoring methodology
+- [[empathy-ledger|Empathy Ledger]] — the consent + audit + AI-use ledger layer
+- [[governed-proof|Governed Proof]] — the publication gate AI outputs pass through
 - [[governance-consent|Governance & Consent]] — consent architecture AI must respect
-- [[empathy-ledger|Empathy Ledger]] — the platform where AI consent settings live
 - [[ai-community-engagement|AI Community Engagement]] — broader AI use in community contexts
 - [[transcript-analysis-method|Transcript Analysis Method]] — the concrete guardrail set for AI transcription and theme extraction`
   },
@@ -7480,36 +7668,60 @@ Allan Palm Island helps explain a recurring ACT pattern: cultural authority trav
   },
   "alma": {
     slug: "alma",
-    title: "ALMA - Accountable Listening and Meaningful Action",
+    title: "ALMA - Australian Living Map of Alternatives",
     domain: "concepts",
-    links: ["soul","lcaa-method","governed-proof","empathy-ledger","governance-consent","ai-ethics","beautiful-obsolescence","glossary","transcript-analysis-method","ways-of-working","roadmap-2026"],
-    content: `# ALMA - Accountable Listening and Meaningful Action
+    links: ["soul","../decisions/2026-05-25-civic-cerebellum-reframe","civic-operating-system","justicehub","../decisions/act-brand-alignment-map","civicgraph","empathy-ledger","governed-proof","lcaa-method","evidence-as-by-product","governance-consent","ai-ethics","beautiful-obsolescence","transcript-analysis-method","glossary"],
+    content: `# ALMA - Australian Living Map of Alternatives
 
-> Listening becomes action only when consent, authority, provenance, and review are clear.
+> The Living Map. A catalogue of community-led alternatives to detention, dependency, and extractive systems, each scored by evidence quality and cultural authority. A noun, not a verb.
 
-## One-Line Definition
+> This concept sits downstream of [[soul|Soul]]. If anything on this page contradicts soul, soul is right. It was rewritten on 2026-05-25 as part of the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe]] cleanup, after the name "Australian Living Map of Alternatives" was made canonical and the older "sensemaking process" framing was retired.
 
-Accountable Listening and Meaningful Action (ALMA) is ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.
+## What ALMA Is
+
+Australian Living Map of Alternatives (ALMA) is ACT's catalogue of community-led interventions that work, do not work, or are still being learned. Today it holds 1,112 interventions from 507 organisations across the youth justice, child protection, family services, and adjacent fields. Each intervention is scored on six dimensions and tied back to evidence, source, cultural authority, and target cohort.
+
+ALMA is **the map**. It is not a process, not a dashboard, not an AI agent. It is the curated reference that other parts of the civic operating system draw on when they need to answer "what works, and how do we know."
+
+The map lives in the database: \`alma_interventions\`, \`alma_evidence\`, \`alma_outcomes\`. The catalogue is the canonical artifact. Any concept page or pitch deck that disagrees with what is actually in those tables is wrong; the tables are right.
+
+## The Six Scoring Dimensions (the methodology)
+
+Every intervention in ALMA is scored on six dimensions. The scoring methodology is what makes the map *governed* rather than just a list.
+
+| Dimension | What it asks |
+|---|---|
+| **Evidence strength** | Is the claim sourced and reliable? What kind of evidence supports it (research, practice records, lived-experience accounts)? |
+| **Community authority** | Who has the right to speak about this? Has cultural authority been verified? |
+| **Harm risk** | What could go wrong if this is funded, replicated, or scaled? |
+| **Implementation capability** | Can this be done responsibly now, with the people and infrastructure available? |
+| **Option value** | Does adopting this open or close future possibilities? |
+| **Community value return** | Does value flow back to the people and place involved, or only outward to funders and institutions? |
+
+These six dimensions **are** ALMA's methodology. They are not external supports for some other thing called ALMA. The dimensions plus the catalogue plus the scoring records together are the Map.
 
 ## Where ALMA Sits
 
-ALMA is downstream of [[soul|Soul]] and [[lcaa-method|LCAA Method]]. It is not the soul of ACT, the founder voice, an AI personality, or a dashboard.
+The conceptual lineage, updated to match the post-reframe architecture:
 
 \`\`\`text
 Soul
-Why this exists before ACT
+  Why ACT exists
 
-LCAA
-How ACT practises: Listen, Curiosity, Action, Art
+LCAA Method
+  How ACT practises: Listen, Curiosity, Action, Art
 
 ALMA
-How listening becomes accountable action
+  The catalogue of community-led alternatives, evidence-graded and cultural-authority-verified
+
+Empathy Ledger
+  The consent infrastructure that protects the stories and storytellers feeding into evidence
 
 Governed Proof
-How action becomes evidence, review, confidence, and publication
+  The audit + review + publication layer that gates which claims from ALMA can be shared, and with what confidence
 
-Projects
-Harvest, JusticeHub, Empathy Ledger, Community Capital, CONTAINED
+JusticeHub
+  The practice layer. JusticeHub Atlas surfaces ALMA publicly; JusticeHub Practice draws on ALMA when partner orgs do the work
 \`\`\`
 
 The short version:
@@ -7517,123 +7729,93 @@ The short version:
 \`\`\`text
 Soul tells us why.
 LCAA tells us how we practise.
-ALMA tells us how listening becomes accountable action.
-Governed Proof tells us how action becomes evidence.
-Harvest shows whether any of it is real.
+ALMA holds what we have learned about what works.
+Empathy Ledger protects the consent of the people whose work and stories feed it.
+Governed Proof gates what can be published and at what confidence.
+JusticeHub is where the map gets used in the real world.
 \`\`\`
 
-## What ALMA Does
+## How ALMA Connects to the Civic Operating System
 
-ALMA helps ACT and community partners decide what can be acted on, shared, funded, reviewed, held back, handed over, or refused after listening.
+Per the [[civic-operating-system|Civic Operating System]] architecture, ALMA is the **evidence catalogue** layer that the practice and intelligence layers draw on. Specifically:
 
-It does this by asking:
+- **[[justicehub|JusticeHub]] Atlas** is the public surface where ALMA is read. The Atlas is the user-facing brand; ALMA is the data layer behind it. In external copy, prefer "JusticeHub evidence map" or "the evidence catalogue" over bare "ALMA" (see [[../decisions/act-brand-alignment-map|brand alignment map]] line 196).
+- **[[justicehub|JusticeHub]] Practice** queries ALMA when a partner organisation is doing operational work, to surface "what has worked for this cohort in this region."
+- **[[civicgraph|CivicGraph]]** holds the financial and structural context (who funds whom, who contracts with whom). When CivicGraph and ALMA are composed, the question "what works AND who actually funds it" becomes answerable.
+- **[[empathy-ledger|Empathy Ledger]]** holds the consented stories that feed evidence into ALMA. Stories do not enter ALMA without consent flowing through Empathy Ledger first.
+- **[[governed-proof|Governed Proof]]** gates publication. A claim from ALMA does not become a public statement without Governed Proof's confidence rating, review status, and audit trail attached.
 
-- What did we hear?
-- Who holds authority here?
-- What does consent allow?
-- Where did this evidence come from?
-- What action would be meaningful to the people, place, or system involved?
-- What should be reviewed, held back, handed over, or refused?
+## How the Map Gets Curated
 
-## The ALMA Movement
+ALMA is a *Living* Map for a reason: the catalogue is added to, scored, and re-reviewed continuously, not built once. The curation process draws on the [[lcaa-method|LCAA Method]]:
 
-ALMA is the bridge between listening and action.
+- **Listen** — new interventions enter the catalogue from practitioner accounts, lived-experience interviews, sector research, [[empathy-ledger|Empathy Ledger]] stories with consent, and partner-org self-reports. The intake is broad; the scoring is what filters.
+- **Curiosity** — every new entry is scored on the six dimensions by a reviewer with cultural authority appropriate to the intervention. Indigenous-led interventions are scored by Indigenous reviewers; lived-experience interventions are scored with lived-experience input.
+- **Action** — entries with sufficient confidence are surfaced through [[justicehub|JusticeHub]] Atlas, used in commissioned briefs, and quoted in sector publications. Low-confidence entries stay in the map but are flagged.
+- **Art** — the map itself is published as a public artifact (the Atlas) and as a periodic State-of-the-Field synthesis. The art is in the curation, not in concealing the work.
 
-\`\`\`text
-Listen
-  receive what is offered
-  resist the urge to arrive with a fix
+Curation is a continuous practice, not a quarterly project. The map gets re-scored when new evidence arrives or when the cultural-authority assessment of a prior entry needs updating.
 
-Meaning
-  check authority, consent, context, provenance, and consequence
-  decide whether the signal is ready for action
-
-Action
-  act, review, publish, fund, hold back, hand over, or refuse
-\`\`\`
-
-The working sentence is:
-
-> We listened. We checked who has authority. We checked what consent allows. We traced the evidence. We asked what action would be meaningful. We either acted, reviewed, held back, or handed over.
-
-That is ALMA.
-
-## What ALMA Does Not Do
+## What ALMA Is Not
 
 ALMA is not:
 
-- the Soul
-- the founder voice
-- an AI personality
-- a dashboard
-- a product brand
-- a ranking engine
-- a measurement dashboard
-- a replacement for community authority
-- a way to make extraction sound ethical
-- permission to publish without review
-- permission to make AI sovereign
-
-## Operational Records
-
-Some legacy schemas and reports use fields named \`alma_signals\`, \`ALMA score\`, or \`ALMA interventions\`. Keep those as internal record names where changing them would break data lineage.
-
-Do not let those fields redefine ALMA.
-
-The six review fields are prompts inside the governed process, not the public meaning of ALMA:
-
-| Review field | What it slows down |
-| --- | --- |
-| Evidence strength | Is the claim sourced and reliable? |
-| Community authority | Who has the right to speak or decide? |
-| Harm risk | What could go wrong if we act or share? |
-| Implementation capability | Can this be done responsibly now? |
-| Option value | Does this open or close future possibilities? |
-| Community value return | Does value flow back to the people or place involved? |
-
-These fields can support ALMA. They are not ALMA itself.
+- **A process.** ALMA is the map; the process of curating it draws on LCAA, and the process of publishing from it draws on Governed Proof. Don't conflate the noun with the verbs that act on it.
+- **An AI agent.** ALMA does not "decide" anything. Reviewers with cultural authority do the scoring. Software helps the recording, the lookups, and the visualisations.
+- **A ranking engine.** ALMA scores interventions on six dimensions; it does not produce a single "ALMA score" that ranks every intervention against every other. The dimensions are intentionally multi-axis to resist single-number ranking.
+- **A measurement dashboard.** ALMA is the catalogue; impact dashboards built on top of it are derivative outputs, not ALMA itself.
+- **The Soul.** [[soul|Soul]] is upstream. ALMA is downstream of Soul and LCAA.
+- **A replacement for community authority.** ALMA records the community authority that scored each entry; it does not substitute for that authority.
+- **A way to make extraction sound ethical.** Putting cultural-authority and evidence-confidence scores on extractive interventions does not redeem them. Low scores are honest; low scores are also a signal to stop funding the intervention.
+- **Permission to publish without review.** Publication from ALMA goes through [[governed-proof|Governed Proof]]. The map is a reference, not a publication licence.
+- **A user-facing brand.** Public copy prefers "JusticeHub evidence map" or "the evidence catalogue." ALMA is the internal name for the system behind the surface (see [[../decisions/act-brand-alignment-map|brand alignment map]]).
 
 ## First-Use Rule
 
-Always spell out the first mention:
+Always spell out the first mention on any page:
 
 \`\`\`text
-Accountable Listening and Meaningful Action (ALMA)
+Australian Living Map of Alternatives (ALMA)
 \`\`\`
 
-Do not use the acronym alone in public-facing writing unless it has already been defined on that page.
+Do not use the bare acronym in public-facing writing unless it has already been defined on that page.
 
-Bad:
+In external copy, prefer the user-facing brand:
 
 \`\`\`text
-ALMA will assess community signals and generate recommendations.
+JusticeHub evidence map (drawn from ACT's Australian Living Map of Alternatives, ALMA)
 \`\`\`
 
-Better:
+Never use the older expansion ("Accountable Listening and Meaningful Action"). That expansion was retired on 2026-05-25 because it described a process the name did not match. If you find it in any surface, fix it.
 
-\`\`\`text
-Accountable Listening and Meaningful Action (ALMA) helps ACT and community partners decide what can be acted on, shared, funded, reviewed, or held back after listening.
-\`\`\`
+## Composing ALMA into Impact Reporting
 
-Best:
+Impact reporting at ACT is not a separate system. It is what comes out when ALMA, [[empathy-ledger|Empathy Ledger]], [[civicgraph|CivicGraph]], and [[governed-proof|Governed Proof]] are composed correctly. A funder report draws on:
 
-\`\`\`text
-Accountable Listening and Meaningful Action (ALMA) is not an AI deciding for people. It is ACT's governed sensemaking process: listening first, checking consent and authority, tracing evidence, then supporting meaningful action.
-\`\`\`
+- ALMA for "which interventions are working and how confident are we"
+- Empathy Ledger for the consented stories that put faces and voices to the evidence
+- CivicGraph for the funding flows, contracts, and structural context that the interventions sit inside
+- Governed Proof for the confidence rating, the audit trail, and the publication boundaries
+
+See [[evidence-as-by-product|Evidence as a By-Product of the Work]] for the longer treatment of how reporting composes from the layers, why "evidence as a separate reporting task" is the wrong frame, and what funder/sector/internal reports look like in the composed architecture.
 
 ## Backlinks
 
-- [[soul|Soul]] - the upstream why; ALMA is downstream, never the soul
-- [[lcaa-method|LCAA Method]] - the practice loop that ALMA serves
-- [[governed-proof|Governed Proof]] - the evidence, review, and publication layer after action
-- [[empathy-ledger|Empathy Ledger]] - the story and consent infrastructure ALMA must respect
-- [[governance-consent|Governance & Consent]] - consent and authority rules ALMA depends on
-- [[ai-ethics|AI Ethics & Agent Strategy]] - AI support must remain subordinate to ALMA's consent, authority, provenance, and review checks
-- [[beautiful-obsolescence|Beautiful Obsolescence]] - handover discipline for any action ALMA supports
-- [[glossary|Glossary]] - shared language entry for ALMA across the ecosystem
-- [[transcript-analysis-method|Transcript Analysis Method]] - story analysis process that can feed ALMA review
-- [[ways-of-working|Ways of Working]] - daily rhythm for applying ALMA in planning, meetings, and review
-- [[roadmap-2026|2026 Roadmap]] - annual plan that anchors story, consent, evidence, and action`
+- [[soul|Soul]] — the upstream why
+- [[lcaa-method|LCAA Method]] — the practice loop that curates the map
+- [[empathy-ledger|Empathy Ledger]] — the consent infrastructure that feeds ALMA
+- [[governed-proof|Governed Proof]] — the audit and publication gate downstream of ALMA
+- [[justicehub|JusticeHub]] — the surface where ALMA gets used (Atlas as public read, Practice as operational draw-down)
+- [[civicgraph|CivicGraph]] — the financial and structural context ALMA composes with
+- [[civic-operating-system|Civic Operating System]] — the architecture ALMA sits inside
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how impact reporting composes from ALMA + EL + CivicGraph + Governed Proof
+- [[governance-consent|Governance & Consent]] — the consent and authority rules ALMA depends on
+- [[ai-ethics|AI Ethics]] — AI support remains subordinate to ALMA's consent, authority, evidence, and review rules
+- [[beautiful-obsolescence|Beautiful Obsolescence]] — handover discipline for the catalogue
+- [[transcript-analysis-method|Transcript Analysis Method]] — the story-analysis process that can feed ALMA review
+- [[glossary|Glossary]] — shared language entry across the ecosystem
+- [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] — the decision that prompted this rewrite
+- [[../decisions/act-brand-alignment-map|Brand Alignment Map]] — naming rules including the "JusticeHub evidence map" preference for external copy`
   },
   "alma-intervention-portfolio": {
     slug: "alma-intervention-portfolio",
@@ -9019,7 +9201,7 @@ Cars and Microcontrollers shares the *making-as-pathway* pattern with [[resoleut
     slug: "ceo-operating-model",
     title: "ACT CEO Operating Model — how to use the brain every day",
     domain: "decisions",
-    links: ["README","act-core-facts","act-brand-alignment-map","../cockpit/today","../../thoughts/shared/plans/act-brain-expansion","../../thoughts/shared/plans/act-ceo-cockpit","../../thoughts/shared/plans/act-alignment-loop","../../thoughts/shared/plans/act-entity-migration-checklist-2026-06-30"],
+    links: ["../concepts/evidence-as-by-product","README","act-core-facts","act-brand-alignment-map","../cockpit/today","../../thoughts/shared/plans/act-brain-expansion","../../thoughts/shared/plans/act-ceo-cockpit","../../thoughts/shared/plans/act-alignment-loop","../../thoughts/shared/plans/act-entity-migration-checklist-2026-06-30"],
     content: `# ACT CEO Operating Model
 
 The brain (act-core-facts + brand alignment map + cockpit + Alignment Loop) exists so you stop carrying ACT in your head. This doc is how you USE it.
@@ -9094,6 +9276,13 @@ ON ANY NEW DESIGN WORK in any ACT repo
 - **Daily action**: if a funder needs a call, do it; if a tranche due, follow up
 - **Strategic action**: Minderoo lands mid-May; pitch already in \`thoughts/shared/writing/drafts/goods-minderoo-pitch/\`
 
+### Impact reporting + Evidence
+- **Standing principle**: [[../concepts/evidence-as-by-product|Evidence as a By-Product of the Work]] — impact reporting composes from the layers (Empathy Ledger, ALMA, CivicGraph, Governed Proof). It is not a separate workstream and does not have its own team or budget line.
+- **Sources at composition time**: ALMA for "what works", Empathy Ledger for consented stories, CivicGraph for financial context, Governed Proof for confidence rating and publication boundaries.
+- **Four standing report shapes**: funder report (per bespoke EL customer) · sector report (State of Civic Money, annual flagship) · internal cockpit (this doc and the daily cockpit) · grant-application evidence bundle.
+- **What ACT stops doing**: writing "what happened" narratives from memory at quarter-end; treating reports as the deliverable; letting funder formats dictate which layer owns evidence; using ALMA as the answer to every evidence question.
+- **Action**: when a new funder asks for a report, do not start a new template. Compose from the existing layers. If the layers are missing the data, fix the layers, not the report.
+
 ### Brand + Design (any sub-brand work)
 - **Read first**: \`wiki/decisions/act-brand-alignment-map.md\`
 - **Decision tree**: data tool → CivicGraph cluster; multi-tenant storytelling → EL v2; STAY journal extension → JusticeHub; default → parent editorial (act-regenerative-studio)
@@ -9103,7 +9292,7 @@ ON ANY NEW DESIGN WORK in any ACT repo
 ### Communications + Public-facing writing
 - **Voice rules**: \`.claude/skills/act-brand-alignment/references/writing-voice.md\` (Curtis method + AI-tells blocklist)
 - **Identity**: \`.claude/skills/act-brand-alignment/references/brand-core.md\` (LCAA, voice, project narratives)
-- **Naming rules**: in act-core-facts.md (first-use Accountable Listening and Meaningful Action (ALMA); call the intervention map JusticeHub evidence; no bare "LCAA"; Indigenous place names always; no em-dashes)
+- **Naming rules**: in act-core-facts.md (first-use Australian Living Map of Alternatives (ALMA); call the intervention map JusticeHub evidence; no bare "LCAA"; Indigenous place names always; no em-dashes)
 - **Daily action**: nothing — this surfaces only when you write
 - **Whenever drafting**: load both writing-voice.md + brand-core.md before composing (every Claude session in any ACT repo already has the pointers via CLAUDE.md)
 
@@ -9277,6 +9466,295 @@ ON ANY NEW DESIGN WORK in any ACT repo
 - [[../../thoughts/shared/plans/act-ceo-cockpit|CEO cockpit plan]]
 - [[../../thoughts/shared/plans/act-alignment-loop|Alignment Loop plan]]
 - [[../../thoughts/shared/plans/act-entity-migration-checklist-2026-06-30|Cutover plan]]`
+  },
+  "civic-operating-system": {
+    slug: "civic-operating-system",
+    title: "Civic Operating System",
+    domain: "concepts",
+    links: ["soul","../decisions/2026-05-25-civic-cerebellum-reframe","civicgraph/","justicehub/","empathy-ledger/","alma","../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan","civic-reflex-automation","../decisions/2026-04-18-oonchiumpa-story-approval/","lcaa-method","governed-proof","ai-ethics","beautiful-obsolescence","four-lanes","consent-as-infrastructure","act-identity","act-ecosystem","civic-world-model"],
+    content: `# Civic Operating System
+
+> Three tools, one architecture. CivicGraph sees the field. JusticeHub supports the work. Empathy Ledger holds the trust. Together they form the civic cerebellum: the quiet reflex layer that helps communities, services, and social enterprises get the boring-but-essential work done reliably, ethically, and at scale.
+
+> This concept sits downstream of [[soul|Soul]]. If anything in this page contradicts soul, soul is right. It is established by [[../decisions/2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]] (signed off 2026-05-25).
+
+## The Premise
+
+Most AI being built for civil society is trying to become the CEO: planning, reasoning, agentic decision-making, "smarter strategy." There is real value in that work. It is not the work A Curious Tractor (ACT) is here to do.
+
+Civic and social-impact systems do not only fail because they lack strategy. They fail because the basic reflexes break down. The follow-up does not happen. The consent is not logged. The referral gets lost. The evidence is not captured. The report is written too late. The community feedback never makes it back into the system.
+
+ACT is building the **civic cerebellum**: the quiet reflex layer that helps the necessary things happen reliably. The point is not to replace human judgment. The point is to offload the boring, repetitive, essential work into trusted routines, so people can spend more time on care, relationships, strategy, and the complex decisions that AI should not make.
+
+The Civic Operating System is the name for the technical and operational architecture that makes this real across all of ACT's product work.
+
+## The Three Layers
+
+| Layer | Tool | One-line role |
+|---|---|---|
+| **Intelligence** | [[civicgraph\\|CivicGraph]] | Sees the civic field. Maps money, power, opportunities, deserts. |
+| **Practice** | [[justicehub\\|JusticeHub]] | Supports the work. Reflex layer for community-led justice and social-impact practice. |
+| **Accountability** | [[empathy-ledger\\|Empathy Ledger]] | Holds the trust. Consent, audit, AI-use ledger, human-in-the-loop, sovereignty primitives. |
+
+The three layers are designed to be used together. They are also each individually useful. A community organisation can adopt Empathy Ledger without touching CivicGraph. A foundation can subscribe to CivicGraph briefs without using JusticeHub. The architecture rewards composition without demanding it.
+
+### Intelligence — CivicGraph
+
+CivicGraph is the **intelligence sensorium** of the civic OS. It holds the dataset of who funds whom, who lobbies whom, who contracts with whom, who sits on which board, where money flows and where it does not. It produces public-good artifacts (Funding Deserts Atlas, Revolving Door Explorer, quarterly State of Civic Money, open API) and commissioned intelligence (foundation deep-dive briefs, place-based intelligence packs, procurement watchlists, dependency-risk audits).
+
+CivicGraph is **not** for sale as a vertical SaaS. It is **not** a strategic exit asset. It remains commercially active through three named flywheels: public-good legitimacy, commissioned intelligence, and ACT advisory. See [[../decisions/2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]] for the full reasoning.
+
+### Practice — JusticeHub
+
+JusticeHub has two surfaces. **JusticeHub Atlas** is the public evidence map: the [[alma|Australian Living Map of Alternatives (ALMA)]] catalogue, triangulated claims, the Centre of Excellence reading view. **JusticeHub Practice** is the operational reflex layer for partner organisations: intake, referrals, case log, co-design log, evidence bundles for funders.
+
+The Atlas tells you what works. Practice helps you do it. Practice is not a case management tool in the bureaucratic sense; it is infrastructure that supports community-led practice with reflex routines that make essential steps happen reliably.
+
+### Accountability — Empathy Ledger
+
+Empathy Ledger is the **trust layer**. It holds consent state, audit trails, AI-use ledger, human-in-the-loop checkpoints, cultural-safety enforcement, Guardian Checks against fabrication. It is the layer that makes the invisible visible: who saw what, when, with what permission, scored by what AI, reviewed by which human.
+
+Empathy Ledger's accountability primitives are exposed as an open API (\`/api/v1/accountability/*\`) so that the other layers of the civic OS, and any partner organisation outside ACT, can call them. The trust contracts that govern the civic OS are public infrastructure, not a proprietary moat.
+
+## The Shared Reflex Primitives
+
+A single reflex loop runs through all three layers. The same six primitives, named the same way, produced and consumed by every product in the civic OS.
+
+\`\`\`
+       intake  ─→  consent  ─→  triage  ─→  referral
+          ↑                                      │
+          │                                      ↓
+       evidence  ←─  audit  ←─  follow-up  ←─────┘
+\`\`\`
+
+| Primitive | What it is | Which layer typically writes it | Which layer typically reads it |
+|---|---|---|---|
+| **intake** | Capturing who is in the room, what they need, what they have agreed to | JusticeHub Practice | Empathy Ledger (consent state), CivicGraph (caseload anonymised) |
+| **consent** | Granular, revocable, culturally-graded permission to use information | Empathy Ledger | All three layers verify it before any use |
+| **triage** | Sorting and prioritising by need, risk, fit | JusticeHub Practice | CivicGraph (matched against opportunities) |
+| **referral** | A warm handoff between programs, services, or organisations | JusticeHub Practice | Empathy Ledger (logs the handoff event) |
+| **follow-up** | The reminder, the check-in, the loop that actually closes | JusticeHub Practice | Empathy Ledger (audit), CivicGraph (outcome data) |
+| **audit** | The append-only record of what happened, who decided, what AI touched it | Empathy Ledger | All three layers write to it; storytellers and orgs read from it |
+
+The loop is what most civic systems fail to complete. Intake happens; follow-up does not. Referral is logged; the audit trail is missing. Consent is captured once and then assumed forever. The civic OS exists to make each step of this loop happen reliably, with trust contracts attached, every time.
+
+## How the Layers Call Each Other
+
+The civic OS is not a marketing line. It is enforced in code by three cross-product APIs:
+
+1. **CivicGraph → Empathy Ledger.** Every public CivicGraph artifact (Funding Deserts Atlas page, Revolving Door Explorer query, API call) writes a provenance event to Empathy Ledger's accountability log. This is how CivicGraph claims are made traceable.
+2. **JusticeHub → Empathy Ledger.** Before JusticeHub surfaces a story, an evidence bundle, or a co-designed artifact, it verifies the consent token against Empathy Ledger. Consent is not assumed; it is checked at use.
+3. **JusticeHub → CivicGraph.** When a partner organisation is using JusticeHub Practice, it fetches relevant opportunities, grants, and funder intelligence from CivicGraph. Practice does not reinvent intelligence; it consumes it.
+
+The three APIs are defined in the per-codebase build prompts at [[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|the FY27 Launch Operations Plan]] §7. They are the technical proof that the civic OS exists as one system, not three products that happen to be sold together.
+
+## The Public-Good Non-Negotiable
+
+Every layer produces public-good outputs on a published cadence. Those outputs are not gated, not paywalled, not redacted for commercial customers. Commissioned customers accept this before any engagement begins.
+
+The rule cascades:
+
+- CivicGraph's Funding Deserts Atlas publishes even when foundations who pay for commissioned briefs are named as funding deserts.
+- Empathy Ledger's accountability API is open infrastructure that any organisation can call.
+- JusticeHub Atlas (the evidence map) is never sold. Commissioned work is JusticeHub Practice (operational reflex layer for partner orgs) and program evidence-bundles, not the map itself.
+
+The rule filters customers. The customers it filters out were not going to fund the work ACT exists to do. The customers it lets through fund it well and trust it more for the public commitment.
+
+See [[../decisions/2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]] §"The Public-Good Non-Negotiable Rule" for the formal statement.
+
+## Fundable Build Areas
+
+The civic OS is built and funded along five named build areas. Each one is grant-fundable on its own; together they form the architecture.
+
+1. **Civic reflex automation** — the cerebellum thesis directly. Intake, referral, follow-up, documentation, reporting, consent, risk flags. See [[civic-reflex-automation|Civic Reflex Automation]] (forthcoming) for the longer treatment.
+2. **Ethical AI infrastructure** — audit trails, consent records, human-in-the-loop checkpoints, explainability notes, risk registers, AI-use ledger. Empathy Ledger's domain.
+3. **Justice and early-intervention practice systems** — practical, co-designed workflows for youth justice, diversion, restorative approaches, social enterprise pathways, place-based support. JusticeHub Practice's domain.
+4. **Civic intelligence and opportunity mapping** — turning fragmented civic information into usable intelligence. CivicGraph's domain.
+5. **Evidence, learning, and reporting as a by-product** — every intake, workshop, referral, decision, consent process, and follow-up becomes part of a living evidence base. Cross-cutting across all three layers.
+
+## How the Civic OS Becomes Visible
+
+Three coordinated launches in 2026/27 make the civic OS visible from three different angles:
+
+| Launch | Date | The angle |
+|---|---|---|
+| **JusticeHub at the Reintegration Conference** | Week of 22 June 2026 | "The practice system for community-led justice work" |
+| **Empathy Ledger Field Trip + Africa/Europe witness work** | 29 June to 9 August 2026 | "What communities already know — and the trust layer that lets us learn from them" |
+| **CivicGraph at Philanthropy Australia** | September 2026 | "The intelligence layer that makes the rest of the civic OS funded and accountable at scale" |
+| **Empathy Ledger × [[../decisions/2026-04-18-oonchiumpa-story-approval\\|Oonchiumpa]] × Flinders University launch** | Q1 2027 | "The accountability layer proven with the most cultural-safety-demanding partner possible" |
+
+Each launch reads as one civic operating system becoming visible from a different angle. The launches compound because they share one narrative. Full operational detail at [[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|the FY27 Launch Operations Plan]].
+
+## Sibling Concepts
+
+The Civic OS sits alongside, not above, the other load-bearing ACT concepts:
+
+- [[soul|Soul]] — the why behind all of it
+- [[lcaa-method|LCAA Method]] — Listen, Curiosity, Action, Art as the operating practice
+- [[alma|Australian Living Map of Alternatives (ALMA)]] — the cultural authority and methodology layer
+- [[governed-proof|Governed Proof]] — the accountability and verification stack
+- [[ai-ethics|AI Ethics]] — the principles that constrain every AI choice in the civic OS
+- [[beautiful-obsolescence|Beautiful Obsolescence]] — the design discipline (note: applies to JusticeHub, Empathy Ledger, Goods on Country, The Harvest; CivicGraph is infrastructure-inherited, not infrastructure-obsoleted, per the [[../decisions/2026-05-25-civic-cerebellum-reframe|reframe ADR]])
+- [[four-lanes|The Four Lanes]] — how money flows through the entities supporting all of this
+- [[consent-as-infrastructure|Consent as Infrastructure]] — the principle Empathy Ledger operationalises
+
+## Cross-links to Add
+
+This concept page is new (2026-05-25). The following pages should be updated to link to it as a sibling concept once their next edit cycle comes around:
+
+- [[soul|soul.md]] — add Civic Operating System to the list of load-bearing concepts
+- [[act-identity|act-identity.md]] — reference under "How ACT Builds" or similar
+- [[act-ecosystem|act-ecosystem.md]] — name the three-layer architecture explicitly
+- [[civic-world-model|civic-world-model.md]] — needs rewriting per the [[../decisions/2026-05-25-civic-cerebellum-reframe|reframe ADR]] (drop "replacement for top-down hierarchy" framing; reframe as "intelligence sensorium feeding the civic reflex layer")`
+  },
+  "civic-reflex-automation": {
+    slug: "civic-reflex-automation",
+    title: "Civic Reflex Automation",
+    domain: "concepts",
+    links: ["soul","../operations/act-operational-thesis","../decisions/2026-05-25-civic-cerebellum-reframe","civic-operating-system","justicehub","../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan","empathy-ledger","alma","civicgraph","ai-ethics","consent-as-infrastructure","lcaa-method","beautiful-obsolescence","governed-proof"],
+    content: `# Civic Reflex Automation
+
+> AI in civic work has one job: remove the friction between intention and action. Automate the boring. Amplify the art. Never replace human judgment on relationships, consent, or creative direction.
+
+> This concept sits downstream of [[soul|Soul]]. If anything in this page contradicts soul, soul is right. It is the public-facing version of an internal thesis that ACT has been running against its own operations for two years; the internal application is documented at [[../operations/act-operational-thesis|the operational thesis]] §5. It is established as a portfolio-level concept by [[../decisions/2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]] (2026-05-25).
+
+## The Premise
+
+Most AI being built for the social sector is trying to do the most interesting work: decide, strategise, advise, "agent." That is not where civic systems usually fail. They fail because the basic reflexes break down. The follow-up does not happen. The consent is not logged. The referral gets lost. The evidence is not captured. The report is written too late. The community feedback never makes it back into the system.
+
+Civic Reflex Automation is the thesis that the highest-leverage use of AI in civil society is the **boring-but-essential** work: tagging, matching, syncing, reporting, reminding, documenting, audit-trailing. The work that humans should not have to do, that they will quietly stop doing under load, and that the system depends on happening every time.
+
+The point is not to replace human judgment. The point is to offload the repetitive, friction-heavy, easy-to-drop work into trusted routines, so people can spend more time on the work that only humans should do: care, relationships, strategy, art, and the decisions that matter.
+
+This is the cerebellum thesis. It is the load-bearing argument for the [[civic-operating-system|Civic Operating System]].
+
+## The Principle
+
+\`\`\`
+Automate: tagging, matching, syncing, reporting, compliance, reminding, auditing
+Amplify:  storytelling, design, community engagement, research, art, strategy
+Never:    replace human judgment on relationships, consent, or creative direction
+\`\`\`
+
+The matrix is short on purpose. Every product decision, every funding pitch, every feature request gets held against it. If a proposed AI capability sits in Automate, build it. If it sits in Amplify, design it carefully and keep the human in the loop. If it sits in Never, refuse it on principle even when the customer is paying.
+
+The Never row is what most AI vendors will not commit to. It is what makes Civic Reflex Automation a real thesis instead of a marketing line.
+
+## How ACT Applies This Thesis to Itself First
+
+ACT runs Civic Reflex Automation against its own operations before pitching it to anyone else. The internal application is documented at [[../operations/act-operational-thesis|the operational thesis]] §5. The short version:
+
+| System | What it automates | Human effort |
+|---|---|---|
+| Weekly reconciliation cron | Tags transactions, matches receipts, learns rules, sends Telegram summary | Glance at message |
+| Receipt matching engine | Dice-coefficient fuzzy matching across 4 receipt sources | Approve candidates |
+| Wiki CI pipeline | Push-triggered rebuild, auto-sync across 3 surfaces | Nothing |
+| Xero token sync | Detects drift across 3 token stores, auto-refreshes | Run script on auth errors |
+| Telegram bot ("Farmhand") | 19 agent tools — query projects, search wiki, draft writing | Talk to it |
+| Project tagging rules | Self-learning location/vendor/subscription rules | Approve new rules |
+| Dext + bill connectors | Auto-extract and attach receipts | Nothing |
+
+The rule: anything that two humans cannot reliably do twice a week gets automated. Anything that needs care, judgment, or relational presence does not.
+
+This is the proof-of-concept that the thesis works. The thesis is not theoretical. ACT runs on it.
+
+## The Five Fundable Build Areas
+
+Civic Reflex Automation is the umbrella thesis. Five named build areas operationalise it across the [[civic-operating-system|Civic Operating System]]. Each is grant-fundable on its own. Together they form the portfolio.
+
+### 1. Civic Reflex Automation
+
+The base layer. AI that makes the necessary work happen reliably: intake flows, referral pathways, reminders, documentation, reporting, partner updates, meeting notes, grant evidence, consent records, risk flags, follow-up loops.
+
+This is the layer that turns repetitive, necessary, high-friction civic work into trusted routines. It is the cerebellum directly.
+
+Where it lives in the civic OS: primarily [[justicehub|JusticeHub Practice]], with reflex primitives ([[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|FY27 ops plan]] §7.4) reusable across any community organisation that adopts the stack.
+
+Who funds it: justice innovation funds, place-based collaboratives, philanthropic infrastructure grants, government social services modernisation programs.
+
+### 2. Ethical AI Infrastructure
+
+The trust layer. Audit trails, consent records, human-in-the-loop checkpoints, explainability notes, risk registers, AI-use ledger, sovereignty primitives, Guardian Checks against fabrication.
+
+This is the layer that makes invisible decisions visible. It is what lets a civic organisation use AI without losing accountability, dignity, or human oversight. The biggest risk in civic AI is not bad answers; it is invisible decisions. This layer fixes that.
+
+Where it lives in the civic OS: [[empathy-ledger|Empathy Ledger]], with the accountability API exposed for sibling products and external partners ([[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|FY27 ops plan]] §7.2).
+
+Who funds it: AI safety funders, governance and transparency philanthropy, government digital responsibility programs, Indigenous data sovereignty initiatives.
+
+Funding line: *We are not building AI tools. We are building the accountability infrastructure that lets civic organisations use AI safely.*
+
+### 3. Justice and Early-Intervention Practice Systems
+
+The practice layer. Practical, co-designed workflows for youth justice, diversion, restorative approaches, social enterprise pathways, place-based support, community-led intervention.
+
+This is not software in the traditional sense. It is a repeatable practice system for community-led justice innovation. The software is the spine; the practice is the product.
+
+Where it lives in the civic OS: [[justicehub|JusticeHub]] (Atlas as the public evidence map, Practice as the operational reflex layer), powered by the [[alma|Australian Living Map of Alternatives (ALMA)]] catalogue.
+
+Who funds it: justice reform funders (Justice Reform Initiative, Paul Ramsay Foundation), state government innovation programs, community foundations, place-based justice collaboratives.
+
+### 4. Civic Intelligence and Opportunity Mapping
+
+The intelligence layer. AI that helps organisations understand what is happening across communities, policy, partners, funding, risks, and needs. Turns fragmented civic information into usable intelligence.
+
+This is the layer that gives the system situational awareness. Without it, even the best practice workflows are flying blind.
+
+Where it lives in the civic OS: [[civicgraph|CivicGraph]], with three named revenue flywheels (public-good legitimacy, commissioned intelligence, ACT advisory) per [[../decisions/2026-05-25-civic-cerebellum-reframe|the Reframe ADR]].
+
+Who funds it: research infrastructure funders (ARC, philanthropic data-for-good initiatives), peak bodies, government transparency programs, philanthropic networks who want honest mirrors held to their own sector.
+
+### 5. Evidence, Learning, and Reporting as a By-Product
+
+The cross-cutting layer. Funders do not just want activity; they want evidence. Most small organisations struggle to produce it because reporting is painful and time-consuming.
+
+This build area treats impact evidence as a **by-product of doing the work**, not a separate task. Every intake, workshop, referral, decision, consent process, and follow-up writes to the evidence base. The report at the end of the year is generated from the ledger, not re-collected from memory.
+
+Where it lives in the civic OS: cross-cutting. Reflex primitives in JusticeHub write to the audit log in Empathy Ledger; CivicGraph rolls up sector-wide data for benchmarks. The evidence-export bundle in the [[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|FY27 ops plan]] §7.4 is the user-facing surface.
+
+Who funds it: evaluation-focused funders, government outcomes-based programs, philanthropic networks tired of reading shallow narrative reports.
+
+Funding line: *Every intake, workshop, referral, decision, consent process, and follow-up becomes part of a living evidence base. Reporting stops being a tax on the work and starts being a by-product of it.*
+
+## What Civic Reflex Automation is NOT
+
+The thesis is precise on purpose. Calling out what it is not protects the work from drift:
+
+- **Not "AI agents that decide."** Civic Reflex Automation does not advocate for AI making consequential decisions about people, programs, or funding. It automates the work that should happen every time so humans have more time for the decisions that should not be automated.
+- **Not "replace caseworkers / advocates / community workers."** The point is to free those roles from admin drag, not to substitute for them. If an AI tool can do a caseworker's listening, the caseworker was never doing listening.
+- **Not "automate compassion."** Care, relational presence, cultural authority, and creative judgment sit in the Never row. They are not even candidates for automation.
+- **Not "AI optimism."** The thesis is grounded in scepticism: most AI claims in civic work are oversold, and the highest-leverage use of AI in civil society is the boring stuff, not the impressive stuff.
+
+## Who This Thesis is For
+
+Civic Reflex Automation is the argument ACT brings into rooms with:
+
+- **Foundations and philanthropic networks** weighing how to fund AI in the social sector. The thesis gives them a defensible criterion for what to fund and what to refuse.
+- **Government social services modernisation programs** under pressure to "use AI" without harming service users. The thesis gives them a category of use that is safe, useful, and measurable.
+- **Boards of community organisations** asking whether they should adopt AI. The thesis gives them a posture: yes for the boring stuff, only with consent infrastructure, never for the judgment calls.
+- **Peer organisations in the civic AI space** who have been pulled toward the agentic-CEO framing. The thesis is the counter-position.
+
+It is also the argument behind ACT's own thought leadership work: the annual flagship publication, the keynote at Philanthropy Australia, the co-authored academic whitepaper ("Civic Cerebellum vs Civic CEO"), and the founder-led witness work on the Empathy Ledger Field Trip (June to August 2026). Full operational treatment in the [[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|FY27 Launch Operations Plan]].
+
+## Sibling Concepts
+
+- [[civic-operating-system|Civic Operating System]] — the architecture that Civic Reflex Automation operationalises
+- [[soul|Soul]] — the why behind it
+- [[ai-ethics|AI Ethics]] — the constraints (especially the consent and authority rules that define the Never row)
+- [[consent-as-infrastructure|Consent as Infrastructure]] — the principle Empathy Ledger operationalises in service of this thesis
+- [[lcaa-method|LCAA Method]] — Listen, Curiosity, Action, Art as the human work this thesis protects
+- [[beautiful-obsolescence|Beautiful Obsolescence]] — the design discipline (automation that survives community handover counts; automation that requires ACT to maintain it forever does not)
+- [[governed-proof|Governed Proof]] — the verification layer that makes claims from this thesis defensible
+- [[alma|Australian Living Map of Alternatives (ALMA)]] — the cultural authority methodology that the practice layer draws on
+
+## Cross-links to Add
+
+This concept page is new (2026-05-25). The following pages should be updated to link to it on their next edit cycle:
+
+- [[soul|soul.md]] — add Civic Reflex Automation as a named load-bearing concept
+- [[ai-ethics|ai-ethics.md]] — link to this page as the operational expression of the ethics principles
+- [[../operations/act-operational-thesis|operational thesis §5]] — add a forward link noting that this page is the public-facing version of the internal thesis; the operational thesis section stays as the internal application proof
+- [[civic-operating-system|civic-operating-system.md]] — the "Fundable Build Areas" section in that file should link each build area heading to the corresponding section here once the full set of concept pages is in place`
   },
   "civic-transparency-movement": {
     slug: "civic-transparency-movement",
@@ -9456,35 +9934,51 @@ The limiting factors remain data access (not all public data is machine-readable
     slug: "civic-world-model",
     title: "Civic World Model",
     domain: "concepts",
-    links: ["third-reality","civicgraph","funding-transparency","acco-sector-analysis"],
+    links: ["civic-operating-system","soul","../decisions/2026-05-25-civic-cerebellum-reframe","alma","justicehub","civic-reflex-automation","empathy-ledger","../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan","third-reality","civicgraph","funding-transparency","acco-sector-analysis","ai-ethics"],
     content: `# Civic World Model
 
-> Replacing the "middle management" of the state and philanthropy with an interconnected intelligence layer.
+> The intelligence sensorium of the [[civic-operating-system|Civic Operating System]]. CivicGraph maps entities, capital flows, and social outcomes so practitioners, communities, journalists, and funders can act with situational awareness. It does not replace the humans in the system; it gives them the field of view they have been missing.
+
+> This concept sits downstream of [[soul|Soul]]. If anything in this page contradicts soul, soul is right. It was rewritten on 2026-05-25 per [[../decisions/2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]].
 
 ## Origin
 
-Inspired by Block's "[From Hierarchy to Intelligence](https://block.xyz/inside/from-hierarchy-to-intelligence)" thesis, which describes replacing traditional corporate hierarchies (where middle management routes information slowly) with AI-coordinated systems.
+Inspired by Block's "[From Hierarchy to Intelligence](https://block.xyz/inside/from-hierarchy-to-intelligence)" thesis, which describes the shift from routing information through slow human middle-layers to coordinating through deterministic, machine-readable models of an organisation's state.
 
-CivicGraph is building the **Civic World Model** — the social sector equivalent. Instead of relying on government bureaucrats, grant managers, and delayed annual reports to route information, CivicGraph deterministically maps entities, capital flows, and social outcomes in real time.
+CivicGraph applies the same idea to the social sector. Capital flows, contracts, donations, board interlocks, grant decisions, and procurement awards are scattered across dozens of government data systems and made legible only through delayed, narrative-shaped annual reports. CivicGraph reads those systems directly and makes the underlying state of civic Australia visible to the people who need to see it: community organisations, place-based collaboratives, journalists, researchers, ethically-minded funders, and government departments who want their own sector held to honest mirrors.
+
+The point is not to replace human judgment in grant-making or policy. The point is to make sure the humans doing that work are not flying blind.
 
 ## Four Architectural Principles (from Block)
 
-### 1. The "Honest Signal"
-Block views transaction data as the most honest signal. In social impact, traditional signals are subjective grant applications and marketing spin. CivicGraph redefines the honest signal by tracking actual money flows (procurement, donations, grants) cross-referenced with ALMA-governed evidence records.
+### 1. The Honest Signal
 
-### 2. Humans at the Edge
-The system handles intelligence and coordination. Human roles shift to the "edge" — community leaders running diversion programs, storytellers on Empathy Ledger, designers of Goods on Country. Administrative burden removed from grassroots organizations.
+Block treats transaction data as the most honest signal. In social impact, the dominant signals are subjective grant applications and marketing-shaped annual reports. CivicGraph redefines the honest signal by tracking actual money flows (procurement, donations, grants) cross-referenced with [[alma|Australian Living Map of Alternatives (ALMA)]]-governed evidence records.
+
+Honest does not mean complete. Every CivicGraph chart, brief, or atlas ships with a methodology page that names what the signal measures, what it does not measure, and how to cite or challenge it. Honesty about limits is part of the signal.
+
+### 2. Humans at the Frontline, AI at the Reflex Layer
+
+Block's principle is "humans at the edge" — meaning the people doing the actual work in communities, not the administrative middle layers. CivicGraph reads the same way: the human work stays where it always was, with community leaders running diversion programs, storytellers contributing to Empathy Ledger, designers of Goods on Country, caseworkers in [[justicehub|JusticeHub]] Practice. CivicGraph removes the administrative drag of finding the right grants, mapping the right partners, evidencing the right outcomes, so that human time goes to relationships, judgment, and the work AI should never do.
+
+This is the [[civic-reflex-automation|Civic Reflex Automation]] thesis applied to intelligence: the reflex work (sensing, mapping, linking) gets automated; the human work (deciding, relating, judging) stays human.
 
 ### 3. Capabilities vs. Interfaces
-CivicGraph is the underlying **Capability and Intelligence Layer** — the atomic data primitive. JusticeHub, Empathy Ledger, and government dashboards are **Interfaces** that surface this civic intelligence to different audiences.
 
-### 4. Building the "Company World Model"
-A machine-readable state of operations, priorities, and roadblocks in real time. CivicGraph does this for the public sector — 566,522 entities connected by 1,536,626 relationships across 254 tables and 29.5M records.
+CivicGraph is the underlying **capability and intelligence layer**: the atomic data primitive of the civic OS. [[justicehub|JusticeHub]], [[empathy-ledger|Empathy Ledger]], journalist explorers, foundation deep-dive briefs, and government dashboards are **interfaces** that surface this civic intelligence to different audiences.
+
+The same dataset feeds many surfaces. The Funding Deserts Atlas is one surface. The Revolving Door Explorer is another. A foundation deep-dive brief is a third. The Open API ([[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|FY27 ops plan]] §7.3) is the fourth, letting researchers, journalists, and partner organisations build their own.
+
+### 4. A Machine-Readable State of the Civic Sector
+
+Block's principle: a machine-readable model of an organisation's operations, priorities, and roadblocks in real time. CivicGraph applies this to the public benefit sector: 566,522 entities connected by 1,536,626 relationships across 254 tables and 29.5M records, refreshed on a published cadence, queryable by anyone with an API key.
+
+The model is descriptive, not prescriptive. It tells you what is, not what should be. What should be is a question for humans, communities, and democratic processes. CivicGraph informs that conversation; it does not arbitrate it.
 
 ## CivicGraph Platform Stats (Live)
 
 | Domain | Tables | Records |
-|--------|--------|---------|
+|---|---|---|
 | Registries | 9 | 23.5M |
 | Entity Graph | 9 | 3.4M |
 | Procurement | 12 | 1.1M |
@@ -9497,7 +9991,7 @@ A machine-readable state of operations, priorities, and roadblocks in real time.
 
 ## Entity Linkage
 
-The ABN (Australian Business Number) is the universal join key. 559K+ entities resolved from 8 government data systems using ABN matching and normalized name fuzzy-matching.
+The ABN (Australian Business Number) is the universal join key. 559K+ entities resolved from 8 government data systems using ABN matching and normalised name fuzzy-matching.
 
 Key linkage rates:
 - Justice Funding: **86%** (146K records)
@@ -9508,20 +10002,37 @@ Key linkage rates:
 
 ## Data Coverage Gaps
 
-- NSW, VIC, WA, SA, TAS, NT, ACT lack org-level funding data (only QLD has granular per-recipient grants)
-- 94,162 funding records still unclassified by topic
-- 873 LGAs identified as funding deserts
+Honest about what is missing:
+- NSW, VIC, WA, SA, TAS, NT, and ACT lack org-level funding data. Only Queensland publishes granular per-recipient grants. Every CivicGraph state-comparison artifact names this limit.
+- 94,162 funding records remain unclassified by topic. Topic tagging continues incrementally; the unclassified pool is shrinking but visible.
+- 873 LGAs identified as funding deserts in the current materialised view; the methodology page for the Funding Deserts Atlas explains how the score is computed and what it does not capture.
 
-## The Product Vision
+## Role within the Civic Operating System
 
-CivicGraph is not a data dashboard — it's a **replacement for the archaic, top-down hierarchy** of traditional grant-making and policy-creation. Transitioning social impact from bureaucratic hierarchy to decentralized, verifiable intelligence.
+CivicGraph is the **intelligence layer** of the [[civic-operating-system|Civic Operating System]], per [[../decisions/2026-05-25-civic-cerebellum-reframe|the Reframe ADR]] (2026-05-25). The other two layers are [[justicehub|JusticeHub]] (practice) and [[empathy-ledger|Empathy Ledger]] (accountability).
+
+How CivicGraph connects to the other two:
+
+- Every public CivicGraph artifact writes provenance events to **Empathy Ledger's accountability API**. This is how CivicGraph claims become traceable.
+- **JusticeHub Practice fetches opportunities, grants, and funder intelligence** from CivicGraph when partner organisations are doing live practice work. JusticeHub does not reinvent intelligence; it consumes it.
+- CivicGraph's public-good artifacts (Funding Deserts Atlas, Revolving Door Explorer, State of Civic Money) **publish openly regardless of who pays for commissioned work**. This is the public-good non-negotiable rule from the reframe ADR.
+
+## What This Page Used to Say
+
+For honest record-keeping: an earlier version of this page (pre-2026-05-25) framed CivicGraph as "a replacement for the archaic, top-down hierarchy of traditional grant-making and policy-creation" and described the work as "replacing the middle management of the state and philanthropy." That framing was retired by the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] as too close to the agentic-CEO positioning ACT explicitly rejects. The retired framing is preserved in git history.
+
+CivicGraph does not replace civic institutions or the humans inside them. It gives those humans, and the communities they serve, a field of view they did not previously have. The difference matters.
 
 ## Backlinks
 
+- [[civic-operating-system|Civic Operating System]] — the architecture this layer sits inside
+- [[civic-reflex-automation|Civic Reflex Automation]] — the thesis this layer expresses for intelligence
 - [[third-reality|The Third Reality]] — the methodology this model enables
-- [[civicgraph|CivicGraph]] — the platform
-- [[funding-transparency|Funding Transparency]] — public-money legibility problem this architecture is designed to solve
-- [[acco-sector-analysis|ACCO Sector Analysis]] — who the model serves`
+- [[civicgraph|CivicGraph]] — the platform itself
+- [[funding-transparency|Funding Transparency]] — the public-money legibility problem this architecture is designed to surface
+- [[acco-sector-analysis|ACCO Sector Analysis]] — one of the audiences the model serves
+- [[ai-ethics|AI Ethics]] — the principles that constrain how CivicGraph data is used
+- [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] — the decision that established this layer's role in the civic OS`
   },
   "civicgraph": {
     slug: "civicgraph",
@@ -13411,6 +13922,148 @@ An A2 poster with a literal keyhole die-cut. 2-colour Riso: bone cream + urgent 
 - [Claim: information asymmetry is the system](../../narrative/civicgraph/claim-information-asymmetry-is-the-system.md)
 - [[civicgraph|CivicGraph]]`
   },
+  "evidence-as-by-product": {
+    slug: "evidence-as-by-product",
+    title: "Evidence as a By-Product of the Work",
+    domain: "concepts",
+    links: ["soul","../decisions/2026-05-25-civic-cerebellum-reframe","civic-reflex-automation","empathy-ledger/","alma/","civicgraph/","justicehub/","governed-proof/","empathy-ledger","alma","governed-proof","civic-operating-system","civicgraph","justicehub","lcaa-method","consent-as-infrastructure","ai-ethics","../decisions/ceo-operating-model","../operations/act-operational-thesis"],
+    content: `# Evidence as a By-Product of the Work
+
+> Impact reporting is not a separate system. It is what composes when the existing layers do their jobs cleanly. Every intake, story, consent, referral, audit, and review writes to the evidence base. The report at the end of the quarter is generated from the ledger, not re-collected from memory.
+
+> This concept sits downstream of [[soul|Soul]]. If anything on this page contradicts soul, soul is right. It was created on 2026-05-25 to give impact reporting a canonical home after the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe]] tightened the boundaries between ALMA, Empathy Ledger, Governed Proof, and CivicGraph.
+
+## The Principle
+
+Most civic and social-impact organisations treat reporting as a separate task: the work happens, then someone writes up what happened, then the report goes to the funder. The report is a tax on the work. It draws on memory, partial notes, and selective interpretation. By the time it lands with the funder, the most useful evidence has been smoothed into narrative shape and the awkward parts have been quietly dropped.
+
+ACT operates on a different principle: **evidence is a by-product of doing the work, not a separate task that happens after it.** Every intake captures consent and cohort. Every referral writes to an audit trail. Every story enters with explicit consent scope. Every AI inference writes to a ledger. Every published claim carries a confidence rating and a review record. When the funder asks for a report, the report assembles itself from the ledger.
+
+This is the operational expression of the [[civic-reflex-automation|Civic Reflex Automation]] thesis applied to evidence. The reflex work (capturing, tagging, scoring, auditing) gets automated; the human work (interpreting, deciding, narrating, defending) stays human and gets faster because the underlying material is already structured.
+
+## Why "Evidence as Separate Reporting Task" Is the Wrong Frame
+
+Three failure modes that the separate-task frame produces:
+
+1. **The work that should happen does not happen, because the reporting cost is paid later.** Consent gets verbally implied. Cultural authority gets assumed. Outcomes get observed without being recorded. Each of these is a small saving in the moment and a large debt at reporting time.
+2. **Reports become marketing.** When evidence is reconstructed from memory at the end of a quarter, the natural pull is toward stories that make the work look good. The contrary signals (the intervention that did not work, the consent that was withdrawn, the outcome that came in worse than expected) get quietly omitted because they are harder to source and less rewarding to write.
+3. **The next round of funding decisions is made on smoothed evidence.** Funders allocate the next dollar based on the last report. If the last report dropped the contrary signals, the next round of funding doubles down on interventions that the evidence would have recommended against. Smoothed evidence is not just a cosmetic problem; it shapes where money goes.
+
+The by-product frame fixes all three. The work that should happen happens because the system writes it down as it goes. Reports cannot omit contrary signals because the signals are in the ledger. Funders can be shown the unvarnished record because the unvarnished record is what exists.
+
+## The Layers That Compose Into Reporting
+
+| Layer | What it contributes | What it does not contribute |
+|---|---|---|
+| **[[empathy-ledger\\|Empathy Ledger]]** | Consented stories, AI-use ledger, audit trail, cultural-safety enforcement, storyteller-revocable permissions | Programmatic outcome data, financial flows, sector-wide context |
+| **[[alma\\|ALMA]]** | The catalogue of community-led interventions with evidence scoring and cultural-authority verification | Specific case-level outcomes, real-time consent state, financial context |
+| **[[civicgraph\\|CivicGraph]]** | Financial flows, contract data, donations, board interlocks, funding deserts, sector-wide structural context | Storyteller voice, intervention evidence quality, cultural authority assessments |
+| **[[justicehub\\|JusticeHub]] Practice** | Intake records, referrals, follow-up loops, case logs, outcomes captured during the work | The published surfaces those records support |
+| **[[governed-proof\\|Governed Proof]]** | Confidence ratings, review status, publication boundaries, audit trails for what is shared, with whom, when | Original source data; Governed Proof is a gate over the other layers, not a source |
+
+The principle: **each layer does one thing.** When a funder, a sector publication, an internal cockpit, or a grant-application evidence bundle is needed, the report is composed from the layers, not re-collected from people's memory.
+
+## Composition Patterns
+
+The same underlying layers produce different reports depending on which slice is drawn. Four patterns ACT runs against:
+
+### Funder report (e.g. PICC, JCF, Buttery, SMART Recovery, Oonchiumpa)
+
+What the funder is asked to read: "what happened with the work you funded, with the people behind it, with what confidence, and what the evidence says you should fund next."
+
+What composes it:
+- Empathy Ledger surfaces the consented stories from the cohort
+- ALMA surfaces the interventions used and their evidence scoring
+- JusticeHub Practice surfaces the intake-to-outcome trail for the cohort
+- CivicGraph surfaces the financial context (what other funding flowed into the same place, what the dependency profile looks like)
+- Governed Proof gates which specific claims are shared with the funder under what confidence rating
+
+The report is shaped to the funder's audience and time budget; the underlying ledger is the same one that produces every other report.
+
+### Sector report (e.g. State of Civic Money quarterly, the annual flagship publication)
+
+What the sector is asked to read: "what is happening across the field, what works at scale, what is being abandoned, what the structural pattern looks like."
+
+What composes it:
+- CivicGraph drives the headline numbers (funding flows by sector, region, deserts, concentration)
+- ALMA's catalogue contributes the "what works" pattern across many interventions
+- Empathy Ledger contributes selected consented stories that put voices to the patterns (with cultural-authority sign-off per the brand alignment rules)
+- Governed Proof gates publication, ensuring named entities, foundations, and orgs are mentioned only at the confidence level the audit trail supports
+
+Sector reports follow the [[../decisions/2026-05-25-civic-cerebellum-reframe|public-good non-negotiable rule]]: they publish openly even when commissioned customers are named in unflattering positions.
+
+### Internal cockpit (CEO daily / weekly view)
+
+What ACT internal needs: "are we on mission, what is breaking, what decisions need our attention this week."
+
+What composes it:
+- JusticeHub Practice surfaces intake volume, referral throughput, follow-up loop completion rates
+- Empathy Ledger surfaces consent state, AI-use volume, Guardian Check exceptions
+- ALMA surfaces which scoring backlog has grown
+- CivicGraph surfaces grant pipeline state and funder engagement metrics
+- Governed Proof surfaces what is awaiting review and what is approaching publication
+
+The cockpit does not need new data collection. It is a live read of the existing ledgers, refreshed daily.
+
+### Grant-application evidence bundle
+
+What a grant application needs: "show that the work you are proposing has evidence behind it, consent infrastructure in place, and an honest track record of what has and has not worked."
+
+What composes it:
+- ALMA evidence of the intervention type the application proposes
+- Empathy Ledger consent infrastructure documentation
+- Past funder reports (composed using the patterns above) as proof of track record
+- Governed Proof confidence ratings on the specific claims the application is making
+
+The bundle is generated, not re-written. The first grant application takes time to design the composition; the next twenty applications draw on the same composition.
+
+## What "By-Product" Means Operationally
+
+For evidence to be a by-product rather than a separate task, four operational disciplines have to be in place at the source layers:
+
+1. **No untracked work.** Every intake, every referral, every story, every AI inference writes to the ledger at the moment it happens. The ledger is authoritative; anything not in the ledger does not count as evidence at reporting time.
+2. **Consent is captured at intake, not at publication.** [[empathy-ledger|Empathy Ledger]] enforces granular consent with cultural-safety scoring at the moment a story is recorded. Re-asking for consent at publication is a sign the original consent capture was insufficient.
+3. **Scoring is continuous, not batched.** [[alma|ALMA]] entries get scored when they enter the catalogue or when new evidence arrives, not in quarterly review sprints. A backlog of unscored entries is a debt, not a normal state.
+4. **Publication is reviewed once, audited forever.** [[governed-proof|Governed Proof]] gates the publication moment. Once a claim is published, the review record stays with it. Corrections and retractions are recorded; they do not erase the original.
+
+These disciplines are documented per layer in [[empathy-ledger|Empathy Ledger]], [[alma|ALMA]], and [[governed-proof|Governed Proof]]. This concept page is the explanation of *why* the disciplines matter together, not their individual specification.
+
+## What ACT Stops Doing
+
+Adopting this principle means actively stopping a few practices that creep into evidence work by default:
+
+- **Stop writing "what happened" narratives from memory at quarter-end.** If the work was not captured live, it does not get re-invented; the gap is reported honestly.
+- **Stop holding "impact report" as a separate workstream with its own team or budget line.** Reports compose from the layers; the budget goes into making the layers reliable.
+- **Stop treating the report as the deliverable.** The deliverable is the work. The report is a read on the work. If the report is the only place the work shows up, the work was not actually done.
+- **Stop using ALMA as the answer to every evidence question.** ALMA is the catalogue, not the funder report. Composing ALMA with the other layers produces the report; ALMA alone does not.
+- **Stop letting funder formats dictate which layer is the source of truth.** A funder asking for a particular metric does not get to decide which ACT layer owns the corresponding evidence; the architecture decides, and the composition shapes the answer to the funder's format.
+
+## Sibling Concepts
+
+- [[civic-operating-system|Civic Operating System]] — the architecture that makes this composition technically real
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis underneath the "by-product" principle
+- [[soul|Soul]] — the why
+- [[alma|ALMA]] — the catalogue layer
+- [[empathy-ledger|Empathy Ledger]] — the consent and audit layer
+- [[civicgraph|CivicGraph]] — the intelligence and financial-context layer
+- [[justicehub|JusticeHub]] — the practice layer
+- [[governed-proof|Governed Proof]] — the publication gate
+- [[lcaa-method|LCAA Method]] — the human practice the layers serve
+- [[consent-as-infrastructure|Consent as Infrastructure]] — the principle Empathy Ledger operationalises
+- [[ai-ethics|AI Ethics]] — the principles that constrain how AI is used at any layer
+
+## Cross-links to Add
+
+This concept page is new (2026-05-25). The following pages should be updated on next edit cycle to link to it:
+
+- [[soul|soul.md]] — name the evidence-as-by-product principle as a load-bearing concept
+- [[alma|alma.md]] — already links here; verify on next read
+- [[governed-proof|governed-proof.md]] — already links here; verify on next read
+- [[civic-operating-system|civic-operating-system.md]] — add as a related concept under "Fundable Build Areas" §5
+- [[civic-reflex-automation|civic-reflex-automation.md]] — already names this as build area §5; add a direct link to this page
+- [[../decisions/ceo-operating-model|ceo-operating-model.md]] — should reference this principle as the standing answer to "how do we do reporting"
+- [[../operations/act-operational-thesis|act-operational-thesis.md]] — should reference this principle as the answer to "how does the studio's evidence work compose"`
+  },
   "facilitation": {
     slug: "facilitation",
     title: "Facilitation for your team",
@@ -16133,7 +16786,7 @@ Ben wants to visit all these places to build direct relationships. Priority cont
     slug: "glossary",
     title: "Glossary",
     domain: "concepts",
-    links: ["beautiful-obsolescence","lcaa-method","alma","consent-as-infrastructure","justicehub","goods-on-country","voice-guide","governed-proof","custodian-economy"],
+    links: ["beautiful-obsolescence","lcaa-method","alma","civicgraph","justicehub","empathy-ledger","civic-operating-system","civic-reflex-automation","evidence-as-by-product","consent-as-infrastructure","goods-on-country","voice-guide","governed-proof","custodian-economy"],
     content: `# Glossary
 
 > Terms and concepts used across ACT. This is a living document — update as language evolves.
@@ -16158,8 +16811,17 @@ ACT's methodology for ethical innovation:
 
 See [[lcaa-method|LCAA Method]].
 
-### Accountable Listening and Meaningful Action (ALMA)
-ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review. ALMA is not the Soul, an AI personality, a dashboard, or a ranking engine. See [[alma|ALMA]].
+### Australian Living Map of Alternatives (ALMA)
+ACT's catalogue of community-led interventions that work, scored on six dimensions (evidence strength, community authority, harm risk, implementation capability, option value, community value return). The catalogue lives in the \`alma_interventions\`, \`alma_evidence\`, and \`alma_outcomes\` database tables. ALMA is the map, not a process, not an AI agent, not a ranking engine. See [[alma|ALMA]].
+
+### Civic Operating System
+The three-layer architecture for ACT's product work: [[civicgraph|CivicGraph]] (intelligence, sees the field), [[justicehub|JusticeHub]] (practice, supports the work), [[empathy-ledger|Empathy Ledger]] (accountability, holds the trust). The three call each other in code. See [[civic-operating-system|Civic Operating System]].
+
+### Civic Reflex Automation
+ACT's AI thesis: automate the boring (tagging, matching, syncing, reporting, reminders, audits), amplify the art (storytelling, design, engagement), never replace human judgment on relationships, consent, or creative direction. See [[civic-reflex-automation|Civic Reflex Automation]].
+
+### Evidence as a By-Product of the Work
+The principle that impact reporting composes from the existing layers (Empathy Ledger, ALMA, CivicGraph, Governed Proof) rather than running as a separate reporting workstream. Every intake, story, consent, referral, audit, and review writes to the evidence base; the report at the end of the quarter is generated from the ledger, not re-collected from memory. See [[evidence-as-by-product|Evidence as a By-Product of the Work]].
 
 ### Power Take-Off (PTO)
 A tractor mechanism that transfers engine power to implements. ACT's founding metaphor: we provide power that communities direct, not the other way around.
@@ -16220,14 +16882,14 @@ Standardized \`/api/registry\` endpoint exposed by each project. Enables ecosyst
 
 ---
 
-## ALMA Review Fields
+## ALMA Scoring Dimensions
 
-Some legacy schemas use \`alma_signals\` fields. Treat these as review prompts inside [[alma|ALMA]], not as the public definition of ALMA.
+The six dimensions every intervention in [[alma|ALMA]] is scored on. These dimensions **are** ALMA's methodology, not external supports for some other thing called ALMA. The catalogue plus the dimensions plus the scoring records together are the Map.
 
-| Review Field | What It Checks |
+| Scoring Dimension | What It Checks |
 |--------|-----------------|
 | Evidence Strength | Is the claim sourced and reliable? |
-| Community Authority | Who holds authority? Is consent in place? |
+| Community Authority | Who holds authority? Has cultural authority been verified? |
 | Harm Risk | What could go wrong if this is acted on or shared? |
 | Implementation Capability | Can this be acted on responsibly now? |
 | Option Value | Does this open or close future possibilities? |
@@ -16304,7 +16966,7 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 | Acronym | Meaning |
 |---------|---------|
 | ACT | A Curious Tractor |
-| ALMA | Accountable Listening and Meaningful Action |
+| ALMA | Australian Living Map of Alternatives |
 | BCV | Black Cockatoo Valley |
 | CSA | Community Supported Agriculture |
 | GHL | GoHighLevel (CRM platform) |
@@ -16322,7 +16984,10 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 ## Backlinks
 
 - [[lcaa-method|LCAA Method]] — core methodology
-- [[alma|ALMA]] — governed listening-to-action process
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture for ACT's product work
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis underneath the civic OS
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — the impact reporting principle
+- [[alma|ALMA]] — the catalogue of community-led alternatives, evidence-graded with cultural authority
 - [[governed-proof|Governed Proof]] — evidence, review, confidence, publication, and audit trail
 - [[consent-as-infrastructure|Consent as Infrastructure]] — OCAP architecture
 - [[beautiful-obsolescence|Beautiful Obsolescence]] — handover design principle
@@ -16869,16 +17534,18 @@ Every project should be able to answer:
     slug: "governed-proof",
     title: "Governed Proof",
     domain: "concepts",
-    links: ["alma","soul","ways-of-working","governance-consent","consent-as-infrastructure","empathy-ledger","justicehub","transcript-analysis-method","vignette-workflows"],
+    links: ["alma","soul","evidence-as-by-product","civic-operating-system","ways-of-working","governance-consent","consent-as-infrastructure","empathy-ledger","justicehub","transcript-analysis-method","vignette-workflows"],
     content: `# Governed Proof
 
 > Proof is not what ACT says happened. Proof is what can be traced, reviewed, shared, and challenged without bypassing consent or authority.
 
 ## Definition
 
-Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits after [[alma|Accountable Listening and Meaningful Action (ALMA)]].
+Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits alongside [[alma|Australian Living Map of Alternatives (ALMA)]] (the catalogue of what works) and downstream of the practice (LCAA, Empathy Ledger, JusticeHub).
 
-ALMA helps decide whether listening can become action. Governed Proof records what happened next, what supports it, who reviewed it, what confidence it carries, and what can be shared.
+ALMA holds the evidence-graded catalogue. Governed Proof gates which claims drawn from ALMA, or from any other ACT source, can be published, with what confidence, to what audience, and under what review trail.
+
+Together they answer two different questions. ALMA: "what do we know about what works?" Governed Proof: "what are we ready to say in public, and how do we stand behind it?"
 
 ## Where It Sits
 
@@ -16912,15 +17579,17 @@ Governed Proof does not replace consent, community authority, Elder review, or r
 
 ## Backlinks
 
-- [[alma|ALMA]] - the listening-to-action process upstream of governed proof
-- [[soul|Soul]] - upstream why; governed proof is downstream, not the source of meaning
-- [[ways-of-working|Ways of Working]] - daily operational rhythm that applies review and publication discipline
-- [[governance-consent|Governance & Consent]] - consent and authority model
-- [[consent-as-infrastructure|Consent as Infrastructure]] - technical architecture for consent
-- [[empathy-ledger|Empathy Ledger]] - source of consented story records
-- [[justicehub|JusticeHub]] - public evidence and action surface
-- [[transcript-analysis-method|Transcript Analysis Method]] - pipeline that creates reviewable story evidence
-- [[vignette-workflows|Vignette Workflows]] - story evidence workflow`
+- [[alma|ALMA]] — the evidence catalogue this layer composes with for publication
+- [[soul|Soul]] — upstream why; governed proof is downstream, not the source of meaning
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how Governed Proof composes with ALMA, Empathy Ledger, and CivicGraph to produce impact reports
+- [[civic-operating-system|Civic Operating System]] — the architecture this layer sits inside
+- [[ways-of-working|Ways of Working]] — daily operational rhythm that applies review and publication discipline
+- [[governance-consent|Governance & Consent]] — consent and authority model
+- [[consent-as-infrastructure|Consent as Infrastructure]] — technical architecture for consent
+- [[empathy-ledger|Empathy Ledger]] — source of consented story records
+- [[justicehub|JusticeHub]] — practice and public-evidence surface
+- [[transcript-analysis-method|Transcript Analysis Method]] — pipeline that creates reviewable story evidence
+- [[vignette-workflows|Vignette Workflows]] — story evidence workflow`
   },
   "grantscope": {
     slug: "grantscope",
@@ -19998,7 +20667,7 @@ JusticeHub needs **$500K** to scale nationally.
 
 ## ALMA-Governed Evidence Records
 
-The "what works" layer sitting on top of funding data, governed by [[alma|Accountable Listening and Meaningful Action (ALMA)]]:
+The "what works" layer sitting on top of funding data, governed by [[alma|Australian Living Map of Alternatives (ALMA)]]:
 - Evidence-based interventions mapped by topic and geography
 - 9 topic domains: child-protection, community-led, diversion, family-services, indigenous, legal-services, ndis, prevention, youth-justice
 - Cross-referenced with CivicGraph entity graph (56% linkage rate)
@@ -20471,7 +21140,7 @@ The broader Oonchiumpa participant and storyteller layer should still live mostl
     slug: "lcaa-method",
     title: "LCAA Method",
     domain: "concepts",
-    links: ["soul","act-identity","goods-on-country","beautiful-obsolescence","gold-phone","the-confessional","treacher","uncle-allan-palm-island-art","alma","bg-fit","benjamin-knight","nicholas-marchesi","richard-cassidy","shaun-fisher","the-harvest","four-lanes","empathy-ledger","civicgraph","picc","third-reality","governed-proof","ai-community-engagement","place-land-practice","ways-of-working","voice-guide","visual-system","roadmap-2026","y1-release-program","regional-arts-fellowship","fishers-oysters"],
+    links: ["soul","act-identity","goods-on-country","beautiful-obsolescence","gold-phone","the-confessional","treacher","uncle-allan-palm-island-art","alma","bg-fit","benjamin-knight","nicholas-marchesi","richard-cassidy","shaun-fisher","the-harvest","four-lanes","empathy-ledger","civicgraph","picc","third-reality","governed-proof","civic-operating-system","civic-reflex-automation","evidence-as-by-product","ai-community-engagement","place-land-practice","ways-of-working","voice-guide","visual-system","roadmap-2026","y1-release-program","regional-arts-fellowship","fishers-oysters"],
     content: `# LCAA Method
 
 > Listen. Curiosity. Action. Art.
@@ -20635,8 +21304,11 @@ Every project, every piece of art, every community relationship can be tagged wi
 - [[civicgraph|CivicGraph]]: Curiosity
 - [[picc|PICC]]: spans all four phases
 - [[third-reality|The Third Reality]]: the synthesis LCAA produces
-- [[alma|ALMA]]: governed sensemaking process that turns listening into accountable action
+- [[alma|ALMA]]: the catalogue of community-led alternatives, evidence-graded with cultural authority; what gets curated through LCAA's Curiosity phase
 - [[governed-proof|Governed Proof]]: evidence and review layer after action
+- [[civic-operating-system|Civic Operating System]]: the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) that operationalises LCAA at the product level
+- [[civic-reflex-automation|Civic Reflex Automation]]: the AI thesis that protects LCAA's human work by automating only the boring reflex tasks
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]]: how impact reporting composes from LCAA's outputs without becoming a separate task
 - [[ai-community-engagement|AI and Community Engagement]]: administrative compression that protects time for relational work
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the Action phase discipline
 - [[place-land-practice|Place & Land Practice]]: Country and land practice as the pace-setting context for the whole method
@@ -28014,7 +28686,7 @@ This is a seasonal map, not a fixed plan. ACT chooses readiness over deadlines a
 | Finalise compendium and align project language to core model | In Progress |
 | Stabilise Harvest operations and maker pathways in Witta | In Progress |
 | Confirm Goods production readiness and support pathways | Planning |
-| Align AI agent guardrails to Accountable Listening and Meaningful Action (ALMA) and Empathy Ledger | Complete |
+| Align AI agent guardrails to Australian Living Map of Alternatives (ALMA) and Empathy Ledger | Complete |
 | JusticeHub vision and path to externalise | Planning |
 | ACT regular communication (1-to-some and 1-to-many via GHL) | In Progress |
 
@@ -28985,7 +29657,7 @@ The spreadsheet's \`notes\` column flags every \`REVIEW\` line; the goal is REVI
     slug: "soul",
     title: "Soul",
     domain: "concepts",
-    links: ["alma","../people/benjamin-knight","../people/nicholas-marchesi","act-identity","lcaa-method","governed-proof","four-lanes","beautiful-obsolescence"],
+    links: ["civic-operating-system","civicgraph","justicehub","empathy-ledger","civic-reflex-automation","alma","governed-proof","evidence-as-by-product","../people/benjamin-knight","../people/nicholas-marchesi","act-identity","lcaa-method","four-lanes","beautiful-obsolescence"],
     content: `# Soul
 
 > Two humans, one tractor. This is why we do it.
@@ -29056,13 +29728,13 @@ Identity, method, the four lanes, the entity structure: all downstream. They are
 
 When in doubt about anything else in the wiki or the website, return here first. If the answer doesn't sit on top of what is in this file, the answer is wrong.
 
-## Relationship to ALMA
+## Relationship to the Downstream Architecture
 
-Soul is why ACT exists.
+Soul is why ACT exists. Everything else is how the soul gets delivered without losing itself.
 
-ALMA is not the soul.
+ACT's product work runs on a [[civic-operating-system|civic operating system]] with three layers: [[civicgraph|CivicGraph]] (intelligence — sees the field), [[justicehub|JusticeHub]] (practice — supports the work), [[empathy-ledger|Empathy Ledger]] (accountability — holds the trust). The [[civic-reflex-automation|Civic Reflex Automation]] thesis says these layers exist to handle the boring-but-essential work reliably so humans stay free for relationships, judgment, and art. [[alma|Australian Living Map of Alternatives (ALMA)]] is the catalogue of what works that the practice layer draws on. [[governed-proof|Governed Proof]] gates what can be published from any of it. [[evidence-as-by-product|Evidence as a By-Product of the Work]] is how impact reporting composes from the layers without becoming a separate workstream.
 
-[[alma|Accountable Listening and Meaningful Action (ALMA)]] is one downstream process that helps ACT move from listening to responsible action without bypassing consent, authority, provenance, or human and community review.
+None of these is the soul. They are how the soul stays operational without being eaten by drift.
 
 ---
 
@@ -29072,8 +29744,11 @@ ALMA is not the soul.
 - [[../people/nicholas-marchesi|Nicholas Marchesi OAM]]: co-founder, place and hospitality
 - [[act-identity|ACT Identity]]: the org built on top of this soul
 - [[lcaa-method|LCAA Method]]: the externalised practice loop
-- [[alma|ALMA]]: downstream governed process for moving from listening to accountable action
-- [[governed-proof|Governed Proof]]: evidence, review, and publication layer after action
+- [[civic-operating-system|Civic Operating System]]: the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) downstream of soul
+- [[civic-reflex-automation|Civic Reflex Automation]]: the AI thesis — automate the boring, amplify the art, never replace judgment
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]]: how impact reporting composes from the layers
+- [[alma|ALMA]]: the catalogue of community-led alternatives, evidence-graded with cultural authority
+- [[governed-proof|Governed Proof]]: evidence, review, and publication layer
 - [[four-lanes|The Four Lanes]]: the body the soul lives in, the economy that sustains the work and the founders
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the discipline that lets the soul outlive the org`
   },
@@ -34446,7 +35121,7 @@ This method is the answer.
     links: ["alma","governed-proof","vignette-workflows","governance-consent","act-architecture","transcript-analysis-method"],
     content: `# Descript Transcription & ALMA Review Workflow
 
-> How transcribed stories move from Descript into Empathy Ledger and through Accountable Listening and Meaningful Action review.
+> How transcribed stories move from Descript into Empathy Ledger and through Australian Living Map of Alternatives review.
 
 ## Overview
 
@@ -35021,6 +35696,261 @@ _To consume this audit programmatically, read \`url-audit-latest.json\` in this 
     domain: "decisions",
     links: ["act-infrastructure","act-monthly-dinners","barkly-backbone","bg-fit","black-cockatoo-valley","campfire","caring-for-those-who-care","civicgraph","community-capital","confit-pathways","contained","custodian-first-economy","dad-lab-25","deadlylabs","designing-for-obsolescence","diagrama","empathy-ledger","feel-good-project","fishers-oysters","global-laundry-alliance","goods","grantscope","junes-patch","marriage-celebrant","mounty-yarns","oonchiumpa","place-based-policy-lab","quandamooka-justice-strategy","resoleution","tomnet"],
     content: `# URL Audit — 2026-05-17
+
+> Generated by \`scripts/wiki-verify-urls.mjs\`. Cross-references every wiki project article against the canonical \`Acurioustractor\` GitHub org and Benjamin Knight's Vercel team.
+
+## Summary
+
+| Metric | Count |
+|---|---|
+| Total project articles | 30 |
+| Live URL (HTTP 2xx) | 8 |
+| Dead URL (4xx/5xx/timeout) | 0 |
+| No URL configured | 22 |
+| No GitHub repo matched | 20 |
+
+## Article Audit
+
+| Article | GitHub Repo | Vercel Project | Canonical URL | Live |
+|---|---|---|---|---|
+| [[act-infrastructure]] | — | — | — | · |
+| [[act-monthly-dinners]] | — | — | — | · |
+| [[barkly-backbone]] | [barkly-research-platform](https://github.com/Acurioustractor/barkly-research-platform) | \`barkly-research-platform\` | — | · |
+| [[bg-fit]] | — | — | — | · |
+| [[black-cockatoo-valley]] | — | — | — | · |
+| [[campfire]] | [Campfire-Website](https://github.com/Acurioustractor/Campfire-Website) | \`campfire-website\` | [link](https://campfire-website-amber.vercel.app) | ✓ 200 |
+| [[caring-for-those-who-care]] | — | — | — | · |
+| [[civicgraph]] | — | — | [link](https://civicgraph.app) | ✓ 200 |
+| [[community-capital]] | — | — | — | · |
+| [[confit-pathways]] | — | — | — | · |
+| [[contained]] | [contained-campaign-site](https://github.com/Acurioustractor/contained-campaign-site) | — | — | · |
+| [[custodian-first-economy]] | — | — | — | · |
+| [[dad-lab-25]] | — | — | — | · |
+| [[deadlylabs]] | — | — | — | · |
+| [[designing-for-obsolescence]] | — | — | — | · |
+| [[diagrama]] | [diagrama-australia](https://github.com/Acurioustractor/diagrama-australia) | \`diagrama-australia\` | — | · |
+| [[empathy-ledger]] | [empathy-ledger-v2](https://github.com/Acurioustractor/empathy-ledger-v2) | \`empathy-ledger-v2\` | [link](https://empathy-ledger-v2.vercel.app) | ✓ 200 |
+| [[feel-good-project]] | — | — | — | · |
+| [[fishers-oysters]] | [fishers-oysters](https://github.com/Acurioustractor/fishers-oysters) | \`fishers-oysters\` | [link](https://fishers-oysters.vercel.app) | ✓ 200 |
+| [[global-laundry-alliance]] | — | — | — | · |
+| [[goods]] | [goods-asset-tracker](https://github.com/Acurioustractor/goods-asset-tracker) | — | [link](https://v2-rho-ochre.vercel.app) | ✓ 200 |
+| [[grantscope]] | [grantscope](https://github.com/Acurioustractor/grantscope) | \`grantscope\` | [link](https://grantscope.vercel.app) | ✓ 200 |
+| [[junes-patch]] | — | — | — | · |
+| [[marriage-celebrant]] | — | — | — | · |
+| [[mounty-yarns]] | [mounty-yarns](https://github.com/Acurioustractor/mounty-yarns) | — | [link](https://mounty-yarns.vercel.app) | ✓ 200 |
+| [[oonchiumpa]] | [Oonchiumpa](https://github.com/Acurioustractor/Oonchiumpa) | — | [link](https://oonchiumpa.vercel.app) | ✓ 200 |
+| [[place-based-policy-lab]] | — | — | — | · |
+| [[quandamooka-justice-strategy]] | — | — | — | · |
+| [[resoleution]] | — | — | — | · |
+| [[tomnet]] | — | — | — | · |
+
+## Articles missing a repo
+
+- [[act-infrastructure]]
+- [[act-monthly-dinners]]
+- [[bg-fit]]
+- [[black-cockatoo-valley]]
+- [[caring-for-those-who-care]]
+- [[civicgraph]]
+- [[community-capital]]
+- [[confit-pathways]]
+- [[custodian-first-economy]]
+- [[dad-lab-25]]
+- [[deadlylabs]]
+- [[designing-for-obsolescence]]
+- [[feel-good-project]]
+- [[global-laundry-alliance]]
+- [[junes-patch]]
+- [[marriage-celebrant]]
+- [[place-based-policy-lab]]
+- [[quandamooka-justice-strategy]]
+- [[resoleution]]
+- [[tomnet]]
+
+## Articles with dead URLs
+
+_(none)_
+
+---
+
+_To consume this audit programmatically, read \`url-audit-latest.json\` in this directory. The wiki viewer (\`tools/act-wikipedia.html\`) reads it via the regen script (\`scripts/wiki-build-viewer.mjs\`) to render the Website / Repo / Deploy badges in each project infobox._`
+  },
+  "url-audit-2026-05-20": {
+    slug: "url-audit-2026-05-20",
+    title: "URL Audit 2026-05-20",
+    domain: "decisions",
+    links: ["act-infrastructure","act-monthly-dinners","barkly-backbone","bg-fit","black-cockatoo-valley","campfire","caring-for-those-who-care","civicgraph","community-capital","confit-pathways","contained","custodian-first-economy","dad-lab-25","deadlylabs","designing-for-obsolescence","diagrama","empathy-ledger","feel-good-project","fishers-oysters","global-laundry-alliance","goods","grantscope","junes-patch","marriage-celebrant","mounty-yarns","oonchiumpa","place-based-policy-lab","quandamooka-justice-strategy","resoleution","tomnet"],
+    content: `# URL Audit — 2026-05-20
+
+> Generated by \`scripts/wiki-verify-urls.mjs\`. Cross-references every wiki project article against the canonical \`Acurioustractor\` GitHub org and Benjamin Knight's Vercel team.
+
+## Summary
+
+| Metric | Count |
+|---|---|
+| Total project articles | 30 |
+| Live URL (HTTP 2xx) | 8 |
+| Dead URL (4xx/5xx/timeout) | 0 |
+| No URL configured | 22 |
+| No GitHub repo matched | 20 |
+
+## Article Audit
+
+| Article | GitHub Repo | Vercel Project | Canonical URL | Live |
+|---|---|---|---|---|
+| [[act-infrastructure]] | — | — | — | · |
+| [[act-monthly-dinners]] | — | — | — | · |
+| [[barkly-backbone]] | [barkly-research-platform](https://github.com/Acurioustractor/barkly-research-platform) | \`barkly-research-platform\` | — | · |
+| [[bg-fit]] | — | — | — | · |
+| [[black-cockatoo-valley]] | — | — | — | · |
+| [[campfire]] | [Campfire-Website](https://github.com/Acurioustractor/Campfire-Website) | \`campfire-website\` | [link](https://campfire-website-amber.vercel.app) | ✓ 200 |
+| [[caring-for-those-who-care]] | — | — | — | · |
+| [[civicgraph]] | — | — | [link](https://civicgraph.app) | ✓ 200 |
+| [[community-capital]] | — | — | — | · |
+| [[confit-pathways]] | — | — | — | · |
+| [[contained]] | [contained-campaign-site](https://github.com/Acurioustractor/contained-campaign-site) | — | — | · |
+| [[custodian-first-economy]] | — | — | — | · |
+| [[dad-lab-25]] | — | — | — | · |
+| [[deadlylabs]] | — | — | — | · |
+| [[designing-for-obsolescence]] | — | — | — | · |
+| [[diagrama]] | [diagrama-australia](https://github.com/Acurioustractor/diagrama-australia) | \`diagrama-australia\` | — | · |
+| [[empathy-ledger]] | [empathy-ledger-v2](https://github.com/Acurioustractor/empathy-ledger-v2) | \`empathy-ledger-v2\` | [link](https://empathy-ledger-v2.vercel.app) | ✓ 200 |
+| [[feel-good-project]] | — | — | — | · |
+| [[fishers-oysters]] | [fishers-oysters](https://github.com/Acurioustractor/fishers-oysters) | \`fishers-oysters\` | [link](https://fishers-oysters.vercel.app) | ✓ 200 |
+| [[global-laundry-alliance]] | — | — | — | · |
+| [[goods]] | [goods-asset-tracker](https://github.com/Acurioustractor/goods-asset-tracker) | — | [link](https://v2-rho-ochre.vercel.app) | ✓ 200 |
+| [[grantscope]] | [grantscope](https://github.com/Acurioustractor/grantscope) | \`grantscope\` | [link](https://grantscope.vercel.app) | ✓ 200 |
+| [[junes-patch]] | — | — | — | · |
+| [[marriage-celebrant]] | — | — | — | · |
+| [[mounty-yarns]] | [mounty-yarns](https://github.com/Acurioustractor/mounty-yarns) | — | [link](https://mounty-yarns.vercel.app) | ✓ 200 |
+| [[oonchiumpa]] | [Oonchiumpa](https://github.com/Acurioustractor/Oonchiumpa) | — | [link](https://oonchiumpa.vercel.app) | ✓ 200 |
+| [[place-based-policy-lab]] | — | — | — | · |
+| [[quandamooka-justice-strategy]] | — | — | — | · |
+| [[resoleution]] | — | — | — | · |
+| [[tomnet]] | — | — | — | · |
+
+## Articles missing a repo
+
+- [[act-infrastructure]]
+- [[act-monthly-dinners]]
+- [[bg-fit]]
+- [[black-cockatoo-valley]]
+- [[caring-for-those-who-care]]
+- [[civicgraph]]
+- [[community-capital]]
+- [[confit-pathways]]
+- [[custodian-first-economy]]
+- [[dad-lab-25]]
+- [[deadlylabs]]
+- [[designing-for-obsolescence]]
+- [[feel-good-project]]
+- [[global-laundry-alliance]]
+- [[junes-patch]]
+- [[marriage-celebrant]]
+- [[place-based-policy-lab]]
+- [[quandamooka-justice-strategy]]
+- [[resoleution]]
+- [[tomnet]]
+
+## Articles with dead URLs
+
+_(none)_
+
+---
+
+_To consume this audit programmatically, read \`url-audit-latest.json\` in this directory. The wiki viewer (\`tools/act-wikipedia.html\`) reads it via the regen script (\`scripts/wiki-build-viewer.mjs\`) to render the Website / Repo / Deploy badges in each project infobox._`
+  },
+  "url-audit-2026-05-23": {
+    slug: "url-audit-2026-05-23",
+    title: "URL Audit 2026-05-23",
+    domain: "decisions",
+    links: ["act-infrastructure","act-monthly-dinners","barkly-backbone","bg-fit","black-cockatoo-valley","campfire","caring-for-those-who-care","civicgraph","community-capital","confit-pathways","contained","custodian-first-economy","dad-lab-25","deadlylabs","designing-for-obsolescence","diagrama","empathy-ledger","feel-good-project","fishers-oysters","global-laundry-alliance","goods","grantscope","junes-patch","marriage-celebrant","mounty-yarns","oonchiumpa","place-based-policy-lab","quandamooka-justice-strategy","resoleution","tomnet"],
+    content: `# URL Audit — 2026-05-23
+
+> Generated by \`scripts/wiki-verify-urls.mjs\`. Cross-references every wiki project article against the canonical \`Acurioustractor\` GitHub org and Benjamin Knight's Vercel team.
+
+## Summary
+
+| Metric | Count |
+|---|---|
+| Total project articles | 30 |
+| Live URL (HTTP 2xx) | 8 |
+| Dead URL (4xx/5xx/timeout) | 0 |
+| No URL configured | 22 |
+| No GitHub repo matched | 20 |
+
+## Article Audit
+
+| Article | GitHub Repo | Vercel Project | Canonical URL | Live |
+|---|---|---|---|---|
+| [[act-infrastructure]] | — | — | — | · |
+| [[act-monthly-dinners]] | — | — | — | · |
+| [[barkly-backbone]] | [barkly-research-platform](https://github.com/Acurioustractor/barkly-research-platform) | \`barkly-research-platform\` | — | · |
+| [[bg-fit]] | — | — | — | · |
+| [[black-cockatoo-valley]] | — | — | — | · |
+| [[campfire]] | [Campfire-Website](https://github.com/Acurioustractor/Campfire-Website) | \`campfire-website\` | [link](https://campfire-website-amber.vercel.app) | ✓ 200 |
+| [[caring-for-those-who-care]] | — | — | — | · |
+| [[civicgraph]] | — | — | [link](https://civicgraph.app) | ✓ 200 |
+| [[community-capital]] | — | — | — | · |
+| [[confit-pathways]] | — | — | — | · |
+| [[contained]] | [contained-campaign-site](https://github.com/Acurioustractor/contained-campaign-site) | — | — | · |
+| [[custodian-first-economy]] | — | — | — | · |
+| [[dad-lab-25]] | — | — | — | · |
+| [[deadlylabs]] | — | — | — | · |
+| [[designing-for-obsolescence]] | — | — | — | · |
+| [[diagrama]] | [diagrama-australia](https://github.com/Acurioustractor/diagrama-australia) | \`diagrama-australia\` | — | · |
+| [[empathy-ledger]] | [empathy-ledger-v2](https://github.com/Acurioustractor/empathy-ledger-v2) | \`empathy-ledger-v2\` | [link](https://empathy-ledger-v2.vercel.app) | ✓ 200 |
+| [[feel-good-project]] | — | — | — | · |
+| [[fishers-oysters]] | [fishers-oysters](https://github.com/Acurioustractor/fishers-oysters) | \`fishers-oysters\` | [link](https://fishers-oysters.vercel.app) | ✓ 200 |
+| [[global-laundry-alliance]] | — | — | — | · |
+| [[goods]] | [goods-asset-tracker](https://github.com/Acurioustractor/goods-asset-tracker) | — | [link](https://v2-rho-ochre.vercel.app) | ✓ 200 |
+| [[grantscope]] | [grantscope](https://github.com/Acurioustractor/grantscope) | \`grantscope\` | [link](https://grantscope.vercel.app) | ✓ 200 |
+| [[junes-patch]] | — | — | — | · |
+| [[marriage-celebrant]] | — | — | — | · |
+| [[mounty-yarns]] | [mounty-yarns](https://github.com/Acurioustractor/mounty-yarns) | — | [link](https://mounty-yarns.vercel.app) | ✓ 200 |
+| [[oonchiumpa]] | [Oonchiumpa](https://github.com/Acurioustractor/Oonchiumpa) | — | [link](https://oonchiumpa.vercel.app) | ✓ 200 |
+| [[place-based-policy-lab]] | — | — | — | · |
+| [[quandamooka-justice-strategy]] | — | — | — | · |
+| [[resoleution]] | — | — | — | · |
+| [[tomnet]] | — | — | — | · |
+
+## Articles missing a repo
+
+- [[act-infrastructure]]
+- [[act-monthly-dinners]]
+- [[bg-fit]]
+- [[black-cockatoo-valley]]
+- [[caring-for-those-who-care]]
+- [[civicgraph]]
+- [[community-capital]]
+- [[confit-pathways]]
+- [[custodian-first-economy]]
+- [[dad-lab-25]]
+- [[deadlylabs]]
+- [[designing-for-obsolescence]]
+- [[feel-good-project]]
+- [[global-laundry-alliance]]
+- [[junes-patch]]
+- [[marriage-celebrant]]
+- [[place-based-policy-lab]]
+- [[quandamooka-justice-strategy]]
+- [[resoleution]]
+- [[tomnet]]
+
+## Articles with dead URLs
+
+_(none)_
+
+---
+
+_To consume this audit programmatically, read \`url-audit-latest.json\` in this directory. The wiki viewer (\`tools/act-wikipedia.html\`) reads it via the regen script (\`scripts/wiki-build-viewer.mjs\`) to render the Website / Repo / Deploy badges in each project infobox._`
+  },
+  "url-audit-2026-05-24": {
+    slug: "url-audit-2026-05-24",
+    title: "URL Audit 2026-05-24",
+    domain: "decisions",
+    links: ["act-infrastructure","act-monthly-dinners","barkly-backbone","bg-fit","black-cockatoo-valley","campfire","caring-for-those-who-care","civicgraph","community-capital","confit-pathways","contained","custodian-first-economy","dad-lab-25","deadlylabs","designing-for-obsolescence","diagrama","empathy-ledger","feel-good-project","fishers-oysters","global-laundry-alliance","goods","grantscope","junes-patch","marriage-celebrant","mounty-yarns","oonchiumpa","place-based-policy-lab","quandamooka-justice-strategy","resoleution","tomnet"],
+    content: `# URL Audit — 2026-05-24
 
 > Generated by \`scripts/wiki-verify-urls.mjs\`. Cross-references every wiki project article against the canonical \`Acurioustractor\` GitHub org and Benjamin Knight's Vercel team.
 
@@ -36649,7 +37579,7 @@ That is what Nigel's postcard does in a judge's hand. That is what the entire AC
     links: [],
     content: `# Wiki Health Report — 2026-04-07
 
-**Articles:** 314
+**Articles:** 321
 **Wikilinks:** 753
 
 ## Summary
@@ -37799,8 +38729,8 @@ function showMainPage() {
     { n: totalLinks, label: 'Wikilinks', color: '#7b68ee' },
     { n: mappedCount, label: 'Linked to EL', color: '#00af89' },
     { n: 269, label: 'Storytellers', color: '#e67e22' },
-    { n: 119, label: 'Stories', color: '#c0392b' },
-    { n: 6526, label: 'Photos', color: '#16a085' }
+    { n: 242, label: 'Stories', color: '#c0392b' },
+    { n: 6743, label: 'Photos', color: '#16a085' }
   ];
   counters.forEach(function(c) {
     html += '<div style="background:#fff;border:1px solid #e5e5e5;border-radius:4px;padding:14px 6px;">';
@@ -37835,7 +38765,7 @@ function showMainPage() {
 
   // ── VOICES OF ACT ─────────────────────────────────
   html += '<h2 style="font-family: \'Linux Libertine\', Georgia, Times, serif; font-size:1.4em; font-weight:normal; border-bottom:1px solid #a2a9b1; padding-bottom:0.3em; margin: 0 0 0.8em 0;">Voices of ACT</h2>';
-  let allFeatured = [{"id":"0d69f085-dfc5-4a7e-bf03-f9bdb5099d7f","name":"Uncle George","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/uncle_george.jpg","location":"Mount Isa","isElder":true,"project":"BG Fit","projectSlug":"mount-isa"},{"id":"1b2598cf-80a2-4386-969a-3e9315950b04","name":"Brodie Germaine","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/brodie_germaine.jpg","location":"Mount Isa, Queensland, Australia","isElder":false,"project":"BG Fit","projectSlug":"mount-isa"},{"id":"07dbb433-e386-49ca-a24a-e4a5a5c12417","name":"Allan Palm Island","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775114118938_20251216-1E5A8879.jpg","location":"Palm Island (Bwgcolman Country)","isElder":true,"project":"Uncle Allan Palm Island Art","projectSlug":"allan-palm-island"},{"id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810","name":"Benjamin Knight","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1778447929801_BK_Photo.jpg","location":"Australia","isElder":false,"project":"CONTAINED","projectSlug":"contained"},{"id":"5bb1c324-659b-4082-8999-52c68139e564","name":"Shaun Fisher","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/shaun_fisher.jpg","location":"Stradbroke","isElder":false,"project":"Fishers Oysters","projectSlug":"fishers-oysters"},{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false,"project":"Goods","projectSlug":"projects/goods/rd-activity-register"},{"id":"337766a9-d0ca-405c-acc1-7be7b13a6d4c","name":"Dianne Stokes","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/dianne_stokes.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":true,"project":"Goods","projectSlug":"projects/goods/rd-activity-register"},{"id":"e0da3338-1a38-4b5a-9a26-73c9873b9242","name":"Cliff Plummer","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/cliff_plummer.jpg","location":"Tennant Creek, Northern Territory, Australia","isElder":false,"project":"Goods","projectSlug":"projects/goods/rd-activity-register"}];
+  let allFeatured = [{"id":"0d69f085-dfc5-4a7e-bf03-f9bdb5099d7f","name":"Uncle George","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/uncle_george.jpg","location":"Mount Isa","isElder":true,"project":"BG Fit","projectSlug":"mount-isa"},{"id":"1b2598cf-80a2-4386-969a-3e9315950b04","name":"Brodie Germaine","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/brodie_germaine.jpg","location":"Mount Isa, Queensland, Australia","isElder":false,"project":"BG Fit","projectSlug":"mount-isa"},{"id":"07dbb433-e386-49ca-a24a-e4a5a5c12417","name":"Allan Palm Island","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775114118938_20251216-1E5A8879.jpg","location":"Palm Island (Bwgcolman Country)","isElder":true,"project":"Uncle Allan Palm Island Art","projectSlug":"allan-palm-island"},{"id":"8b5f3aa0-5955-43ac-8442-37e48e7fc810","name":"Benjamin Knight","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1778447929801_BK_Photo.jpg","location":"Australia","isElder":false,"project":"CONTAINED","projectSlug":"contained"},{"id":"5bb1c324-659b-4082-8999-52c68139e564","name":"Shaun Fisher","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/profile-images/storytellers/shaun_fisher.jpg","location":"Stradbroke","isElder":false,"project":"Fishers Oysters","projectSlug":"fishers-oysters"},{"id":"4b35b1af-9815-4b66-89ed-84ac0f5b3a2b","name":"Fred Campbell","avatar":"https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/media/d0a162d2-282e-4653-9d12-aa934c9dfa4e/1775863239871_Screenshot_2026-04-11_at_9.09.45_am.png","location":"Alice Springs","isElder":false,"project":"Goods","projectSlug":"projects/goods/rd-activity-register"}];
   if (allFeatured.length > 0) {
     html += '<div style="display:flex;flex-wrap:wrap;gap:10px;margin-bottom:0.5em;">';
     allFeatured.forEach(function(s) {
@@ -37911,7 +38841,7 @@ function showMainPage() {
   // ── FOOTER ────────────────────────────────────────
   html += '<div class="mp-stats" style="text-align:center;font-size:12px;color:#888;border-top:1px solid #e5e5e5;padding-top:1em;margin-top:1em;">';
   html += 'Tractorpedia is maintained using the <a href="#llm-knowledge-base" class="wikilink" onclick="navigateTo(\'llm-knowledge-base\'); return false;">LLM Knowledge Base</a> pattern. ';
-  html += 'Photos live from <a href="https://www.empathyledger.com" target="_blank">Empathy Ledger</a>. Last compiled: 2026-05-18.';
+  html += 'Photos live from <a href="https://www.empathyledger.com" target="_blank">Empathy Ledger</a>. Last compiled: 2026-05-25.';
   html += '</div>';
 
   document.getElementById('mw-content-text').innerHTML = html;
@@ -38909,6 +39839,114 @@ function showArtPortfolio() {
       }
     });
   });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
+  // Now async-load real photos for each card. fetchELMedia(slug) handles project_id + filename fallback.
+  artProjects.forEach(function(p) {
+    fetchELMedia(p.slug, 1).then(function(media) {
+      let el = document.getElementById('art-thumb-' + p.slug);
+      if (!el) return;
+      if (media && media.length > 0) {
+        el.innerHTML = '<img src="' + media[0].url + '" style="width:100%;height:100%;object-fit:cover;" alt="' + (media[0].title || p.name) + '">';
+      } else {
+        el.innerHTML = '<div style="text-align:center;padding:20px;"><div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#aaa;">photos coming soon</div><div style="font-size:11px;color:#bbb;margin-top:4px;">tag in Empathy Ledger</div></div>';
+      }
+    });
+  });
 }
 
 // ============================================================
@@ -38918,6 +39956,42 @@ function handleHash() {
   let hash = window.location.hash.substring(1);
   if (!hash) {
     showMainPage();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
+    return;
+  }
+  if (hash === 'art-portfolio') {
+    showArtPortfolio();
     return;
   }
   if (hash === 'art-portfolio') {

--- a/wiki/AGENTS.md
+++ b/wiki/AGENTS.md
@@ -94,7 +94,7 @@ If you're running a batch of edits, lint and rebuild once at the end.
 - **Always add new articles to `wiki/index.md`** — orphaned articles fail lint
 - **Always add a `## Backlinks` section** — missing backlinks generate lint warnings
 - **Respect consent tiers** — stories from Empathy Ledger may have `consent_tier: internal-only` in frontmatter. These are excluded from the public viewer automatically.
-- **ALMA first-use rule** — spell out Accountable Listening and Meaningful Action (ALMA) on first use. Do not define ALMA as the Soul, an AI agent, a ranking engine, or a measurement dashboard.
+- **ALMA first-use rule** — spell out Australian Living Map of Alternatives (ALMA) on first use. Do not define ALMA as the Soul, an AI agent, a ranking engine, or a measurement dashboard.
 
 ## Key Scripts
 

--- a/wiki/cockpit/four-lanes-today.md
+++ b/wiki/cockpit/four-lanes-today.md
@@ -1,13 +1,13 @@
 ---
 title: Four Lanes Today
 status: Live
-updated: 2026-05-18
+updated: 2026-05-25
 source_of_truth: wiki/concepts/four-lanes.md
 ---
 
 # Four Lanes Today
 
-> Live snapshot of ACT's internal economy. Generated 2026-05-18.
+> Live snapshot of ACT's internal economy. Generated 2026-05-25.
 > Methodology and meaning: [[../concepts/four-lanes|The Four Lanes]].
 
 > **Data range:** 2025-10-01 to 2026-03-31. If this lags the current date, statement ingestion is behind.
@@ -28,18 +28,18 @@ Q3 FY26 (2026-01-01 to 2026-03-31):
 ## Last 90 days
 
 - **To Us**: $0 (0%)
-- **To Down**: $440 (0%)
-- **To Grow**: $104,757 (100%)
+- **To Down**: $431 (1%)
+- **To Grow**: $84,799 (99%)
 - **To Others**: $0 (0%)
 
-Revenue last 90 days: $128,061
+Revenue last 90 days: $109,360
 
 ## LCAA by spend (last 90 days)
 
-- **Listen**: $28,866 (27%)
-- **Curiosity**: $7,052 (7%)
-- **Action**: $59,976 (57%)
-- **Art**: $9,303 (9%)
+- **Listen**: $26,252 (31%)
+- **Curiosity**: $6,852 (8%)
+- **Action**: $50,088 (59%)
+- **Art**: $2,038 (2%)
 
 ## Soul check
 

--- a/wiki/concepts/act-ecosystem.md
+++ b/wiki/concepts/act-ecosystem.md
@@ -13,6 +13,14 @@ status: Active
 
 [[empathy-ledger|Empathy Ledger]] is the connective tissue. It flows stories into The Harvest, evidence into JusticeHub, community voices into PICC's annual report, and cultural knowledge into CivicGraph's picture of the system. Without Empathy Ledger, you have data. With it, you have the [[third-reality|Third Reality]].
 
+## The Civic Operating System (within the ecosystem)
+
+Three of the ecosystem's projects, [[civicgraph|CivicGraph]] (intelligence), [[justicehub|JusticeHub]] (practice), and [[empathy-ledger|Empathy Ledger]] (accountability), form **one civic operating system with three layers**. They share one architecture, share consent and audit primitives, and call each other in code. Together they are the reflex layer of ACT's product work, the cerebellum that makes the boring-but-essential work happen reliably.
+
+The other clusters below (Place, Community Control at Scale, Youth and Justice, Art and Culture) are not part of the civic OS. They sit alongside it on different revenue lanes (see [[four-lanes|The Four Lanes]]). The civic OS gives them intelligence, practice infrastructure, and accountability rails when they want them; it does not absorb them.
+
+See [[civic-operating-system|Civic Operating System]] for the architecture, [[civic-reflex-automation|Civic Reflex Automation]] for the AI thesis, and [[evidence-as-by-product|Evidence as a By-Product]] for how impact reporting composes from the layers.
+
 ## The Clusters
 
 ### 1. Narrative Sovereignty
@@ -87,8 +95,12 @@ The ACT Studio coordinates across all of them. Every project can syndicate conte
 ## Backlinks
 
 - [[act-identity|ACT Identity]] — what ACT is and how it's structured
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) sitting inside this ecosystem
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis underneath the civic OS
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how impact reporting composes from the layers
 - [[empathy-ledger|Empathy Ledger]] — the connective tissue
 - [[the-harvest|The Harvest]] — place cluster anchor
 - [[picc|PICC]] — the proof case
 - [[third-reality|The Third Reality]] — the impact methodology that ties it together
 - [[lcaa-method|LCAA Method]] — the operating framework
+- [[four-lanes|The Four Lanes]] — how money flows through the ecosystem; clarifies which projects sit inside the civic OS and which sit alongside it

--- a/wiki/concepts/act-identity.md
+++ b/wiki/concepts/act-identity.md
@@ -49,6 +49,14 @@ Every ACT project, relationship, and piece of infrastructure can be tagged with 
 
 The test for any ACT project: can the community run this without us? Can they modify it? Can they export their data? If any answer is no, the work is not finished.
 
+## The Civic Operating System
+
+ACT's product work is organised as one civic operating system with three layers: [[civicgraph|CivicGraph]] sees the field (intelligence), [[justicehub|JusticeHub]] supports the work (practice), [[empathy-ledger|Empathy Ledger]] holds the trust (accountability). They share one architecture, one ethics, and one set of reflex primitives (intake, consent, triage, referral, follow-up, audit, evidence). They are not three independent products; they are three layers of one system.
+
+The AI thesis underneath is [[civic-reflex-automation|Civic Reflex Automation]]: automate the boring, amplify the art, never replace human judgment on relationships, consent, or creative direction. Impact reporting follows the [[evidence-as-by-product|Evidence as a By-Product]] principle, where reporting composes from the layers rather than running as a separate workstream.
+
+See [[civic-operating-system|the Civic Operating System concept page]] for the architecture, and the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] for the decision that established it.
+
 ## How ACT Differs from a Typical NGO
 
 | Typical NGO | ACT |

--- a/wiki/concepts/ai-ethics.md
+++ b/wiki/concepts/ai-ethics.md
@@ -9,7 +9,13 @@ status: Active
 
 ## Overview
 
-ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect [[alma|Accountable Listening and Meaningful Action (ALMA)]]: consent, authority, provenance, and review before action. Efficiency is never a sufficient reason to bypass these constraints.
+ACT's approach to AI is built on a single principle: AI serves community voice, it never replaces it. Every AI capability in the ecosystem must respect three composed gatekeepers, each owned by a different layer of the [[civic-operating-system|civic operating system]]:
+
+- **Consent** lives in [[empathy-ledger|Empathy Ledger]] (consent state, AI-use ledger, audit trail)
+- **Cultural authority and evidence quality** live in [[alma|Australian Living Map of Alternatives (ALMA)]] scoring methodology (the six dimensions; cultural-authority verification before any score is set)
+- **Publication discipline** lives in [[governed-proof|Governed Proof]] (confidence rating, review trail, what can be shared with whom)
+
+Efficiency is never a sufficient reason to bypass any of these. This is the operational expression of the [[civic-reflex-automation|Civic Reflex Automation]] thesis: gatekeeping reflexes are automated and verifiable; the human work (cultural authority, judgment, relationship) stays human.
 
 This article covers the ethical framework, the internal agent roles, and what AI can and cannot do within ACT systems.
 
@@ -23,18 +29,17 @@ This article covers the ethical framework, the internal agent roles, and what AI
 | **Community authority highest weight** | Overrides efficiency in decision paths |
 | **Consent before analysis** | No opt-out model, explicit opt-in only |
 
-## AI Under ALMA Review
+## AI Under the Composed Gatekeepers
 
-ALMA is not an AI agent or a technical gatekeeper. It is the governed sensemaking process AI tools must remain subordinate to:
+ALMA is the catalogue, not the gatekeeping process. The three gates above (consent, cultural authority and evidence quality, publication discipline) are each owned by a different layer and composed at runtime. The flow:
 
 ```
 User/Community Input
         ↓
-   Governed Review
-   - Consent verified?
-   - Cultural sensitivity flagged?
-   - Authority confirmed?
-   - Provenance clear?
+   Composed Gate (at intake)
+   - Consent verified?         (Empathy Ledger)
+   - Cultural authority?       (ALMA scoring methodology)
+   - Evidence supported?       (ALMA scoring methodology)
         ↓
    AI Processing (if permitted)
         ↓
@@ -43,8 +48,15 @@ User/Community Input
    - Individual profiling avoided?
    - Value returned to community?
         ↓
-   Output
+   Composed Gate (at output)
+   - Publication permitted?    (Governed Proof)
+   - Confidence rating set?    (Governed Proof)
+   - Audit trail written?      (Empathy Ledger AI-use ledger)
+        ↓
+   Output (with provenance, written to audit trail)
 ```
+
+Each gate is a real check enforced by code in the relevant layer, not an aspirational principle. See [[civic-operating-system|the Civic Operating System concept page]] for how the layers compose.
 
 ## What AI Can Do
 
@@ -104,7 +116,7 @@ For any new AI feature:
 | Check | Required |
 |-------|----------|
 | OCAP principles respected? | Yes |
-| Accountable Listening and Meaningful Action (ALMA) respected? | Yes |
+| Australian Living Map of Alternatives (ALMA) respected? | Yes |
 | Individual profiling prevented? | Yes |
 | Sacred content hard-blocked? | Yes |
 | Community authority preserved? | Yes |
@@ -123,8 +135,11 @@ As AI capabilities grow, ACT maintains:
 
 ## Backlinks
 
-- [[alma|ALMA]] — governed sensemaking process AI must remain subordinate to
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture this ethics framework composes across
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis these principles operationalise (automate the boring, amplify the art, never replace judgment)
+- [[alma|ALMA]] — the catalogue layer; AI must respect its cultural authority and evidence-scoring methodology
+- [[empathy-ledger|Empathy Ledger]] — the consent + audit + AI-use ledger layer
+- [[governed-proof|Governed Proof]] — the publication gate AI outputs pass through
 - [[governance-consent|Governance & Consent]] — consent architecture AI must respect
-- [[empathy-ledger|Empathy Ledger]] — the platform where AI consent settings live
 - [[ai-community-engagement|AI Community Engagement]] — broader AI use in community contexts
 - [[transcript-analysis-method|Transcript Analysis Method]] — the concrete guardrail set for AI transcription and theme extraction

--- a/wiki/concepts/alma.md
+++ b/wiki/concepts/alma.md
@@ -1,35 +1,62 @@
 ---
-title: ALMA - Accountable Listening and Meaningful Action
+title: ALMA - Australian Living Map of Alternatives
 status: Active
+source_of_truth: wiki/concepts/soul.md
+reframed_by: wiki/decisions/2026-05-25-civic-cerebellum-reframe.md
+rewritten: 2026-05-25
 ---
 
-# ALMA - Accountable Listening and Meaningful Action
+# ALMA - Australian Living Map of Alternatives
 
-> Listening becomes action only when consent, authority, provenance, and review are clear.
+> The Living Map. A catalogue of community-led alternatives to detention, dependency, and extractive systems, each scored by evidence quality and cultural authority. A noun, not a verb.
 
-## One-Line Definition
+> This concept sits downstream of [[soul|Soul]]. If anything on this page contradicts soul, soul is right. It was rewritten on 2026-05-25 as part of the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe]] cleanup, after the name "Australian Living Map of Alternatives" was made canonical and the older "sensemaking process" framing was retired.
 
-Accountable Listening and Meaningful Action (ALMA) is ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review.
+## What ALMA Is
+
+Australian Living Map of Alternatives (ALMA) is ACT's catalogue of community-led interventions that work, do not work, or are still being learned. Today it holds 1,112 interventions from 507 organisations across the youth justice, child protection, family services, and adjacent fields. Each intervention is scored on six dimensions and tied back to evidence, source, cultural authority, and target cohort.
+
+ALMA is **the map**. It is not a process, not a dashboard, not an AI agent. It is the curated reference that other parts of the civic operating system draw on when they need to answer "what works, and how do we know."
+
+The map lives in the database: `alma_interventions`, `alma_evidence`, `alma_outcomes`. The catalogue is the canonical artifact. Any concept page or pitch deck that disagrees with what is actually in those tables is wrong; the tables are right.
+
+## The Six Scoring Dimensions (the methodology)
+
+Every intervention in ALMA is scored on six dimensions. The scoring methodology is what makes the map *governed* rather than just a list.
+
+| Dimension | What it asks |
+|---|---|
+| **Evidence strength** | Is the claim sourced and reliable? What kind of evidence supports it (research, practice records, lived-experience accounts)? |
+| **Community authority** | Who has the right to speak about this? Has cultural authority been verified? |
+| **Harm risk** | What could go wrong if this is funded, replicated, or scaled? |
+| **Implementation capability** | Can this be done responsibly now, with the people and infrastructure available? |
+| **Option value** | Does adopting this open or close future possibilities? |
+| **Community value return** | Does value flow back to the people and place involved, or only outward to funders and institutions? |
+
+These six dimensions **are** ALMA's methodology. They are not external supports for some other thing called ALMA. The dimensions plus the catalogue plus the scoring records together are the Map.
 
 ## Where ALMA Sits
 
-ALMA is downstream of [[soul|Soul]] and [[lcaa-method|LCAA Method]]. It is not the soul of ACT, the founder voice, an AI personality, or a dashboard.
+The conceptual lineage, updated to match the post-reframe architecture:
 
 ```text
 Soul
-Why this exists before ACT
+  Why ACT exists
 
-LCAA
-How ACT practises: Listen, Curiosity, Action, Art
+LCAA Method
+  How ACT practises: Listen, Curiosity, Action, Art
 
 ALMA
-How listening becomes accountable action
+  The catalogue of community-led alternatives, evidence-graded and cultural-authority-verified
+
+Empathy Ledger
+  The consent infrastructure that protects the stories and storytellers feeding into evidence
 
 Governed Proof
-How action becomes evidence, review, confidence, and publication
+  The audit + review + publication layer that gates which claims from ALMA can be shared, and with what confidence
 
-Projects
-Harvest, JusticeHub, Empathy Ledger, Community Capital, CONTAINED
+JusticeHub
+  The practice layer. JusticeHub Atlas surfaces ALMA publicly; JusticeHub Practice draws on ALMA when partner orgs do the work
 ```
 
 The short version:
@@ -37,120 +64,90 @@ The short version:
 ```text
 Soul tells us why.
 LCAA tells us how we practise.
-ALMA tells us how listening becomes accountable action.
-Governed Proof tells us how action becomes evidence.
-Harvest shows whether any of it is real.
+ALMA holds what we have learned about what works.
+Empathy Ledger protects the consent of the people whose work and stories feed it.
+Governed Proof gates what can be published and at what confidence.
+JusticeHub is where the map gets used in the real world.
 ```
 
-## What ALMA Does
+## How ALMA Connects to the Civic Operating System
 
-ALMA helps ACT and community partners decide what can be acted on, shared, funded, reviewed, held back, handed over, or refused after listening.
+Per the [[civic-operating-system|Civic Operating System]] architecture, ALMA is the **evidence catalogue** layer that the practice and intelligence layers draw on. Specifically:
 
-It does this by asking:
+- **[[justicehub|JusticeHub]] Atlas** is the public surface where ALMA is read. The Atlas is the user-facing brand; ALMA is the data layer behind it. In external copy, prefer "JusticeHub evidence map" or "the evidence catalogue" over bare "ALMA" (see [[../decisions/act-brand-alignment-map|brand alignment map]] line 196).
+- **[[justicehub|JusticeHub]] Practice** queries ALMA when a partner organisation is doing operational work, to surface "what has worked for this cohort in this region."
+- **[[civicgraph|CivicGraph]]** holds the financial and structural context (who funds whom, who contracts with whom). When CivicGraph and ALMA are composed, the question "what works AND who actually funds it" becomes answerable.
+- **[[empathy-ledger|Empathy Ledger]]** holds the consented stories that feed evidence into ALMA. Stories do not enter ALMA without consent flowing through Empathy Ledger first.
+- **[[governed-proof|Governed Proof]]** gates publication. A claim from ALMA does not become a public statement without Governed Proof's confidence rating, review status, and audit trail attached.
 
-- What did we hear?
-- Who holds authority here?
-- What does consent allow?
-- Where did this evidence come from?
-- What action would be meaningful to the people, place, or system involved?
-- What should be reviewed, held back, handed over, or refused?
+## How the Map Gets Curated
 
-## The ALMA Movement
+ALMA is a *Living* Map for a reason: the catalogue is added to, scored, and re-reviewed continuously, not built once. The curation process draws on the [[lcaa-method|LCAA Method]]:
 
-ALMA is the bridge between listening and action.
+- **Listen** — new interventions enter the catalogue from practitioner accounts, lived-experience interviews, sector research, [[empathy-ledger|Empathy Ledger]] stories with consent, and partner-org self-reports. The intake is broad; the scoring is what filters.
+- **Curiosity** — every new entry is scored on the six dimensions by a reviewer with cultural authority appropriate to the intervention. Indigenous-led interventions are scored by Indigenous reviewers; lived-experience interventions are scored with lived-experience input.
+- **Action** — entries with sufficient confidence are surfaced through [[justicehub|JusticeHub]] Atlas, used in commissioned briefs, and quoted in sector publications. Low-confidence entries stay in the map but are flagged.
+- **Art** — the map itself is published as a public artifact (the Atlas) and as a periodic State-of-the-Field synthesis. The art is in the curation, not in concealing the work.
 
-```text
-Listen
-  receive what is offered
-  resist the urge to arrive with a fix
+Curation is a continuous practice, not a quarterly project. The map gets re-scored when new evidence arrives or when the cultural-authority assessment of a prior entry needs updating.
 
-Meaning
-  check authority, consent, context, provenance, and consequence
-  decide whether the signal is ready for action
-
-Action
-  act, review, publish, fund, hold back, hand over, or refuse
-```
-
-The working sentence is:
-
-> We listened. We checked who has authority. We checked what consent allows. We traced the evidence. We asked what action would be meaningful. We either acted, reviewed, held back, or handed over.
-
-That is ALMA.
-
-## What ALMA Does Not Do
+## What ALMA Is Not
 
 ALMA is not:
 
-- the Soul
-- the founder voice
-- an AI personality
-- a dashboard
-- a product brand
-- a ranking engine
-- a measurement dashboard
-- a replacement for community authority
-- a way to make extraction sound ethical
-- permission to publish without review
-- permission to make AI sovereign
-
-## Operational Records
-
-Some legacy schemas and reports use fields named `alma_signals`, `ALMA score`, or `ALMA interventions`. Keep those as internal record names where changing them would break data lineage.
-
-Do not let those fields redefine ALMA.
-
-The six review fields are prompts inside the governed process, not the public meaning of ALMA:
-
-| Review field | What it slows down |
-| --- | --- |
-| Evidence strength | Is the claim sourced and reliable? |
-| Community authority | Who has the right to speak or decide? |
-| Harm risk | What could go wrong if we act or share? |
-| Implementation capability | Can this be done responsibly now? |
-| Option value | Does this open or close future possibilities? |
-| Community value return | Does value flow back to the people or place involved? |
-
-These fields can support ALMA. They are not ALMA itself.
+- **A process.** ALMA is the map; the process of curating it draws on LCAA, and the process of publishing from it draws on Governed Proof. Don't conflate the noun with the verbs that act on it.
+- **An AI agent.** ALMA does not "decide" anything. Reviewers with cultural authority do the scoring. Software helps the recording, the lookups, and the visualisations.
+- **A ranking engine.** ALMA scores interventions on six dimensions; it does not produce a single "ALMA score" that ranks every intervention against every other. The dimensions are intentionally multi-axis to resist single-number ranking.
+- **A measurement dashboard.** ALMA is the catalogue; impact dashboards built on top of it are derivative outputs, not ALMA itself.
+- **The Soul.** [[soul|Soul]] is upstream. ALMA is downstream of Soul and LCAA.
+- **A replacement for community authority.** ALMA records the community authority that scored each entry; it does not substitute for that authority.
+- **A way to make extraction sound ethical.** Putting cultural-authority and evidence-confidence scores on extractive interventions does not redeem them. Low scores are honest; low scores are also a signal to stop funding the intervention.
+- **Permission to publish without review.** Publication from ALMA goes through [[governed-proof|Governed Proof]]. The map is a reference, not a publication licence.
+- **A user-facing brand.** Public copy prefers "JusticeHub evidence map" or "the evidence catalogue." ALMA is the internal name for the system behind the surface (see [[../decisions/act-brand-alignment-map|brand alignment map]]).
 
 ## First-Use Rule
 
-Always spell out the first mention:
+Always spell out the first mention on any page:
 
 ```text
-Accountable Listening and Meaningful Action (ALMA)
+Australian Living Map of Alternatives (ALMA)
 ```
 
-Do not use the acronym alone in public-facing writing unless it has already been defined on that page.
+Do not use the bare acronym in public-facing writing unless it has already been defined on that page.
 
-Bad:
+In external copy, prefer the user-facing brand:
 
 ```text
-ALMA will assess community signals and generate recommendations.
+JusticeHub evidence map (drawn from ACT's Australian Living Map of Alternatives, ALMA)
 ```
 
-Better:
+Never use the older expansion ("Accountable Listening and Meaningful Action"). That expansion was retired on 2026-05-25 because it described a process the name did not match. If you find it in any surface, fix it.
 
-```text
-Accountable Listening and Meaningful Action (ALMA) helps ACT and community partners decide what can be acted on, shared, funded, reviewed, or held back after listening.
-```
+## Composing ALMA into Impact Reporting
 
-Best:
+Impact reporting at ACT is not a separate system. It is what comes out when ALMA, [[empathy-ledger|Empathy Ledger]], [[civicgraph|CivicGraph]], and [[governed-proof|Governed Proof]] are composed correctly. A funder report draws on:
 
-```text
-Accountable Listening and Meaningful Action (ALMA) is not an AI deciding for people. It is ACT's governed sensemaking process: listening first, checking consent and authority, tracing evidence, then supporting meaningful action.
-```
+- ALMA for "which interventions are working and how confident are we"
+- Empathy Ledger for the consented stories that put faces and voices to the evidence
+- CivicGraph for the funding flows, contracts, and structural context that the interventions sit inside
+- Governed Proof for the confidence rating, the audit trail, and the publication boundaries
+
+See [[evidence-as-by-product|Evidence as a By-Product of the Work]] for the longer treatment of how reporting composes from the layers, why "evidence as a separate reporting task" is the wrong frame, and what funder/sector/internal reports look like in the composed architecture.
 
 ## Backlinks
 
-- [[soul|Soul]] - the upstream why; ALMA is downstream, never the soul
-- [[lcaa-method|LCAA Method]] - the practice loop that ALMA serves
-- [[governed-proof|Governed Proof]] - the evidence, review, and publication layer after action
-- [[empathy-ledger|Empathy Ledger]] - the story and consent infrastructure ALMA must respect
-- [[governance-consent|Governance & Consent]] - consent and authority rules ALMA depends on
-- [[ai-ethics|AI Ethics & Agent Strategy]] - AI support must remain subordinate to ALMA's consent, authority, provenance, and review checks
-- [[beautiful-obsolescence|Beautiful Obsolescence]] - handover discipline for any action ALMA supports
-- [[glossary|Glossary]] - shared language entry for ALMA across the ecosystem
-- [[transcript-analysis-method|Transcript Analysis Method]] - story analysis process that can feed ALMA review
-- [[ways-of-working|Ways of Working]] - daily rhythm for applying ALMA in planning, meetings, and review
-- [[roadmap-2026|2026 Roadmap]] - annual plan that anchors story, consent, evidence, and action
+- [[soul|Soul]] — the upstream why
+- [[lcaa-method|LCAA Method]] — the practice loop that curates the map
+- [[empathy-ledger|Empathy Ledger]] — the consent infrastructure that feeds ALMA
+- [[governed-proof|Governed Proof]] — the audit and publication gate downstream of ALMA
+- [[justicehub|JusticeHub]] — the surface where ALMA gets used (Atlas as public read, Practice as operational draw-down)
+- [[civicgraph|CivicGraph]] — the financial and structural context ALMA composes with
+- [[civic-operating-system|Civic Operating System]] — the architecture ALMA sits inside
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how impact reporting composes from ALMA + EL + CivicGraph + Governed Proof
+- [[governance-consent|Governance & Consent]] — the consent and authority rules ALMA depends on
+- [[ai-ethics|AI Ethics]] — AI support remains subordinate to ALMA's consent, authority, evidence, and review rules
+- [[beautiful-obsolescence|Beautiful Obsolescence]] — handover discipline for the catalogue
+- [[transcript-analysis-method|Transcript Analysis Method]] — the story-analysis process that can feed ALMA review
+- [[glossary|Glossary]] — shared language entry across the ecosystem
+- [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] — the decision that prompted this rewrite
+- [[../decisions/act-brand-alignment-map|Brand Alignment Map]] — naming rules including the "JusticeHub evidence map" preference for external copy

--- a/wiki/concepts/civic-world-model.md
+++ b/wiki/concepts/civic-world-model.md
@@ -1,31 +1,55 @@
+---
+title: Civic World Model
+status: Active
+source_of_truth: wiki/concepts/soul.md
+reframed_by: wiki/decisions/2026-05-25-civic-cerebellum-reframe.md
+note: This page was rewritten on 2026-05-25 to drop earlier "replacement for top-down hierarchy" framing (too close to civic-CEO positioning the reframe ADR rejects). Stats and Block's four architectural principles are preserved. Framing verbs are shifted from "replace" to "sense, illuminate, feed."
+---
+
 # Civic World Model
 
-> Replacing the "middle management" of the state and philanthropy with an interconnected intelligence layer.
+> The intelligence sensorium of the [[civic-operating-system|Civic Operating System]]. CivicGraph maps entities, capital flows, and social outcomes so practitioners, communities, journalists, and funders can act with situational awareness. It does not replace the humans in the system; it gives them the field of view they have been missing.
+
+> This concept sits downstream of [[soul|Soul]]. If anything in this page contradicts soul, soul is right. It was rewritten on 2026-05-25 per [[../decisions/2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]].
 
 ## Origin
 
-Inspired by Block's "[From Hierarchy to Intelligence](https://block.xyz/inside/from-hierarchy-to-intelligence)" thesis, which describes replacing traditional corporate hierarchies (where middle management routes information slowly) with AI-coordinated systems.
+Inspired by Block's "[From Hierarchy to Intelligence](https://block.xyz/inside/from-hierarchy-to-intelligence)" thesis, which describes the shift from routing information through slow human middle-layers to coordinating through deterministic, machine-readable models of an organisation's state.
 
-CivicGraph is building the **Civic World Model** — the social sector equivalent. Instead of relying on government bureaucrats, grant managers, and delayed annual reports to route information, CivicGraph deterministically maps entities, capital flows, and social outcomes in real time.
+CivicGraph applies the same idea to the social sector. Capital flows, contracts, donations, board interlocks, grant decisions, and procurement awards are scattered across dozens of government data systems and made legible only through delayed, narrative-shaped annual reports. CivicGraph reads those systems directly and makes the underlying state of civic Australia visible to the people who need to see it: community organisations, place-based collaboratives, journalists, researchers, ethically-minded funders, and government departments who want their own sector held to honest mirrors.
+
+The point is not to replace human judgment in grant-making or policy. The point is to make sure the humans doing that work are not flying blind.
 
 ## Four Architectural Principles (from Block)
 
-### 1. The "Honest Signal"
-Block views transaction data as the most honest signal. In social impact, traditional signals are subjective grant applications and marketing spin. CivicGraph redefines the honest signal by tracking actual money flows (procurement, donations, grants) cross-referenced with ALMA-governed evidence records.
+### 1. The Honest Signal
 
-### 2. Humans at the Edge
-The system handles intelligence and coordination. Human roles shift to the "edge" — community leaders running diversion programs, storytellers on Empathy Ledger, designers of Goods on Country. Administrative burden removed from grassroots organizations.
+Block treats transaction data as the most honest signal. In social impact, the dominant signals are subjective grant applications and marketing-shaped annual reports. CivicGraph redefines the honest signal by tracking actual money flows (procurement, donations, grants) cross-referenced with [[alma|Australian Living Map of Alternatives (ALMA)]]-governed evidence records.
+
+Honest does not mean complete. Every CivicGraph chart, brief, or atlas ships with a methodology page that names what the signal measures, what it does not measure, and how to cite or challenge it. Honesty about limits is part of the signal.
+
+### 2. Humans at the Frontline, AI at the Reflex Layer
+
+Block's principle is "humans at the edge" — meaning the people doing the actual work in communities, not the administrative middle layers. CivicGraph reads the same way: the human work stays where it always was, with community leaders running diversion programs, storytellers contributing to Empathy Ledger, designers of Goods on Country, caseworkers in [[justicehub|JusticeHub]] Practice. CivicGraph removes the administrative drag of finding the right grants, mapping the right partners, evidencing the right outcomes, so that human time goes to relationships, judgment, and the work AI should never do.
+
+This is the [[civic-reflex-automation|Civic Reflex Automation]] thesis applied to intelligence: the reflex work (sensing, mapping, linking) gets automated; the human work (deciding, relating, judging) stays human.
 
 ### 3. Capabilities vs. Interfaces
-CivicGraph is the underlying **Capability and Intelligence Layer** — the atomic data primitive. JusticeHub, Empathy Ledger, and government dashboards are **Interfaces** that surface this civic intelligence to different audiences.
 
-### 4. Building the "Company World Model"
-A machine-readable state of operations, priorities, and roadblocks in real time. CivicGraph does this for the public sector — 566,522 entities connected by 1,536,626 relationships across 254 tables and 29.5M records.
+CivicGraph is the underlying **capability and intelligence layer**: the atomic data primitive of the civic OS. [[justicehub|JusticeHub]], [[empathy-ledger|Empathy Ledger]], journalist explorers, foundation deep-dive briefs, and government dashboards are **interfaces** that surface this civic intelligence to different audiences.
+
+The same dataset feeds many surfaces. The Funding Deserts Atlas is one surface. The Revolving Door Explorer is another. A foundation deep-dive brief is a third. The Open API ([[../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan|FY27 ops plan]] §7.3) is the fourth, letting researchers, journalists, and partner organisations build their own.
+
+### 4. A Machine-Readable State of the Civic Sector
+
+Block's principle: a machine-readable model of an organisation's operations, priorities, and roadblocks in real time. CivicGraph applies this to the public benefit sector: 566,522 entities connected by 1,536,626 relationships across 254 tables and 29.5M records, refreshed on a published cadence, queryable by anyone with an API key.
+
+The model is descriptive, not prescriptive. It tells you what is, not what should be. What should be is a question for humans, communities, and democratic processes. CivicGraph informs that conversation; it does not arbitrate it.
 
 ## CivicGraph Platform Stats (Live)
 
 | Domain | Tables | Records |
-|--------|--------|---------|
+|---|---|---|
 | Registries | 9 | 23.5M |
 | Entity Graph | 9 | 3.4M |
 | Procurement | 12 | 1.1M |
@@ -38,7 +62,7 @@ A machine-readable state of operations, priorities, and roadblocks in real time.
 
 ## Entity Linkage
 
-The ABN (Australian Business Number) is the universal join key. 559K+ entities resolved from 8 government data systems using ABN matching and normalized name fuzzy-matching.
+The ABN (Australian Business Number) is the universal join key. 559K+ entities resolved from 8 government data systems using ABN matching and normalised name fuzzy-matching.
 
 Key linkage rates:
 - Justice Funding: **86%** (146K records)
@@ -49,17 +73,34 @@ Key linkage rates:
 
 ## Data Coverage Gaps
 
-- NSW, VIC, WA, SA, TAS, NT, ACT lack org-level funding data (only QLD has granular per-recipient grants)
-- 94,162 funding records still unclassified by topic
-- 873 LGAs identified as funding deserts
+Honest about what is missing:
+- NSW, VIC, WA, SA, TAS, NT, and ACT lack org-level funding data. Only Queensland publishes granular per-recipient grants. Every CivicGraph state-comparison artifact names this limit.
+- 94,162 funding records remain unclassified by topic. Topic tagging continues incrementally; the unclassified pool is shrinking but visible.
+- 873 LGAs identified as funding deserts in the current materialised view; the methodology page for the Funding Deserts Atlas explains how the score is computed and what it does not capture.
 
-## The Product Vision
+## Role within the Civic Operating System
 
-CivicGraph is not a data dashboard — it's a **replacement for the archaic, top-down hierarchy** of traditional grant-making and policy-creation. Transitioning social impact from bureaucratic hierarchy to decentralized, verifiable intelligence.
+CivicGraph is the **intelligence layer** of the [[civic-operating-system|Civic Operating System]], per [[../decisions/2026-05-25-civic-cerebellum-reframe|the Reframe ADR]] (2026-05-25). The other two layers are [[justicehub|JusticeHub]] (practice) and [[empathy-ledger|Empathy Ledger]] (accountability).
+
+How CivicGraph connects to the other two:
+
+- Every public CivicGraph artifact writes provenance events to **Empathy Ledger's accountability API**. This is how CivicGraph claims become traceable.
+- **JusticeHub Practice fetches opportunities, grants, and funder intelligence** from CivicGraph when partner organisations are doing live practice work. JusticeHub does not reinvent intelligence; it consumes it.
+- CivicGraph's public-good artifacts (Funding Deserts Atlas, Revolving Door Explorer, State of Civic Money) **publish openly regardless of who pays for commissioned work**. This is the public-good non-negotiable rule from the reframe ADR.
+
+## What This Page Used to Say
+
+For honest record-keeping: an earlier version of this page (pre-2026-05-25) framed CivicGraph as "a replacement for the archaic, top-down hierarchy of traditional grant-making and policy-creation" and described the work as "replacing the middle management of the state and philanthropy." That framing was retired by the [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] as too close to the agentic-CEO positioning ACT explicitly rejects. The retired framing is preserved in git history.
+
+CivicGraph does not replace civic institutions or the humans inside them. It gives those humans, and the communities they serve, a field of view they did not previously have. The difference matters.
 
 ## Backlinks
 
+- [[civic-operating-system|Civic Operating System]] — the architecture this layer sits inside
+- [[civic-reflex-automation|Civic Reflex Automation]] — the thesis this layer expresses for intelligence
 - [[third-reality|The Third Reality]] — the methodology this model enables
-- [[civicgraph|CivicGraph]] — the platform
-- [[funding-transparency|Funding Transparency]] — public-money legibility problem this architecture is designed to solve
-- [[acco-sector-analysis|ACCO Sector Analysis]] — who the model serves
+- [[civicgraph|CivicGraph]] — the platform itself
+- [[funding-transparency|Funding Transparency]] — the public-money legibility problem this architecture is designed to surface
+- [[acco-sector-analysis|ACCO Sector Analysis]] — one of the audiences the model serves
+- [[ai-ethics|AI Ethics]] — the principles that constrain how CivicGraph data is used
+- [[../decisions/2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]] — the decision that established this layer's role in the civic OS

--- a/wiki/concepts/glossary.md
+++ b/wiki/concepts/glossary.md
@@ -27,8 +27,17 @@ ACT's methodology for ethical innovation:
 
 See [[lcaa-method|LCAA Method]].
 
-### Accountable Listening and Meaningful Action (ALMA)
-ACT's governed sensemaking process for moving from listening to meaningful action with consent, authority, provenance, and review. ALMA is not the Soul, an AI personality, a dashboard, or a ranking engine. See [[alma|ALMA]].
+### Australian Living Map of Alternatives (ALMA)
+ACT's catalogue of community-led interventions that work, scored on six dimensions (evidence strength, community authority, harm risk, implementation capability, option value, community value return). The catalogue lives in the `alma_interventions`, `alma_evidence`, and `alma_outcomes` database tables. ALMA is the map, not a process, not an AI agent, not a ranking engine. See [[alma|ALMA]].
+
+### Civic Operating System
+The three-layer architecture for ACT's product work: [[civicgraph|CivicGraph]] (intelligence, sees the field), [[justicehub|JusticeHub]] (practice, supports the work), [[empathy-ledger|Empathy Ledger]] (accountability, holds the trust). The three call each other in code. See [[civic-operating-system|Civic Operating System]].
+
+### Civic Reflex Automation
+ACT's AI thesis: automate the boring (tagging, matching, syncing, reporting, reminders, audits), amplify the art (storytelling, design, engagement), never replace human judgment on relationships, consent, or creative direction. See [[civic-reflex-automation|Civic Reflex Automation]].
+
+### Evidence as a By-Product of the Work
+The principle that impact reporting composes from the existing layers (Empathy Ledger, ALMA, CivicGraph, Governed Proof) rather than running as a separate reporting workstream. Every intake, story, consent, referral, audit, and review writes to the evidence base; the report at the end of the quarter is generated from the ledger, not re-collected from memory. See [[evidence-as-by-product|Evidence as a By-Product of the Work]].
 
 ### Power Take-Off (PTO)
 A tractor mechanism that transfers engine power to implements. ACT's founding metaphor: we provide power that communities direct, not the other way around.
@@ -89,14 +98,14 @@ Standardized `/api/registry` endpoint exposed by each project. Enables ecosystem
 
 ---
 
-## ALMA Review Fields
+## ALMA Scoring Dimensions
 
-Some legacy schemas use `alma_signals` fields. Treat these as review prompts inside [[alma|ALMA]], not as the public definition of ALMA.
+The six dimensions every intervention in [[alma|ALMA]] is scored on. These dimensions **are** ALMA's methodology, not external supports for some other thing called ALMA. The catalogue plus the dimensions plus the scoring records together are the Map.
 
-| Review Field | What It Checks |
+| Scoring Dimension | What It Checks |
 |--------|-----------------|
 | Evidence Strength | Is the claim sourced and reliable? |
-| Community Authority | Who holds authority? Is consent in place? |
+| Community Authority | Who holds authority? Has cultural authority been verified? |
 | Harm Risk | What could go wrong if this is acted on or shared? |
 | Implementation Capability | Can this be acted on responsibly now? |
 | Option Value | Does this open or close future possibilities? |
@@ -173,7 +182,7 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 | Acronym | Meaning |
 |---------|---------|
 | ACT | A Curious Tractor |
-| ALMA | Accountable Listening and Meaningful Action |
+| ALMA | Australian Living Map of Alternatives |
 | BCV | Black Cockatoo Valley |
 | CSA | Community Supported Agriculture |
 | GHL | GoHighLevel (CRM platform) |
@@ -191,7 +200,10 @@ Terms like "harvesting data," "capturing value," "mining insights" that treat pe
 ## Backlinks
 
 - [[lcaa-method|LCAA Method]] — core methodology
-- [[alma|ALMA]] — governed listening-to-action process
+- [[civic-operating-system|Civic Operating System]] — the three-layer architecture for ACT's product work
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis underneath the civic OS
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — the impact reporting principle
+- [[alma|ALMA]] — the catalogue of community-led alternatives, evidence-graded with cultural authority
 - [[governed-proof|Governed Proof]] — evidence, review, confidence, publication, and audit trail
 - [[consent-as-infrastructure|Consent as Infrastructure]] — OCAP architecture
 - [[beautiful-obsolescence|Beautiful Obsolescence]] — handover design principle

--- a/wiki/concepts/governed-proof.md
+++ b/wiki/concepts/governed-proof.md
@@ -9,9 +9,11 @@ status: Active
 
 ## Definition
 
-Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits after [[alma|Accountable Listening and Meaningful Action (ALMA)]].
+Governed Proof is ACT's evidence, review, confidence, publication, and audit-trail layer. It sits alongside [[alma|Australian Living Map of Alternatives (ALMA)]] (the catalogue of what works) and downstream of the practice (LCAA, Empathy Ledger, JusticeHub).
 
-ALMA helps decide whether listening can become action. Governed Proof records what happened next, what supports it, who reviewed it, what confidence it carries, and what can be shared.
+ALMA holds the evidence-graded catalogue. Governed Proof gates which claims drawn from ALMA, or from any other ACT source, can be published, with what confidence, to what audience, and under what review trail.
+
+Together they answer two different questions. ALMA: "what do we know about what works?" Governed Proof: "what are we ready to say in public, and how do we stand behind it?"
 
 ## Where It Sits
 
@@ -45,12 +47,14 @@ Governed Proof does not replace consent, community authority, Elder review, or r
 
 ## Backlinks
 
-- [[alma|ALMA]] - the listening-to-action process upstream of governed proof
-- [[soul|Soul]] - upstream why; governed proof is downstream, not the source of meaning
-- [[ways-of-working|Ways of Working]] - daily operational rhythm that applies review and publication discipline
-- [[governance-consent|Governance & Consent]] - consent and authority model
-- [[consent-as-infrastructure|Consent as Infrastructure]] - technical architecture for consent
-- [[empathy-ledger|Empathy Ledger]] - source of consented story records
-- [[justicehub|JusticeHub]] - public evidence and action surface
-- [[transcript-analysis-method|Transcript Analysis Method]] - pipeline that creates reviewable story evidence
-- [[vignette-workflows|Vignette Workflows]] - story evidence workflow
+- [[alma|ALMA]] — the evidence catalogue this layer composes with for publication
+- [[soul|Soul]] — upstream why; governed proof is downstream, not the source of meaning
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how Governed Proof composes with ALMA, Empathy Ledger, and CivicGraph to produce impact reports
+- [[civic-operating-system|Civic Operating System]] — the architecture this layer sits inside
+- [[ways-of-working|Ways of Working]] — daily operational rhythm that applies review and publication discipline
+- [[governance-consent|Governance & Consent]] — consent and authority model
+- [[consent-as-infrastructure|Consent as Infrastructure]] — technical architecture for consent
+- [[empathy-ledger|Empathy Ledger]] — source of consented story records
+- [[justicehub|JusticeHub]] — practice and public-evidence surface
+- [[transcript-analysis-method|Transcript Analysis Method]] — pipeline that creates reviewable story evidence
+- [[vignette-workflows|Vignette Workflows]] — story evidence workflow

--- a/wiki/concepts/lcaa-method.md
+++ b/wiki/concepts/lcaa-method.md
@@ -161,8 +161,11 @@ Every project, every piece of art, every community relationship can be tagged wi
 - [[civicgraph|CivicGraph]]: Curiosity
 - [[picc|PICC]]: spans all four phases
 - [[third-reality|The Third Reality]]: the synthesis LCAA produces
-- [[alma|ALMA]]: governed sensemaking process that turns listening into accountable action
+- [[alma|ALMA]]: the catalogue of community-led alternatives, evidence-graded with cultural authority; what gets curated through LCAA's Curiosity phase
 - [[governed-proof|Governed Proof]]: evidence and review layer after action
+- [[civic-operating-system|Civic Operating System]]: the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) that operationalises LCAA at the product level
+- [[civic-reflex-automation|Civic Reflex Automation]]: the AI thesis that protects LCAA's human work by automating only the boring reflex tasks
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]]: how impact reporting composes from LCAA's outputs without becoming a separate task
 - [[ai-community-engagement|AI and Community Engagement]]: administrative compression that protects time for relational work
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the Action phase discipline
 - [[place-land-practice|Place & Land Practice]]: Country and land practice as the pace-setting context for the whole method

--- a/wiki/concepts/soul.md
+++ b/wiki/concepts/soul.md
@@ -74,13 +74,13 @@ Identity, method, the four lanes, the entity structure: all downstream. They are
 
 When in doubt about anything else in the wiki or the website, return here first. If the answer doesn't sit on top of what is in this file, the answer is wrong.
 
-## Relationship to ALMA
+## Relationship to the Downstream Architecture
 
-Soul is why ACT exists.
+Soul is why ACT exists. Everything else is how the soul gets delivered without losing itself.
 
-ALMA is not the soul.
+ACT's product work runs on a [[civic-operating-system|civic operating system]] with three layers: [[civicgraph|CivicGraph]] (intelligence — sees the field), [[justicehub|JusticeHub]] (practice — supports the work), [[empathy-ledger|Empathy Ledger]] (accountability — holds the trust). The [[civic-reflex-automation|Civic Reflex Automation]] thesis says these layers exist to handle the boring-but-essential work reliably so humans stay free for relationships, judgment, and art. [[alma|Australian Living Map of Alternatives (ALMA)]] is the catalogue of what works that the practice layer draws on. [[governed-proof|Governed Proof]] gates what can be published from any of it. [[evidence-as-by-product|Evidence as a By-Product of the Work]] is how impact reporting composes from the layers without becoming a separate workstream.
 
-[[alma|Accountable Listening and Meaningful Action (ALMA)]] is one downstream process that helps ACT move from listening to responsible action without bypassing consent, authority, provenance, or human and community review.
+None of these is the soul. They are how the soul stays operational without being eaten by drift.
 
 ---
 
@@ -90,7 +90,10 @@ ALMA is not the soul.
 - [[../people/nicholas-marchesi|Nicholas Marchesi OAM]]: co-founder, place and hospitality
 - [[act-identity|ACT Identity]]: the org built on top of this soul
 - [[lcaa-method|LCAA Method]]: the externalised practice loop
-- [[alma|ALMA]]: downstream governed process for moving from listening to accountable action
-- [[governed-proof|Governed Proof]]: evidence, review, and publication layer after action
+- [[civic-operating-system|Civic Operating System]]: the three-layer architecture (CivicGraph, JusticeHub, Empathy Ledger) downstream of soul
+- [[civic-reflex-automation|Civic Reflex Automation]]: the AI thesis — automate the boring, amplify the art, never replace judgment
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]]: how impact reporting composes from the layers
+- [[alma|ALMA]]: the catalogue of community-led alternatives, evidence-graded with cultural authority
+- [[governed-proof|Governed Proof]]: evidence, review, and publication layer
 - [[four-lanes|The Four Lanes]]: the body the soul lives in, the economy that sustains the work and the founders
 - [[beautiful-obsolescence|Beautiful Obsolescence]]: the discipline that lets the soul outlive the org

--- a/wiki/decisions/2026-04-five-year-plan.md
+++ b/wiki/decisions/2026-04-five-year-plan.md
@@ -43,9 +43,11 @@ $100K each, 95%/40% R&D allocation, through the family trust structures being se
 
 ### 2. CivicGraph is the commercial trading arm
 
+> **_updated 2026-05-25:** This section is amended by [[2026-05-25-civic-cerebellum-reframe|the Civic Cerebellum Reframe ADR]] (signed off by Ben + Nic, 2026-05-25). The "CivicGraph as strategic exit lever for a Y5 sale" framing is **retired**. CivicGraph is now positioned as the **intelligence layer of the civic operating system**, alongside JusticeHub (practice) and Empathy Ledger (accountability). The Stripe tiers stand. Commissioned intelligence and ACT advisory are added as named revenue flywheels. The five-year revenue arc below is unchanged; the channels through which it arrives are updated. The Beautiful Obsolescence rule is also amended (CivicGraph is infrastructure-inherited, not infrastructure-obsoleted). See the ADR for full detail.
+
 [[civicgraph|CivicGraph]] keeps its Stripe tiers ($79–$1999/mo), grows its data moat (100K entities, 672K contracts, 312K donations), and is explicitly positioned as the product that funds the other products' community handover.
 
-The [[beautiful-obsolescence|Beautiful Obsolescence]] language stays on [[empathy-ledger|Empathy Ledger]], [[justicehub|JusticeHub]], [[goods-on-country|Goods on Country]], [[the-harvest|The Harvest]]. It is never applied to CivicGraph publicly. CivicGraph exists to be commercially valuable and, in Y5, potentially sold to a strategic acquirer ($4–10M EV range at 3–6x ARR) to fund the Years 6–10 art and activism phase.
+The [[beautiful-obsolescence|Beautiful Obsolescence]] language stays on [[empathy-ledger|Empathy Ledger]], [[justicehub|JusticeHub]], [[goods-on-country|Goods on Country]], [[the-harvest|The Harvest]]. It is never applied to CivicGraph publicly. CivicGraph exists to be commercially valuable and, in Y5, potentially sold to a strategic acquirer ($4–10M EV range at 3–6x ARR) to fund the Years 6–10 art and activism phase. *(2026-05-25 — the Y5 sale framing in this paragraph is retired by the [[2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR]]. Commercial dimension stands; strategic-exit framing does not.)*
 
 ### 3. Empathy Ledger stays bespoke in Y1
 

--- a/wiki/decisions/act-brand-alignment-map.md
+++ b/wiki/decisions/act-brand-alignment-map.md
@@ -19,6 +19,36 @@ review_cadence: monthly + on any new sub-brand
 
 ---
 
+## The three tools are one civic OS (read this first)
+
+> Before any visual deviation rule below: **CivicGraph, JusticeHub, and Empathy Ledger are not three independent products.** They are three layers of one civic operating system. The visual deviations downstream serve the layer differentiation; they are not branding accidents and they cannot be unified into one look without breaking the product architecture.
+
+ACT builds three tools that share one architecture, one ethics, one publishing cadence, and one set of reflex primitives (intake, consent, triage, referral, follow-up, audit, evidence):
+
+| Layer | Tool | Role |
+|---|---|---|
+| **Intelligence** | CivicGraph (grantscope repo) | Sees the civic field. Maps money, power, opportunities, deserts. |
+| **Practice** | JusticeHub | Supports the work. Reflex layer for community-led justice and social-impact practice. |
+| **Accountability** | Empathy Ledger v2 | Holds the trust. Consent, audit, AI-use ledger, human-in-the-loop, sovereignty primitives. |
+
+The three tools call each other technically (CivicGraph writes provenance events to Empathy Ledger's accountability API; JusticeHub fetches opportunities from CivicGraph and verifies consent against Empathy Ledger). The civic OS is enforced in code, not just in marketing.
+
+**Why the visual deviations below exist:**
+- **CivicGraph wears Civic Bauhaus** because the intelligence layer publishes accountability data (funding deserts, revolving doors, power concentration). Warmth on that surface would undermine the teeth the data has earned.
+- **JusticeHub and Empathy Ledger wear Editorial Warmth** (in different subfamilies) because they are practice and storytelling surfaces for human relationships, lived experience, and cultural authority. Bauhaus on those surfaces would feel extractive.
+- The clusters serve the layers. Don't apply Bauhaus to a story surface. Don't apply Editorial Warmth to a data atlas. If a future surface doesn't clearly belong to one layer, that's a product-architecture question first, a visual question second.
+
+**Not in the civic OS:** Goods on Country, ACT Farm, and The Harvest Witta are separate ACT projects on different revenue lanes (see [[../concepts/four-lanes|The Four Lanes]]). They are part of the wider ACT ecosystem but do not inherit the civic-OS three-layer scheme. The visual cluster choices for those surfaces are made independently, per their own sections below.
+
+**Read before designing in any of the three civic-OS repos:**
+- [[../concepts/civic-operating-system|Civic Operating System concept page]] — the architecture, the shared reflex primitives, the cross-product API calls
+- [[2026-05-25-civic-cerebellum-reframe|Civic Cerebellum Reframe ADR (2026-05-25)]] — the decision that established the architecture
+- [[../concepts/civic-reflex-automation|Civic Reflex Automation]] — the AI thesis that makes the layers coherent
+
+The visual decisions in the rest of this file only make sense once you understand which layer your surface serves.
+
+---
+
 ## The visual family (three clusters)
 
 ACT has one parent identity (regenerative innovation; PTO metaphor; LCAA method; Indigenous-led partnership) but three legitimate visual families. Each family has a reason. Don't merge them; choose deliberately.
@@ -163,7 +193,7 @@ These rules apply to every surface, regardless of cluster:
 
 1. **Voice (Curtis method).** Name the room, name the body, load the abstract noun, stop the line before the explanation. From `writing-voice.md`.
 2. **AI-tells blocklist.** Never use: delve, crucial, pivotal, tapestry, underscore, "not just X but Y", rule-of-three adjective padding, em-dashes (in any ACT-facing writing), "challenges and future prospects", "-ing" significance tails.
-3. **Naming.** "Accountable Listening and Meaningful Action (ALMA)" needs first-use expansion and should not be used bare. Call the intervention map "JusticeHub evidence map" or "ALMA-governed JusticeHub evidence", not ALMA. "Listen · Curiosity · Action · Art" never bare "LCAA". Indigenous place names always; colonial in brackets only.
+3. **Naming.** "Australian Living Map of Alternatives (ALMA)" needs first-use expansion and should not be used bare. Call the intervention map "JusticeHub evidence map" or "ALMA-governed JusticeHub evidence", not ALMA. "Listen · Curiosity · Action · Art" never bare "LCAA". Indigenous place names always; colonial in brackets only.
 4. **LCAA imprint.** Every project should be reachable from the LCAA framing — Listen, Curiosity, Action, Art — visually OR narratively. Some lean Listen (EL v2), some Action (JH), some Art (Studio), some all four (Farm). State which.
 5. **Indigenous protocols.** Cultural-protocols-true projects (PICC, Oonchiumpa, BG Fit, Mounty Yarns) require OCAP-style consent before any storyteller content lands publicly. From `wiki/projects/...` per-project notes + `project_wiki_story_sync.md` memory.
 

--- a/wiki/decisions/act-core-facts.md
+++ b/wiki/decisions/act-core-facts.md
@@ -153,7 +153,7 @@ Full list: `config/project-codes.json` (v1.8.0, 74 projects, all with canonical_
 
 ## Naming & voice (always apply)
 
-- **"Accountable Listening and Meaningful Action (ALMA)"** — spell out on first use; never use bare "ALMA" in external copy
+- **"Australian Living Map of Alternatives (ALMA)"** — spell out on first use; never use bare "ALMA" in external copy
 - **"JusticeHub evidence map"** or **"ALMA-governed JusticeHub evidence"** — use this for the intervention map; do not call the map "ALMA"
 - **"Listen · Curiosity · Action · Art"** — never bare acronym "LCAA" in external copy
 - **Indigenous place names always**, colonial in brackets only

--- a/wiki/decisions/ceo-operating-model.md
+++ b/wiki/decisions/ceo-operating-model.md
@@ -80,6 +80,13 @@ ON ANY NEW DESIGN WORK in any ACT repo
 - **Daily action**: if a funder needs a call, do it; if a tranche due, follow up
 - **Strategic action**: Minderoo lands mid-May; pitch already in `thoughts/shared/writing/drafts/goods-minderoo-pitch/`
 
+### Impact reporting + Evidence
+- **Standing principle**: [[../concepts/evidence-as-by-product|Evidence as a By-Product of the Work]] — impact reporting composes from the layers (Empathy Ledger, ALMA, CivicGraph, Governed Proof). It is not a separate workstream and does not have its own team or budget line.
+- **Sources at composition time**: ALMA for "what works", Empathy Ledger for consented stories, CivicGraph for financial context, Governed Proof for confidence rating and publication boundaries.
+- **Four standing report shapes**: funder report (per bespoke EL customer) · sector report (State of Civic Money, annual flagship) · internal cockpit (this doc and the daily cockpit) · grant-application evidence bundle.
+- **What ACT stops doing**: writing "what happened" narratives from memory at quarter-end; treating reports as the deliverable; letting funder formats dictate which layer owns evidence; using ALMA as the answer to every evidence question.
+- **Action**: when a new funder asks for a report, do not start a new template. Compose from the existing layers. If the layers are missing the data, fix the layers, not the report.
+
 ### Brand + Design (any sub-brand work)
 - **Read first**: `wiki/decisions/act-brand-alignment-map.md`
 - **Decision tree**: data tool → CivicGraph cluster; multi-tenant storytelling → EL v2; STAY journal extension → JusticeHub; default → parent editorial (act-regenerative-studio)
@@ -89,7 +96,7 @@ ON ANY NEW DESIGN WORK in any ACT repo
 ### Communications + Public-facing writing
 - **Voice rules**: `.claude/skills/act-brand-alignment/references/writing-voice.md` (Curtis method + AI-tells blocklist)
 - **Identity**: `.claude/skills/act-brand-alignment/references/brand-core.md` (LCAA, voice, project narratives)
-- **Naming rules**: in act-core-facts.md (first-use Accountable Listening and Meaningful Action (ALMA); call the intervention map JusticeHub evidence; no bare "LCAA"; Indigenous place names always; no em-dashes)
+- **Naming rules**: in act-core-facts.md (first-use Australian Living Map of Alternatives (ALMA); call the intervention map JusticeHub evidence; no bare "LCAA"; Indigenous place names always; no em-dashes)
 - **Daily action**: nothing — this surfaces only when you write
 - **Whenever drafting**: load both writing-voice.md + brand-core.md before composing (every Claude session in any ACT repo already has the pointers via CLAUDE.md)
 

--- a/wiki/decisions/roadmap-2026.md
+++ b/wiki/decisions/roadmap-2026.md
@@ -20,7 +20,7 @@ This is a seasonal map, not a fixed plan. ACT chooses readiness over deadlines a
 | Finalise compendium and align project language to core model | In Progress |
 | Stabilise Harvest operations and maker pathways in Witta | In Progress |
 | Confirm Goods production readiness and support pathways | Planning |
-| Align AI agent guardrails to Accountable Listening and Meaningful Action (ALMA) and Empathy Ledger | Complete |
+| Align AI agent guardrails to Australian Living Map of Alternatives (ALMA) and Empathy Ledger | Complete |
 | JusticeHub vision and path to externalise | Planning |
 | ACT regular communication (1-to-some and 1-to-many via GHL) | In Progress |
 

--- a/wiki/decisions/url-audit-latest.json
+++ b/wiki/decisions/url-audit-latest.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-17",
+  "generated": "2026-05-24",
   "results": [
     {
       "slug": "act-infrastructure",
@@ -292,7 +292,7 @@
         "name": "empathy-ledger-v2",
         "url": "https://github.com/Acurioustractor/empathy-ledger-v2",
         "archived": false,
-        "pushedAt": "2026-05-14T20:34:00Z"
+        "pushedAt": "2026-05-23T06:08:10Z"
       },
       "vercelProject": {
         "name": "empathy-ledger-v2",
@@ -332,7 +332,7 @@
         "name": "fishers-oysters",
         "url": "https://github.com/Acurioustractor/fishers-oysters",
         "archived": false,
-        "pushedAt": "2026-05-13T09:07:28Z"
+        "pushedAt": "2026-05-24T20:52:55Z"
       },
       "vercelProject": {
         "name": "fishers-oysters",
@@ -372,7 +372,7 @@
         "name": "goods-asset-tracker",
         "url": "https://github.com/Acurioustractor/goods-asset-tracker",
         "archived": false,
-        "pushedAt": "2026-05-17T22:55:44Z"
+        "pushedAt": "2026-05-23T08:15:22Z"
       },
       "vercelProject": null,
       "canonicalUrl": "https://v2-rho-ochre.vercel.app",
@@ -470,7 +470,7 @@
         "name": "Oonchiumpa",
         "url": "https://github.com/Acurioustractor/Oonchiumpa",
         "archived": false,
-        "pushedAt": "2026-04-16T21:59:21Z"
+        "pushedAt": "2026-05-24T18:52:59Z"
       },
       "vercelProject": null,
       "canonicalUrl": "https://oonchiumpa.vercel.app",

--- a/wiki/finance/act-money-thesis-discussion.md
+++ b/wiki/finance/act-money-thesis-discussion.md
@@ -65,7 +65,7 @@ Marchesi Family Trust ─┘    │
                             ├──► Empathy Ledger v2 (project + future spinout candidate)
                             ├──► JusticeHub (project)
                             ├──► CivicGraph / Civic World Model (project)
-                            └──► ALMA (governed sensemaking process)
+                            └──► ALMA (the catalogue, evidence-graded)
 
 Nicholas Marchesi T/as A Curious Tractor (sole trader, ABN 21 591 780 066)
     Stops trading 30 June 2026

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -26,12 +26,15 @@ This wiki follows the [[llm-knowledge-base|Karpathy LLM Knowledge Base pattern]]
 - [[act-identity|ACT Identity]] — what A Curious Tractor is: dual-entity structure, LCAA, Beautiful Obsolescence
 - [[act-ecosystem|ACT Ecosystem]] — how the projects fit together: narrative, evidence, place, proof case, art
 - [[third-reality|The Third Reality]] — ACT's proprietary methodology for social impact measurement
-- [[civic-world-model|Civic World Model]] — CivicGraph as living civic intelligence
+- [[civic-operating-system|Civic Operating System]] — three layers, one architecture: CivicGraph (intelligence) + JusticeHub (practice) + Empathy Ledger (accountability)
+- [[civic-reflex-automation|Civic Reflex Automation]] — the AI thesis: automate the boring, amplify the art, never replace human judgment
+- [[evidence-as-by-product|Evidence as a By-Product of the Work]] — how impact reporting composes from the layers; no separate reporting workstream
+- [[civic-world-model|Civic World Model]] — the intelligence sensorium of the civic OS: how CivicGraph illuminates the field
 - [[indigenous-data-sovereignty|Indigenous Data Sovereignty]] — Mukurtu, CARE principles, TK Labels
 - [[ocap-principles|OCAP Principles]] — Ownership, Control, Access, Possession — the four architectural requirements
 - [[llm-knowledge-base|LLM Knowledge Base]] — the architecture pattern powering this wiki
 - [[lcaa-method|LCAA Method]] — Listen, Curiosity, Action, Art
-- [[alma|ALMA]] — Accountable Listening and Meaningful Action; ACT's governed process for moving from listening to meaningful action
+- [[alma|ALMA]] — Australian Living Map of Alternatives; the catalogue of community-led interventions, evidence-graded with cultural authority
 - [[governed-proof|Governed Proof]] — evidence, review, confidence, publication, and audit trail after action
 - [[ai-community-engagement|AI and Community Engagement]] — when AI eats the paperwork, people get their time back
 - [[youth-justice-reform|Youth Justice Reform]] — evidence, policy, alternatives

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -18,6 +18,40 @@ Helper: `node scripts/wiki-log.mjs <op> "<summary>" [files...]`
 
 ## 2026
 
+- 2026-05-25 05:37 | viewer-build | 321 articles · 92 photo maps · 2571KB | tools/act-wikipedia.html
+- 2026-05-25 05:37 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-24 09:15 | viewer-build | 321 articles · 92 photo maps · 2568KB | tools/act-wikipedia.html
+- 2026-05-24 09:15 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-24 09:05 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-24.md, wiki/decisions/url-audit-latest.json
+- 2026-05-24 09:00 | lint | 320 canonical articles · 252 broken links · 68 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-24.md, wiki/output/status-latest.json
+- 2026-05-23 16:47 | viewer-build | 316 articles · 92 photo maps · 2485KB | tools/act-wikipedia.html
+- 2026-05-23 16:47 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-23 16:47 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-23.md, wiki/decisions/url-audit-latest.json
+- 2026-05-23 16:47 | lint | 316 canonical articles · 236 broken links · 69 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-23.md, wiki/output/status-latest.json
+- 2026-05-23 15:47 | viewer-build | 316 articles · 92 photo maps · 2484KB | tools/act-wikipedia.html
+- 2026-05-23 15:47 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-23 15:47 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-23.md, wiki/decisions/url-audit-latest.json
+- 2026-05-23 15:46 | lint | 316 canonical articles · 236 broken links · 69 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-23.md, wiki/output/status-latest.json
+- 2026-05-23 15:42 | viewer-build | 316 articles · 92 photo maps · 2483KB | tools/act-wikipedia.html
+- 2026-05-23 15:42 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-23 15:42 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-23.md, wiki/decisions/url-audit-latest.json
+- 2026-05-23 15:42 | lint | 316 canonical articles · 236 broken links · 69 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-23.md, wiki/output/status-latest.json
+- 2026-05-23 15:34 | viewer-build | 316 articles · 92 photo maps · 2482KB | tools/act-wikipedia.html
+- 2026-05-23 15:34 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-23 15:34 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-23.md, wiki/decisions/url-audit-latest.json
+- 2026-05-23 15:34 | lint | 316 canonical articles · 236 broken links · 69 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-23.md, wiki/output/status-latest.json
+- 2026-05-23 14:33 | viewer-build | 316 articles · 92 photo maps · 2487KB | tools/act-wikipedia.html
+- 2026-05-23 14:33 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-23 14:33 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-23.md, wiki/decisions/url-audit-latest.json
+- 2026-05-23 14:33 | lint | 316 canonical articles · 236 broken links · 69 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-23.md, wiki/output/status-latest.json
+- 2026-05-23 14:03 | viewer-build | 315 articles · 92 photo maps · 2482KB | tools/act-wikipedia.html
+- 2026-05-23 14:03 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-23 14:03 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-23.md, wiki/decisions/url-audit-latest.json
+- 2026-05-23 14:03 | lint | 315 canonical articles · 234 broken links · 68 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-23.md, wiki/output/status-latest.json
+- 2026-05-20 09:16 | viewer-build | 314 articles · 92 photo maps · 2477KB | tools/act-wikipedia.html
+- 2026-05-20 09:16 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
+- 2026-05-20 09:16 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-20.md, wiki/decisions/url-audit-latest.json
+- 2026-05-20 09:16 | lint | 314 canonical articles · 232 broken links · 67 orphans · 98% source-bridge coverage | wiki/output/lint-2026-05-20.md, wiki/output/status-latest.json
 - 2026-05-17 08:45 | viewer-build | 314 articles · 92 photo maps · 2475KB | tools/act-wikipedia.html
 - 2026-05-17 08:45 | snapshot-sync | 24 direct mirrors · 55 stories · 4 wrappers | apps/command-center/public/wiki/README.md, apps/command-center/public/wiki/snapshot-meta.json
 - 2026-05-17 08:35 | url-audit | 8 live · 0 dead · 2 known-issue · 22 no-URL · 20 no-repo | wiki/decisions/url-audit-2026-05-17.md, wiki/decisions/url-audit-latest.json

--- a/wiki/operations/act-operational-thesis.md
+++ b/wiki/operations/act-operational-thesis.md
@@ -401,6 +401,8 @@ Never:    replace human judgment on relationships, consent, or creative directio
 
 The AI doesn't decide which stories to tell. It doesn't decide which communities to work with. It doesn't decide what art to make. It makes sure the receipts are matched, the wiki is current, the R&D claim is documented, and the grant opportunities are visible — so that the humans can do the work that only humans should do.
 
+This section is the internal application of ACT's broader [[../concepts/civic-reflex-automation|Civic Reflex Automation]] thesis. ACT applies the thesis to its own operations first; what is documented above is the proof case for what gets pitched externally. See also [[../concepts/evidence-as-by-product|Evidence as a By-Product of the Work]] for how this thesis applies to impact reporting (reporting composes from the layers; it is not a separate workstream).
+
 ---
 
 ## 6. The Karpathy System: How the Wiki Grows Itself

--- a/wiki/output/status-latest.json
+++ b/wiki/output/status-latest.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-17T23:00:00.617Z",
+  "generated_at": "2026-05-24T23:00:00.499Z",
   "scope": "canonical-graph",
   "domains": {
     "art": 8,
     "communities": 3,
-    "concepts": 30,
-    "decisions": 29,
+    "concepts": 33,
+    "decisions": 33,
     "finance": 19,
     "people": 23,
     "projects": 98,
@@ -15,15 +15,15 @@
     "technical": 6
   },
   "summary": {
-    "date": "2026-05-17",
-    "total_articles": 313,
-    "total_links": 2164,
-    "orphans": 67,
-    "broken_links": 230,
+    "date": "2026-05-24",
+    "total_articles": 320,
+    "total_links": 2358,
+    "orphans": 68,
+    "broken_links": 252,
     "stubs": 0,
-    "missing_from_index": 99,
-    "missing_backlinks": 525,
-    "advisory_backlinks": 481
+    "missing_from_index": 103,
+    "missing_backlinks": 527,
+    "advisory_backlinks": 626
   },
   "source_bridge": {
     "raw_sources": 154,
@@ -103,25 +103,25 @@
         "missing_target": "goods-on-country"
       },
       {
-        "stem": "glossary",
-        "title": "Glossary",
-        "relative_path": "concepts/glossary.md",
-        "page_path": "concepts/glossary",
-        "missing_target": "custodian-economy"
+        "stem": "civic-operating-system",
+        "title": "Civic Operating System",
+        "relative_path": "concepts/civic-operating-system.md",
+        "page_path": "concepts/civic-operating-system",
+        "missing_target": "../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan"
       },
       {
-        "stem": "glossary",
-        "title": "Glossary",
-        "relative_path": "concepts/glossary.md",
-        "page_path": "concepts/glossary",
-        "missing_target": "goods-on-country"
+        "stem": "civic-operating-system",
+        "title": "Civic Operating System",
+        "relative_path": "concepts/civic-operating-system.md",
+        "page_path": "concepts/civic-operating-system",
+        "missing_target": "../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan"
       },
       {
-        "stem": "lcaa-method",
-        "title": "LCAA Method",
-        "relative_path": "concepts/lcaa-method.md",
-        "page_path": "concepts/lcaa-method",
-        "missing_target": "goods-on-country"
+        "stem": "civic-reflex-automation",
+        "title": "Civic Reflex Automation",
+        "relative_path": "concepts/civic-reflex-automation.md",
+        "page_path": "concepts/civic-reflex-automation",
+        "missing_target": "../../thoughts/shared/plans/2026-05-25-fy27-launch-operations-plan"
       }
     ],
     "missing_from_index": [
@@ -236,15 +236,15 @@
         }
       },
       {
-        "stem": "act-identity",
-        "title": "A Curious Tractor (ACT)",
-        "relative_path": "concepts/act-identity.md",
-        "page_path": "concepts/act-identity",
+        "stem": "ai-ethics",
+        "title": "AI Ethics & Agent Strategy",
+        "relative_path": "concepts/ai-ethics.md",
+        "page_path": "concepts/ai-ethics",
         "target": {
-          "stem": "act-core-facts",
-          "title": "ACT Core Facts",
-          "relative_path": "decisions/act-core-facts.md",
-          "page_path": "decisions/act-core-facts"
+          "stem": "governed-proof",
+          "title": "Governed Proof",
+          "relative_path": "concepts/governed-proof.md",
+          "page_path": "concepts/governed-proof"
         }
       },
       {
@@ -286,12 +286,6 @@
         "page_path": "decisions/2026-04-18-mounty-yarns-story-approval"
       },
       {
-        "stem": "2026-04-18-oonchiumpa-story-approval",
-        "title": "Oonchiumpa org-level story approval — and the verbal-consent governance pattern",
-        "relative_path": "decisions/2026-04-18-oonchiumpa-story-approval.md",
-        "page_path": "decisions/2026-04-18-oonchiumpa-story-approval"
-      },
-      {
         "stem": "2026-04-18-picc-selective-youth-voice",
         "title": "PICC — selective youth-voice approval",
         "relative_path": "decisions/2026-04-18-picc-selective-youth-voice.md",
@@ -320,6 +314,12 @@
         "title": "Pile-Tagged Opportunity Workspace — Unified Architecture",
         "relative_path": "decisions/2026-05-pile-opportunity-workspace.md",
         "page_path": "decisions/2026-05-pile-opportunity-workspace"
+      },
+      {
+        "stem": "money-stack-one-stop-shop",
+        "title": "Money stack — one-stop-shop",
+        "relative_path": "decisions/money-stack-one-stop-shop.md",
+        "page_path": "decisions/money-stack-one-stop-shop"
       }
     ],
     "stubs": [],

--- a/wiki/projects/contained.md
+++ b/wiki/projects/contained.md
@@ -22,6 +22,25 @@ empathy_ledger_key: contained
 
 > 📣 **Narrative claims store:** [`wiki/narrative/contained/`](../narrative/contained/INDEX.md) — every public argument we have made about CONTAINED, what we have already said, and what we have not yet said. Read this before drafting any new post or op-ed. Run `node scripts/narrative-draft.mjs contained` to assemble a draft brief from the under-deployed claims.
 
+## Goal Stack
+
+> The alignment chain from purpose to this week. The top three layers (**Purpose · 10-year · 12-month**) are durable — change them rarely. The lower layers (**Quarter · Month · Dominoes**) are *living* — refreshed each week in the [[flow-flywheel|Flow Flywheel]] ritual. CONTAINED's weekly dominoes are tracked in Notion under code **ACT-CN**.
+
+| Layer | Goal | Proof it moved |
+|---|---|---|
+| **Purpose** | Make the cost and human reality of youth detention impossible to ignore, and route the attention it generates toward community-led alternatives already working. | — |
+| **10-year** | A nationally recognised touring + permanent justice experience that has measurably shifted public and political framing and helped move funding from detention toward community alternatives. | Framing shift; funding redirected; permanent installs |
+| **12-month** (FY26→27) | Complete the FY26 national tour (Adelaide confirmed + Mount Druitt + 1–2 stops) and establish CONTAINED as a self-sustaining licensed exhibition asset that funds the wider JusticeHub campaign. | Stops delivered; tour funding closed; rental income > production cost |
+| **This quarter** (Apr–Jun 2026) | Deliver Adelaide (Reintegration Puzzle Conference, 24–25 Jun) cleanly; convert the strongest demand states (QLD, NSW) into the next confirmed stop. | Adelaide run; next stop held with a date |
+| **This month** (May 2026) | *Lock Adelaide logistics and secure funding for the next confirmed stop.* — refine each cycle | |
+
+**This week's dominoes** (max 3 — set in the ritual, tracked in Notion · ACT-CN):
+1. *Finalise the CONTAINED host/partner brief (one-pager + budget ladder) so no conversation starts from scratch.*
+2. *Send one direct ask to a top QLD demand contact to convert a signal into a held date.*
+3. *Confirm Adelaide run-of-show + documentation (photo/video) plan.*
+
+*Last reviewed: 2026-05-26 — update the lower three layers each [[flow-flywheel|Flow Flywheel]] cycle.*
+
 ## The Build
 
 CONTAINED was built by hand. Nicholas Marchesi personally constructed the majority of the rooms, wired the electronics that make fluorescent despair tangible, and embedded the technology that bridges experience to action. Benjamin Knight followed paper trails that lead to kids in cages, transforming data into moral urgency.

--- a/wiki/projects/goods.md
+++ b/wiki/projects/goods.md
@@ -20,6 +20,25 @@ empathy_ledger_key: goods
 
 **Status:** Active | **Code:** ACT-GD | **Tier:** Ecosystem
 
+## Goal Stack
+
+> The alignment chain from purpose to this week. The top three layers (**Purpose · 10-year · 12-month**) are durable. The lower layers (**Quarter · Month · Dominoes**) are *living* — refreshed each week in the [[flow-flywheel|Flow Flywheel]] ritual. Goods' weekly dominoes are tracked in Notion under code **ACT-GD**.
+
+| Layer | Goal | Proof it moved |
+|---|---|---|
+| **Purpose** | Put durable, community-owned household goods into remote communities, and build manufacturing communities own and run — so ACT's role progressively diminishes. | — |
+| **10-year** | A network of community-owned, containerised on-country facilities (Jinibara → Alice Springs → Top End / Torres Strait), community-controlled across product, data, and relationships. | Facilities operating; community ownership; local FTE |
+| **12-month** (FY26→27) | Stand up the first containerised facility on Jinibara Country (~1,500 beds, ~6 FTE) and secure the capital stack that funds it — REAL Innovation Fund ($1.2M/4yr) + QBE Catalysing Impact (~$210K). | Facility commissioned; capital closed; FY27 revenue toward $585K |
+| **This quarter** | Drive the QBE Catalysing Impact decision (most time-sensitive — unlocks Snow's impact-investment track); advance REAL + Snow; convert top NT buyer demand. | QBE outcome; Snow advanced; a buyer order closed |
+| **This month** (May 2026) | *Advance the single most time-sensitive capital item and one buyer conversion.* — refine each cycle | |
+
+**This week's dominoes** (max 3 — set in the ritual, tracked in Notion · ACT-GD):
+1. *Finalise the first-facility pilot brief (product, community, equipment, partners, costs, training, output) — fundable and partner-ready.*
+2. *Move the QBE Catalysing Impact application to its next concrete step.*
+3. *Send one buyer ask into a top NT demand community (Maningrida / Wadeye / Galiwinku).*
+
+*Last reviewed: 2026-05-26 — update the lower three layers each [[flow-flywheel|Flow Flywheel]] cycle.*
+
 ## What It Is
 
 Goods on Country is ACT's circular economy social enterprise. It designs, manufactures, and deploys indestructible household goods for remote Aboriginal and marginalised communities across Australia, where extreme heat, overcrowding, dust, and limited repair infrastructure destroy standard products in weeks rather than years.

--- a/wiki/projects/justicehub/justicehub.md
+++ b/wiki/projects/justicehub/justicehub.md
@@ -89,7 +89,7 @@ JusticeHub needs **$500K** to scale nationally.
 
 ## ALMA-Governed Evidence Records
 
-The "what works" layer sitting on top of funding data, governed by [[alma|Accountable Listening and Meaningful Action (ALMA)]]:
+The "what works" layer sitting on top of funding data, governed by [[alma|Australian Living Map of Alternatives (ALMA)]]:
 - Evidence-based interventions mapped by topic and geography
 - 9 topic domains: child-protection, community-led, diversion, family-services, indigenous, legal-services, ndis, prevention, youth-justice
 - Cross-referenced with CivicGraph entity graph (56% linkage rate)

--- a/wiki/projects/the-harvest/the-harvest.md
+++ b/wiki/projects/the-harvest/the-harvest.md
@@ -19,6 +19,25 @@ empathy_ledger_key: the-harvest
 
 **Status:** Active | **Code:** ACT-HV | **Tier:** Ecosystem
 
+## Goal Stack
+
+> The alignment chain from purpose to this week. The top three layers (**Purpose · 10-year · 12-month**) are durable. The lower layers (**Quarter · Month · Dominoes**) are *living* — refreshed each week in the [[flow-flywheel|Flow Flywheel]] ritual. The Harvest's weekly dominoes are tracked in Notion under code **ACT-HV**.
+
+| Layer | Goal | Proof it moved |
+|---|---|---|
+| **Purpose** | Run a regenerative community hub in Witta that is genuinely of its place — the public front of the ACT Farm / BCV place system, built with locals, not launched at them. | — |
+| **10-year** | The Harvest and Black Cockatoo Valley are an established regenerative place system on Jinibara Country — recognised locally, trading sustainably, holding ACT's place, enterprise, and story layers together. | Recognised hub; sustainable trade; paired program steady |
+| **12-month** (FY26→27) | A consistent weekend trading rhythm (kitchen, garden centre, workshops, venue hire), a running CSA, and monthly BCV dinners — the paired-site program operating as a reliable cycle. | Weekly rhythm holds; CSA members; monthly dinners run |
+| **This quarter** | *Establish the dependable weekly rhythm and the local channels that fill it.* — refine each cycle | |
+| **This month** (May 2026) | *e.g. build the local channel map; run the next public garden morning.* — set in ritual | |
+
+**This week's dominoes** (max 3 — set in the ritual, tracked in Notion · ACT-HV):
+1. *Build The Harvest local channel map (local Facebook groups, noticeboards, schools, garden/arts networks, accommodation) so invitations travel where Witta locals already gather.*
+2. *Confirm and promote the next public moment (garden morning / workshop / BCV dinner) through those channels.*
+3. *…*
+
+*Last reviewed: 2026-05-26 — update the lower three layers each [[flow-flywheel|Flow Flywheel]] cycle.*
+
 ## Overview
 
 The Harvest (also known as Witta Harvest HQ) is a regenerative community hub located in Witta, Queensland (postcode 4552), operating from the former [[green-harvest-witta|Green Harvest]] site. It brings together a seasonal kitchen, a garden centre focused on native and productive plants for the Sunshine Coast, artisan workshops, and a flexible venue space — all grounded in regenerative land practice and local food culture.

--- a/wiki/technical/transcription-workflow.md
+++ b/wiki/technical/transcription-workflow.md
@@ -5,7 +5,7 @@ status: Active
 
 # Descript Transcription & ALMA Review Workflow
 
-> How transcribed stories move from Descript into Empathy Ledger and through Accountable Listening and Meaningful Action review.
+> How transcribed stories move from Descript into Empathy Ledger and through Australian Living Map of Alternatives review.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Documentation pass propagating the **Civic Operating System** reframe through the wiki and identity docs, plus the ALMA naming rule, plus one pre-existing goods commit already on this branch.

Two commits:

**`adeb083` — docs(civic-os)** (128 files)
- wiki: Civic Operating System framing added to `act/index`, identity, concepts, decisions, stories; command-center wiki mirror regenerated (snapshot 2026-05-25 via `wiki-sync-command-center-snapshot.mjs`)
- ALMA: "Australian Living Map of Alternatives (ALMA)" spell-out rule applied across `CLAUDE.md`, `AGENTS.md`, `README.md`, `STEERING.md`, the act-brand-alignment skill, website impact page + `alma.ts`, and `draft-funder-newsletter.mjs`
- `docs/alma`: CHARTER + DATA_POSTURE; docs README + V2 roadmap; EL privacy policy

**`c3437b4` — feat(goods)** (already on branch)
- Seed 13 funders into the GHL Supporter Journey pipeline (stage + warmth-band tags)
- Audit + clean the Buyer Pipeline to commercial-only

## Excluded
Dated cron/automation artifacts (money snapshots, cockpit reports, cross-codebase feeds, digests, funder-notes, url-audit/lint output) were left uncommitted in the working tree — same noise that normally blocks `checkout main`.

## Notes
- Website TS edits are trivial string/comment changes (ALMA spell-out); Vercel preview verifies the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)