### PR TITLE
feat(goods): GHL funder + buyer pipeline build (Supporter Journey 13→35, Buyer 1→6, Demand +14)

### DIFF
--- a/scripts/enrich-goods-foundation-contacts-2026-05-27.mjs
+++ b/scripts/enrich-goods-foundation-contacts-2026-05-27.mjs
@@ -1,0 +1,114 @@
+/**
+ * Enrichment pass for the Goods Supporter Journey (follows the 2026-05-27 seed batch).
+ * Source: thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/enrichment.md
+ * (real humans only — verified from synced email; nothing invented).
+ *
+ *   A. Promote 2 shells to real humans (updateContact — NO tags passed, so existing
+ *      goods-* tags are preserved). QBE shell left as-is (route is via Social Impact Hub).
+ *   B. 3 NEW philanthropic foundations Nic is in live Goods conversation with → contact + opp.
+ *   C. Secondary / route / corporate contacts → lookup-or-create, ADDITIVE tags, no opp.
+ *
+ * Idempotent: opps skipped if name exists; contacts looked up by email (POST /contacts/search)
+ * then tagged additively. updateContact is naturally idempotent.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/enrich-goods-foundation-contacts-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env.local scripts/enrich-goods-foundation-contacts-2026-05-27.mjs --apply  # writes
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const PIPELINE_NAME = 'Supporter Journey';
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const BASE_TAGS = ['goods', 'act-gd', 'project:act-gd'];
+
+// A. Shell → real human. updateContact with name+email ONLY (tags preserved). band left as-is.
+const SHELL_UPDATES = [
+  { contactId: 'bkZQ6vDNekvTtUVV1TpI', org: 'Minderoo Foundation',     firstName: 'Lucy',    lastName: 'Stronach', email: 'lstronach@minderoo.org' },
+  { contactId: '86IotCHStn0fEHyhFtoF', org: 'Paul Ramsay Foundation',  firstName: 'William', lastName: 'Frazer',   email: 'wfrazer@paulramsayfoundation.org.au' },
+];
+
+// B. NEW foundations (contact + opp).
+const NEW_OPPS = [
+  { name: 'The Bryan Foundation', value: 0, stage: 'Cultivating', band: 'goods-warm', role: 'goods-funder',
+    contact: { email: 'mcox@thebryanfoundation.org.au', firstName: 'Matthew', lastName: 'Cox', companyName: 'The Bryan Foundation' } },
+  { name: 'The Ian Potter Foundation', value: 0, stage: 'Cultivating', band: 'goods-warm', role: 'goods-funder',
+    contact: { email: 'alberto.furlan@ianpotter.org.au', firstName: 'Alberto', lastName: 'Furlan', companyName: 'The Ian Potter Foundation' } },
+  { name: 'Brian M Davis Charitable Foundation', value: 0, stage: 'Ask made', band: 'goods-warm', role: 'goods-funder',
+    contact: { email: 'sarah.bartak@brianmdavis.org.au', firstName: 'Sarah', lastName: 'Bartak', companyName: 'Brian M Davis Charitable Foundation' } },
+];
+
+// C. Secondary / route / corporate contacts (no opp — captured in CRM, tagged).
+const EXTRA_CONTACTS = [
+  { email: 'anita.hopkins@brianmdavis.org.au', firstName: 'Anita',   lastName: 'Hopkins',     companyName: 'Brian M Davis Charitable Foundation', role: 'goods-funder',    band: 'goods-warm' },
+  { email: 'jonas@paulramsayfoundation.org.au', firstName: 'Jonas',  lastName: 'Kubitscheck', companyName: 'Paul Ramsay Foundation',               role: 'goods-funder',    band: 'goods-steady' },
+  { email: 'jay@socialimpacthub.org',           firstName: 'Jay',    lastName: 'Boolkin',     companyName: 'Social Impact Hub',                    role: 'goods-supporter', band: 'goods-warm' },
+  { email: 'matt.allen@socialimpacthub.org',    firstName: 'Matt',   lastName: 'Allen',       companyName: 'Social Impact Hub',                    role: 'goods-supporter', band: 'goods-warm' },
+  { email: 'mtaylor@envirobank.com.au',         firstName: 'Marty',  lastName: 'Taylor',      companyName: 'Envirobank',                           role: 'goods-supporter', band: 'goods-warm' },
+  { email: 'nanderson@envirobank.com.au',       firstName: 'Narelle',lastName: 'Anderson',    companyName: 'Envirobank',                           role: 'goods-supporter', band: 'goods-warm' },
+];
+
+async function main() {
+  const ghl = createGHLService();
+  const pipeline = await ghl.getPipelineByName(PIPELINE_NAME);
+  if (!pipeline) { console.error(`✗ Pipeline "${PIPELINE_NAME}" not found.`); process.exit(1); }
+  const stageByKey = new Map(pipeline.stages.map((s) => [norm(s.name), s]));
+  const resolveStage = (n) => stageByKey.get(norm(n));
+  const existing = await ghl.getOpportunities(pipeline.id, { limit: 100 });
+  const existingNames = new Set(existing.map((o) => norm(o.name || '')));
+  console.log(`Pipeline "${pipeline.name}" (${pipeline.id}) — existing opps: ${existing.length}`);
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  const res = { updated: [], oppsCreated: [], oppsSkipped: [], contactsNew: [], contactsTagged: [], errors: [] };
+
+  async function ensureContact({ email, firstName, lastName, companyName }, tags) {
+    let contact = null;
+    if (email) {
+      const matches = await ghl.searchContacts(email);
+      contact = matches.find((c) => (c.email || '').toLowerCase() === email.toLowerCase()) || null;
+    }
+    if (!contact) {
+      if (!APPLY) { console.log(`  ↳ WOULD CREATE contact ${firstName} ${lastName} <${email}> [${tags.join(',')}]`); return '(dry)'; }
+      contact = await ghl.createContact({ email, firstName, lastName, companyName, tags });
+      res.contactsNew.push(email); console.log(`  ↳ created contact ${contact.id} <${email}>`);
+    } else if (APPLY) {
+      for (const t of tags) await ghl.addTagToContact(contact.id, t);
+      res.contactsTagged.push(email); console.log(`  ↳ existing contact ${contact.id} <${email}> — tags ensured`);
+    } else { console.log(`  ↳ WOULD TAG existing <${email}> += [${tags.join(',')}]`); }
+    return contact?.id || '(dry)';
+  }
+
+  console.log('── A. Promote shells to real humans (name+email only, tags preserved) ──');
+  for (const u of SHELL_UPDATES) {
+    const line = `${u.org}  → ${u.firstName} ${u.lastName} <${u.email}>  (contact ${u.contactId})`;
+    if (!APPLY) { console.log(`~ WOULD UPDATE  ${line}`); continue; }
+    try {
+      await ghl.updateContact(u.contactId, { firstName: u.firstName, lastName: u.lastName, name: `${u.firstName} ${u.lastName}`, email: u.email });
+      console.log(`~ UPDATED  ${line}`); res.updated.push(u.org);
+    } catch (e) { console.error(`✗ ERROR ${u.org}: ${e.message}`); res.errors.push(`${u.org}: ${e.message}`); }
+  }
+
+  console.log('\n── B. NEW foundations (contact + opp) ──');
+  for (const f of NEW_OPPS) {
+    const cid = await ensureContact(f.contact, [...BASE_TAGS, f.role, f.band]);
+    if (existingNames.has(norm(f.name))) { console.log(`= SKIP opp (exists)  ${f.name}`); res.oppsSkipped.push(f.name); continue; }
+    const st = resolveStage(f.stage);
+    const line = `${f.name}  → ${st.name}  [${f.band}]`;
+    if (!APPLY) { console.log(`+ WOULD CREATE opp  ${line}`); continue; }
+    try {
+      const opp = await ghl.createOpportunity({ pipelineId: pipeline.id, stageId: st.id, name: f.name, monetaryValue: f.value, status: 'open', contactId: cid });
+      console.log(`+ CREATED opp  ${line}  (${opp.id})`); res.oppsCreated.push(f.name);
+    } catch (e) { console.error(`✗ ERROR ${f.name}: ${e.message}`); res.errors.push(`${f.name}: ${e.message}`); }
+  }
+
+  console.log('\n── C. Secondary / route / corporate contacts (no opp) ──');
+  for (const c of EXTRA_CONTACTS) await ensureContact(c, [...BASE_TAGS, c.role, c.band]);
+
+  console.log(`\n── Summary ──`);
+  console.log(`Shells updated: ${res.updated.length} | opps created: ${res.oppsCreated.length} | opps skipped: ${res.oppsSkipped.length} | contacts new: ${res.contactsNew.length} | contacts re-tagged: ${res.contactsTagged.length} | errors: ${res.errors.length}`);
+  if (res.errors.length) console.log(`Errors:\n  ${res.errors.join('\n  ')}`);
+  if (!APPLY) console.log(`\n(Dry-run. Re-run with --apply to write.)`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/seed-goods-buyers-2026-05-27.mjs
+++ b/scripts/seed-goods-buyers-2026-05-27.mjs
@@ -1,0 +1,115 @@
+/**
+ * Seed the Goods BUYER pipelines (2026-05-27 buyers phase).
+ * Source: thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/buyers-candidates.md
+ * Approved (Ben): Buyer Pipeline = 5 warm commercial buyers; Demand Register = the scored
+ * cold prospects (Miwatj routed to Buyer Pipeline; Aputula EXCLUDED — possible dup of an
+ * existing DR row, needs manual confirm); delivery partners NOT touched.
+ *
+ * Tag convention (buyers, per operating model): goods + act-gd + project:act-gd +
+ * goods-role-{health|store|council|landcouncil|housing|corp} + goods-state-{nt|qld} +
+ * goods-communitycontrolled (if CC) + goods-stage-{prospect|active|customer}.
+ *
+ * Idempotent: opp skipped if name exists. Contacts WITH email looked up via search
+ * (create-or-additive-tag); contacts WITHOUT email (shells / named-but-no-email) created
+ * only when the opp will be created (guarded), so re-runs don't duplicate.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/seed-goods-buyers-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env.local scripts/seed-goods-buyers-2026-05-27.mjs --apply  # writes
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const BASE = ['goods', 'act-gd', 'project:act-gd'];
+
+// ── Buyer Pipeline: 5 warm commercial buyers ──
+const BUYERS = [
+  { name: 'Miwatj Health Aboriginal Corporation', stage: 'In Conversation', value: 0,
+    contact: { email: 'madelyn.hay@miwatj.com.au', firstName: 'Madelyn', lastName: 'Hay', companyName: 'Miwatj Health Aboriginal Corporation' },
+    tags: ['goods-role-health', 'goods-state-nt', 'goods-communitycontrolled', 'goods-stage-active'] },
+  { name: 'Anyinginyi Health Aboriginal Corporation', stage: 'In Conversation', value: 4800,
+    contact: { email: 'tony.miles@anyinginyi.com.au', firstName: 'Tony', lastName: 'Miles', companyName: 'Anyinginyi Health Aboriginal Corporation' },
+    tags: ['goods-role-health', 'goods-state-nt', 'goods-communitycontrolled', 'goods-stage-customer'] },
+  { name: 'WHSAC (Groote Archipelago)', stage: 'Outreach Queued', value: 1700000,
+    contact: { firstName: 'Simone', lastName: 'Grimmond', companyName: 'WHSAC (Groote Archipelago)' }, // no email on record — verify before outreach
+    tags: ['goods-role-housing', 'goods-state-nt', 'goods-communitycontrolled', 'goods-stage-prospect'] },
+  { name: "NPY Women's Council", stage: 'Outreach Queued', value: 0,
+    contact: { firstName: 'Angela', lastName: 'Lynch', companyName: "NPY Women's Council" }, // no email on record — verify Angela is current
+    tags: ['goods-role-corp', 'goods-state-nt', 'goods-communitycontrolled', 'goods-stage-prospect'] },
+  { name: 'Centrebuild Pty Ltd', stage: 'In Conversation', value: 0,
+    // Centrecorp's COMMERCIAL twin (109 beds sold). Contact = Randle Walker — same human as the
+    // Centrecorp funder record; deal details live in email with Randle. Links Centrebuild buyer
+    // opp to Randle's existing contact (search-by-email finds him, adds buyer tags additively).
+    contact: { email: 'randle@centrecorp.com.au', firstName: 'Randle', lastName: 'Walker', companyName: 'Centrebuild Pty Ltd' },
+    tags: ['goods-role-corp', 'goods-stage-customer'] },
+];
+
+// ── Demand Register: scored cold prospects (company shells, Signal). Miwatj→BP, Aputula excluded. ──
+const DEMAND = [
+  { name: 'Canteen Creek Store Charitable Trust', tags: ['goods-role-store', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'The Arnhem Land Progress Aboriginal Corporation (ALPA)', tags: ['goods-role-store', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Tangentyere Council Aboriginal Corporation', tags: ['goods-role-council', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Outback Stores Pty Ltd', tags: ['goods-role-store', 'goods-state-nt'] },
+  { name: 'Ntaria School Council Inc', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Central Land Council', tags: ['goods-role-landcouncil', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Anindilyakwa Housing Aboriginal Corporation', tags: ['goods-role-housing', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Tiwi Land Council', tags: ['goods-role-landcouncil', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Aboriginal Medical Services Alliance NT (AMSANT)', tags: ['goods-role-health', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Anindilyakwa Land Council', tags: ['goods-role-landcouncil', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Central Desert Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Tiwi Islands Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Torres Strait Island Regional Council', tags: ['goods-role-council', 'goods-state-qld'] },
+  { name: 'Northern Peninsula Area Regional Council', tags: ['goods-role-council', 'goods-state-qld'] },
+].map((d) => ({ ...d, stage: 'Signal', value: 0, tags: [...d.tags, 'goods-stage-prospect'] }));
+
+async function main() {
+  const ghl = createGHLService();
+  const bp = await ghl.getPipelineByName('Buyer Pipeline');
+  const dr = await ghl.getPipelineByName('Demand Register');
+  if (!bp || !dr) { console.error(`✗ Pipeline not found (bp=${!!bp} dr=${!!dr})`); process.exit(1); }
+  const stageId = (pl, n) => { const s = pl.stages.find((x) => norm(x.name) === norm(n)); if (!s) throw new Error(`stage "${n}" missing in ${pl.name}`); return s.id; };
+  const bpExisting = new Set((await ghl.getOpportunities(bp.id, { limit: 100 })).map((o) => norm(o.name)));
+  const drExisting = new Set((await ghl.getOpportunities(dr.id, { limit: 100 })).map((o) => norm(o.name)));
+  console.log(`Buyer Pipeline (${bp.id}) existing: ${bpExisting.size} | Demand Register (${dr.id}) existing: ${drExisting.size}`);
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  const res = { created: [], skipped: [], contactsNew: [], contactsTagged: [], errors: [] };
+
+  async function seed(pl, existing, e) {
+    if (existing.has(norm(e.name))) { console.log(`= SKIP (exists)  ${e.name}`); res.skipped.push(e.name); return; }
+    const tags = [...BASE, ...e.tags];
+    const line = `${e.name}  $${e.value.toLocaleString()}  → ${e.stage}  [${e.tags.join(',')}]`;
+    if (!APPLY) { console.log(`+ WOULD CREATE  ${line}  contact:${e.contact?.email || (e.contact ? 'shell' : 'shell')}`); return; }
+    try {
+      let cid;
+      const email = e.contact?.email;
+      if (email) {
+        const matches = await ghl.searchContacts(email);
+        let c = matches.find((m) => (m.email || '').toLowerCase() === email.toLowerCase());
+        if (c) { for (const t of tags) await ghl.addTagToContact(c.id, t); res.contactsTagged.push(email); }
+        else { c = await ghl.createContact({ ...e.contact, tags }); res.contactsNew.push(email); }
+        cid = c.id || c.contact?.id;
+      } else {
+        const c = await ghl.createContact({ firstName: e.contact?.firstName || e.name, lastName: e.contact?.lastName, companyName: e.contact?.companyName || e.name, tags });
+        cid = c.id || c.contact?.id; res.contactsNew.push(e.name);
+      }
+      if (!cid) throw new Error('no contact id');
+      const opp = await ghl.createOpportunity({ pipelineId: pl.id, stageId: stageId(pl, e.stage), name: e.name, monetaryValue: e.value, status: 'open', contactId: cid });
+      console.log(`+ CREATED  ${line}  (contact ${cid}, opp ${opp.id})`); res.created.push(e.name);
+    } catch (err) { console.error(`✗ ERROR ${e.name}: ${err.message}`); res.errors.push(`${e.name}: ${err.message}`); }
+  }
+
+  console.log('── Buyer Pipeline (5 warm commercial buyers) ──');
+  for (const b of BUYERS) await seed(bp, bpExisting, b);
+  console.log('\n── Demand Register (14 scored cold prospects) ──');
+  for (const d of DEMAND) await seed(dr, drExisting, d);
+
+  console.log(`\n── Summary ──`);
+  console.log(`Created: ${res.created.length} | skipped(existing): ${res.skipped.length} | contacts new: ${res.contactsNew.length} | re-tagged: ${res.contactsTagged.length} | errors: ${res.errors.length}`);
+  if (res.errors.length) console.log(`Errors:\n  ${res.errors.join('\n  ')}`);
+  if (!APPLY) console.log(`\n(Dry-run. Re-run with --apply to write.)`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/seed-goods-foundation-pipeline-2026-05-27.mjs
+++ b/scripts/seed-goods-foundation-pipeline-2026-05-27.mjs
@@ -1,0 +1,175 @@
+/**
+ * Seed the GHL "Goods — Supporter Journey" pipeline with the approved
+ * 2026-05-27 foundation batch (review doc:
+ * thoughts/shared/drafts/goods-foundation-pipeline-candidates-2026-05-27.md).
+ *
+ * Approved scope (Ben, 2026-05-27):
+ *   A. 4 warm NEW foundations (real email contacts)         → create contact + opp + warmth tag
+ *   B. 5 high-fit NEW foundations (no contact yet)          → contactless opp at stage
+ *   C. top-10 cold GrantScope prospects                     → contactless opp at Identified
+ *   D. enrich the existing 13 with secondary human contacts → lookup-or-create, ADDITIVE tags
+ *
+ * Idempotent:
+ *   - opportunities: skipped if an opp with the same (normalised) name already exists
+ *   - contacts: looked up by email first; tags applied via addTagToContact (never overwrites)
+ *   - cold prospects (C) are EXCLUDED of the Centrecorp-network dupes (#10/#11 in the GS table)
+ *
+ * Provenance:
+ *   - Group A/D contacts + emails: VERIFIED from synced email metadata (gmail-funders.md)
+ *   - Group B/C: GrantScope foundations catalogue (grantscope-foundations.md); fit inferred.
+ *     No contact invented — B/C carry NO human until a real one is found.
+ *
+ * Usage:
+ *   node --env-file=.env.local scripts/seed-goods-foundation-pipeline-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env.local scripts/seed-goods-foundation-pipeline-2026-05-27.mjs --apply  # writes
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const PIPELINE_NAME = 'Supporter Journey';
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const BASE_TAGS = ['goods', 'act-gd', 'project:act-gd'];
+
+// ── A. Warm NEW foundations — real email contacts (place at working stage) ──
+const GROUP_A = [
+  { name: 'The John Villiers Trust', value: 0, stage: 'Cultivating', band: 'goods-warm', role: 'goods-funder',
+    contact: { email: 'ceo@jvtrust.org.au', firstName: 'Fiona', lastName: 'Maxwell', companyName: 'The John Villiers Trust' } },
+  { name: 'Philanthropy Australia', value: 0, stage: 'Cultivating', band: 'goods-warm', role: 'goods-supporter',
+    contact: { email: 'kim@philanthropy.org.au', firstName: 'Kim', lastName: 'Harland', companyName: 'Philanthropy Australia' } },
+  { name: 'REAL Innovation Fund (DEWR)', value: 0, stage: 'Ask made', band: 'goods-warm', role: 'goods-funder',
+    contact: { email: 'REALInnovationFund@dewr.gov.au', firstName: 'REAL Innovation Fund', companyName: 'DEWR — REAL Innovation Fund' } },
+  { name: 'Rotary Global Grant (washers/beds)', value: 0, stage: 'Ask made', band: 'goods-warm', role: 'goods-funder',
+    contact: { email: 'pene.curtis@bigpond.com', firstName: 'Pene', lastName: 'Curtis', companyName: 'Rotary Global Grant' } },
+];
+
+// ── B. High-fit NEW foundations, no human yet — company-shell contact + opp ──
+const GROUP_B = [
+  { name: 'QBE Foundation', value: 200000, stage: 'Ask made', band: 'goods-warm' },
+  { name: 'Minderoo Foundation', value: 200000, stage: 'Qualified', band: 'goods-steady' },
+  { name: 'Paul Ramsay Foundation', value: 0, stage: 'Qualified', band: 'goods-steady' },
+  { name: 'Australian Communities Foundation', value: 0, stage: 'Identified', band: 'goods-cooling' },
+  { name: 'Nova Peris Foundation', value: 0, stage: 'Identified', band: 'goods-cooling' },
+];
+
+// ── C. Top-10 cold GrantScope prospects (Centrecorp-network dupes excluded) — company-shell contact + opp, Identified ──
+const GROUP_C = [
+  'Northern Australian Aboriginal Charitable Trust',
+  'Developing East Arnhem Limited',
+  'Fortescue Foundation',
+  'Rio Tinto Foundation',
+  'BHP Foundation',
+  'Country Connect Foundation Limited',
+  'Uniting Church Australia Frontier Services',
+  'Community Resources Limited',
+  'The Trustee For Yeperenye Charitable Trust',
+  'Mjd Foundation Limited',
+].map((name) => ({ name, value: 0, stage: 'Identified', band: 'goods-cold' }));
+
+// ── D. Enrichment: secondary human contacts for the existing 13 (additive only) ──
+const GROUP_D = [
+  { email: 'S.Grimsley-Ballard@snowfoundation.org.au', firstName: 'Sally', lastName: 'Grimsley-Ballard', companyName: 'Snow Foundation', role: 'goods-funder', band: 'goods-hot' },
+  { email: 'g.byron@snowfoundation.org.au', firstName: 'Georgina', lastName: 'Byron', companyName: 'Snow Foundation', role: 'goods-funder', band: 'goods-hot' },
+  { email: 'A.Machuca@snowfoundation.org.au', firstName: 'Ashley', lastName: 'Machuca', companyName: 'Snow Foundation', role: 'goods-funder', band: 'goods-hot' },
+  { email: 'cvecchio@qic.com', firstName: 'Cat', lastName: 'Vecchio', companyName: 'QIC', role: 'goods-funder', band: 'goods-cooling' },
+  { email: 'C.Sullivan@qic.com', firstName: 'Cat', lastName: 'Sullivan', companyName: 'QIC', role: 'goods-funder', band: 'goods-cooling' },
+  { email: 'bridgit@reddust.org.au', firstName: 'Bridgit', lastName: 'McMullen', companyName: 'Red Dust', role: 'goods-supporter', band: 'goods-cooling' },
+  // ⚠️ TFN: GHL primary = Kristen Lark; this is the active email contact. Flagged for Ben to set primary — NOT overwriting Kristen.
+  { email: 'madeline.alderuccio@thefundingnetwork.com.au', firstName: 'Madeline', lastName: 'Alderuccio', companyName: 'The Funding Network', role: 'goods-funder', band: 'goods-cooling' },
+];
+
+async function main() {
+  const ghl = createGHLService();
+  const pipeline = await ghl.getPipelineByName(PIPELINE_NAME);
+  if (!pipeline) { console.error(`✗ Pipeline "${PIPELINE_NAME}" not found.`); process.exit(1); }
+  console.log(`Pipeline: "${pipeline.name}" (${pipeline.id}) — ${pipeline.stages.length} stages`);
+
+  const stageByKey = new Map(pipeline.stages.map((s) => [norm(s.name), s]));
+  const resolveStage = (n) => stageByKey.get(norm(n));
+  const allStages = [...GROUP_A, ...GROUP_B, ...GROUP_C].map((x) => x.stage);
+  const missing = [...new Set(allStages)].filter((s) => !resolveStage(s));
+  if (missing.length) { console.error(`✗ Missing stages: ${missing.join(', ')}`); process.exit(1); }
+
+  const existing = await ghl.getOpportunities(pipeline.id, { limit: 100 });
+  const existingNames = new Set(existing.map((o) => norm(o.name || '')));
+  console.log(`Existing opportunities: ${existing.length}`);
+  console.log(`Mode: ${APPLY ? 'APPLY (writing)' : 'DRY-RUN (no writes)'}\n`);
+
+  const res = { oppsCreated: [], oppsSkipped: [], contactsNew: [], contactsTagged: [], errors: [] };
+
+  // lookup-or-create a contact, then apply tags additively (never overwrites existing tags)
+  async function ensureContact({ email, firstName, lastName, companyName }, tags) {
+    // NB: ghl.lookupContactByEmail uses GET /contacts/lookup which 400s (GHL reads
+    // "lookup" as a contact id). Use the POST /contacts/search path + exact-email filter.
+    let contact = null;
+    if (email) {
+      const matches = await ghl.searchContacts(email);
+      contact = matches.find((c) => (c.email || '').toLowerCase() === email.toLowerCase()) || null;
+    }
+    if (!contact) {
+      if (!APPLY) { console.log(`  ↳ WOULD CREATE contact ${firstName || ''} ${lastName || ''} <${email}> [${tags.join(',')}]`); return '(dry-run-id)'; }
+      contact = await ghl.createContact({ email, firstName, lastName, companyName, tags });
+      res.contactsNew.push(email);
+      console.log(`  ↳ created contact ${contact.id} <${email}>`);
+    } else if (APPLY) {
+      for (const t of tags) await ghl.addTagToContact(contact.id, t);
+      res.contactsTagged.push(email);
+      console.log(`  ↳ existing contact ${contact.id} <${email}> — tags ensured`);
+    } else {
+      console.log(`  ↳ WOULD TAG existing contact <${email}> += [${tags.join(',')}]`);
+    }
+    return contact?.id || '(dry-run-id)';
+  }
+
+  async function ensureOpp({ name, value, stage }, contactId) {
+    if (existingNames.has(norm(name))) { console.log(`= SKIP opp (exists)  ${name}`); res.oppsSkipped.push(name); return; }
+    const st = resolveStage(stage);
+    const line = `${name}  $${value.toLocaleString()}  → ${st.name}  contact:${contactId || 'NONE'}`;
+    if (!APPLY) { console.log(`+ WOULD CREATE opp  ${line}`); return; }
+    try {
+      const opp = await ghl.createOpportunity({ pipelineId: pipeline.id, stageId: st.id, name, monetaryValue: value, status: 'open', ...(contactId ? { contactId } : {}) });
+      console.log(`+ CREATED opp  ${line}  (${opp.id})`);
+      res.oppsCreated.push(name);
+    } catch (e) { console.error(`✗ ERROR opp ${name}: ${e.message}`); res.errors.push(`${name}: ${e.message}`); }
+  }
+
+  console.log('── A. Warm NEW foundations (contact + opp) ──');
+  for (const f of GROUP_A) {
+    const cid = await ensureContact(f.contact, [...BASE_TAGS, f.role, f.band]);
+    await ensureOpp(f, APPLY ? cid : null);
+  }
+
+  // B/C: GHL requires a contactId on every opp, so create a company-shell contact
+  // (org name, tagged, no human) then the opp. Guarded by opp-exists so re-runs don't dup.
+  async function ensureCompanyOpp(f) {
+    if (existingNames.has(norm(f.name))) { console.log(`= SKIP opp (exists)  ${f.name}`); res.oppsSkipped.push(f.name); return; }
+    const st = resolveStage(f.stage);
+    const line = `${f.name}  $${f.value.toLocaleString()}  → ${st.name}  [company shell, ${f.band}]`;
+    if (!APPLY) { console.log(`+ WOULD CREATE company-contact + opp  ${line}`); return; }
+    try {
+      const c = await ghl.createContact({ firstName: f.name, companyName: f.name, tags: [...BASE_TAGS, 'goods-funder', f.band] });
+      const cid = c?.id || c?.contact?.id;
+      if (!cid) throw new Error('contact create returned no id');
+      res.contactsNew.push(f.name);
+      const opp = await ghl.createOpportunity({ pipelineId: pipeline.id, stageId: st.id, name: f.name, monetaryValue: f.value, status: 'open', contactId: cid });
+      console.log(`+ CREATED  ${line}  (contact ${cid}, opp ${opp.id})`);
+      res.oppsCreated.push(f.name);
+    } catch (e) { console.error(`✗ ERROR ${f.name}: ${e.message}`); res.errors.push(`${f.name}: ${e.message}`); }
+  }
+
+  console.log('\n── B. High-fit NEW foundations (company-shell contact + opp) ──');
+  for (const f of GROUP_B) await ensureCompanyOpp(f);
+
+  console.log('\n── C. Top-10 cold prospects (company-shell contact + opp, Identified) ──');
+  for (const f of GROUP_C) await ensureCompanyOpp(f);
+
+  console.log('\n── D. Enrich existing 13 — secondary contacts (additive) ──');
+  for (const c of GROUP_D) await ensureContact(c, [...BASE_TAGS, c.role, c.band]);
+
+  console.log(`\n── Summary ──`);
+  console.log(`Opps created: ${res.oppsCreated.length} | skipped(existing): ${res.oppsSkipped.length} | contacts new: ${res.contactsNew.length} | contacts re-tagged: ${res.contactsTagged.length} | errors: ${res.errors.length}`);
+  if (res.errors.length) console.log(`Errors:\n  ${res.errors.join('\n  ')}`);
+  if (!APPLY) console.log(`\n(Dry-run. Re-run with --apply to write.)`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/thoughts/shared/drafts/goods-foundation-pipeline-candidates-2026-05-27.md
+++ b/thoughts/shared/drafts/goods-foundation-pipeline-candidates-2026-05-27.md
@@ -1,0 +1,102 @@
+# Goods on Country — Foundation Pipeline Candidates (REVIEW BEFORE GHL WRITE)
+
+**Date:** 2026-05-27 · **Priority:** Foundations ($) first (per Ben) · **Mode:** review-first — nothing is written to GHL until this doc is approved.
+
+> ## ✅ EXECUTED 2026-05-27 (Ben approved: all 9 new · top-10 cold · enrich 13, leave 3)
+> Seeder: `scripts/seed-goods-foundation-pipeline-2026-05-27.mjs` (idempotent, dry-run default). Supporter Journey **13 → 32**.
+> - **A** (4 warm) + **B** (5 high-fit) + **C** (10 cold) = **19 new opportunities** created (all opp IDs returned).
+> - **D**: 3 new + 7 re-tagged secondary contacts (additive). B/C use company-shell contacts (no human — **need enrichment before outreach**).
+> - GHL search index lagged after the write (25→30→32) — **do not re-run `--apply` until settled** or the 2 last-indexed (Developing East Arnhem, Paul Ramsay) would duplicate.
+> - ⚠️ TFN: added Madeline Alderuccio but did **not** change primary (still Kristen Lark) — Ben to confirm. Centrecorp board window (17/05) passed — needs follow-up.
+> Still open: contact-enrichment pass on the 15 shells · live `gmail-deep-search` of accounts@/hi@ · buyers phase (Batch 4).
+
+**Sources** (both read-only, no fabrication):
+- Gmail mine → `handoffs/goods-foundation-pipeline-2026-05-27/gmail-funders.md` (13,614 synced emails, 4 mailboxes, Jul 2025–25 May 2026; benjamin@/nicholas@ well-covered, **accounts@/hi@ thin**). Everything here is **verified from email metadata**.
+- GrantScope mine → `handoffs/goods-foundation-pipeline-2026-05-27/grantscope-foundations.md` (shared ACT DB `foundations` table, 11,010 rows / 2,045 Indigenous-focus; Goods shortlist = 6 seeded rows). Fit scores: 6 are author-set, the rest **inferred**. **No contacts exist in this source.**
+
+**Provenance key:** ✅ mail-verified contact · 🔎 fit inferred (no contact yet) · ⚠️ decision/flag for Ben.
+
+---
+
+## Dedup baseline (don't recreate)
+13 already in GHL Goods Supporter Journey: Mala'la Health, Rotary Eclub Outback, AMP Foundation, FRRR, The Funding Network, Red Dust, QIC, VFFF, Julalikari Council, Our Community Shed, Homeland School, Centrecorp, Snow Foundation.
+
+---
+
+## BATCH 1 — NEW foundations to ADD to Supporter Journey
+
+### 1a. Warm + real contact (from email — place at a real working stage)
+
+| Foundation | Named contact ✅ | Email | Proposed stage | Warmth tag | Notes |
+|---|---|---|---|---|---|
+| **The John Villiers Trust** | Fiona Maxwell (CEO) | ceo@jvtrust.org.au | Cultivating | `goods-warm` | Warmest genuinely-new foundation. CEO-level, "checking in" 2026-04-29, funding a video project — relationship live but not yet a Goods bed/washer ask. |
+| **Philanthropy Australia** | Kim Harland | kim@philanthropy.org.au | Cultivating | `goods-warm` | Convener/peak body, not a grant-maker — a **door-opener** (PA Conference featured Goods). Tag as `goods-supporter` + funder-adjacent. |
+| **REAL Innovation Fund (DEWR)** | program inbox (no human) | REALInnovationFund@dewr.gov.au | Ask made | `goods-warm` | Federal grant; EOI + info-request exchange via PICC/Oonchiumpa for the "Goods Project", Ben chasing status. Govt grant, not philanthropy. |
+| **Rotary Global Grant (route)** | Pene Curtis (+ advisors Tony Miles, Greg, Anne Gripper) | pene.curtis@bigpond.com | Ask made | `goods-warm` | Active application-drafting thread (washers/beds). ⚠️ Distinct from the existing GHL "Rotary Eclub Outback" entry — do not merge. |
+
+### 1b. High-fit, already worked in GrantScope but NOT in GHL (cold contact — place + flag for enrichment)
+
+| Foundation | GS fit | Proposed stage | Warmth | Contact status | Notes |
+|---|---|---|---|---|---|
+| **QBE Foundation** | 93 | Ask made | `goods-warm` 🔎 | needs human | In QBE **Catalysing Impact** cohort, working toward **up-to-$200K match grant** (via Social Impact Hub). Goods v2 even has a `qbe-program` admin page — this is live. **Add now.** |
+| **Minderoo Foundation** | 91 | Qualified | `goods-steady` 🔎 | needs decision-maker | Warm catalytic / recoverable-grant target (~$200K). Route Yajilarra Trust + Minderoo Pictures through this one record. |
+| **Paul Ramsay Foundation** | 89 | Qualified | `goods-steady` 🔎 | needs intro | $183M national; systems-change/procurement framing already in pipeline. |
+| **Australian Communities Foundation** | 84 | Identified | `goods-cooling` 🔎 | needs human | Pooled-giving/donor-collaborative route. |
+| **Nova Peris Foundation** | 76 | Identified | `goods-cooling` 🔎 | needs human | NT Indigenous economic-empowerment; possible route via PICC. |
+
+### 1c. Cold prospects — strongest GrantScope-only leads (Identified, research/enrich before outreach)
+
+🔎 All inferred fit, no contact on record. Top picks (full 37 in the handoff):
+- **Northern Australian Aboriginal Charitable Trust** — website `remotelaundries.org.au`, literally funds remote-community washing. NT + Indigenous + exact use-case. **Standout.**
+- **Developing East Arnhem Ltd** — $2M NT-only remote grant-maker.
+- **Country Connect Foundation** — NT, remote + homelessness.
+- **Community Resources Ltd** — only catalogue hit tagged `social-enterprise` + Indigenous + NT.
+- **Fortescue / Rio Tinto / BHP Foundations** — large corporate-RAP procurement route (WA/national, high ceiling, hard access).
+- ⚠️ **Land-council / mining-benefit trusts** (Tiwi, Anindilyakwa, Mirarr, Karrkad-Kanjdji, etc.) are **community-controlled** — better framed as **partners/co-owners** than funders. Hold for the partner track, not Supporter Journey.
+
+---
+
+## BATCH 2 — ENRICH the existing 13 (add real human contacts + correct stages)
+
+Email surfaced real contacts/intel the GHL records are missing. These are **updates, not new records**:
+
+| Existing record | Add / correct | From email |
+|---|---|---|
+| **Snow Foundation** | Add Sally Grimsley-Ballard (S.Grimsley-Ballard@snowfoundation.org.au), Georgina Byron, Ashley Machuca | Live "Goods Draft Proposal" 2026-04-13 — keep at Stewarding or move to Ask made |
+| **QIC** | Add Justin Welfare (jwelfare@qic.com), Cat Vecchio, Cat Sullivan | NAIDOC beds + 2026 opportunities, active |
+| **The Funding Network** | ⚠️ GHL contact = Kristen Lark; email shows **Madeline Alderuccio** (madeline.alderuccio@thefundingnetwork.com.au) — confirm current contact | Grant distributed Dec 2025, in 6-month reporting |
+| **Red Dust** | Add Bridgit McMullen (bridgit@reddust.org.au) alongside Fiona Scicluna | Active washing-machine coordination |
+| **Centrecorp** | Randle Walker correct ✅ | ⚠️ **Time-sensitive** — board applications closed 17/05 (now passed); confirm outcome/next window |
+| **FRRR** | Steph Pearson correct ✅ | Acquittal done; ⚠️ **VFFF is FRRR's co-funder** — VFFF warmth is *via FRRR*, no direct thread |
+| **AMP Foundation** | program inbox only (amp_foundation@amp.com.au), no human | EOI; awaiting reply / dormant |
+
+---
+
+## BATCH 3 — ⚠️ Reclassify / flag (decisions for Ben)
+
+1. **3 of the current "13" aren't foundations** (GrantScope confirms no philanthropic-funder row): **Mala'la Health**, **Homeland School**, **Julalikari Council** are buyers/partners (income, not philanthropy). Leave in Supporter Journey as income relationships, or move to Demand/Buyer? → your call.
+2. **Centrecorp network dedup:** two related trusts share `centrecorpfoundation.com.au` (Central Aboriginal Charitable Trust / Central Australian Aboriginal Charitable Trust). Do **not** create as separate cold prospects.
+3. **Outback Stores + Charles Darwin University** scored high but are a **remote-retail distribution channel** and a **university** — these are the buyer/partner "anchor gap" from the operating model, not Supporter-Journey funders.
+
+---
+
+## BATCH 4 — Buyers/partners seen (parked for the buyers phase)
+PICC (Narelle Gleeson-Henaway, Mislam Sam), Oonchiumpa (Kristy Bloomfield, Tanya Turner), Anyinginyi Health (Tony Miles). Zinus = supplier (advisory), not a buyer.
+
+---
+
+## Coverage gaps (be honest about these)
+- **accounts@ / hi@ are thinly synced** — funder threads living only there may be missed. A live `gmail-deep-search` of those two would close it.
+- **GrantScope cold prospects have NO contacts** — they need a contact-enrichment pass (web research / Notion Foundations DB) before they're outreach-ready. They'd enter GHL at `Identified` with a placeholder until enriched.
+- **3 GHL funders had no Goods email** (Mala'la, Rotary Eclub Outback, Homeland School) — pre-sync or in the thin mailboxes.
+
+---
+
+## Proposed execution (on approval)
+Writes go through the act-infra GHL service (`scripts/lib/ghl-api-service.mjs` — GHL MCP can't create opportunities), extending the existing `scripts/seed-goods-supporter-journey.mjs` pattern. All adds carry the tag convention: `goods` + `goods-funder`/`goods-supporter` + `goods-<warmth>` + `act-gd` + `project:act-gd`.
+
+**Decisions needed before I write:**
+1. Batch 1a + 1b (9 NEW foundations) — add all, or a subset?
+2. Batch 2 enrichment — apply now, or hold?
+3. Batch 3 reclassification — leave the 3 non-foundations, or move them?
+4. How many of the Batch 1c cold prospects to seed at `Identified` (top 5 / top 10 / none yet)?

--- a/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/buyers-candidates.md
+++ b/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/buyers-candidates.md
@@ -1,0 +1,110 @@
+# Goods on Country — Commercial BUYER pipeline candidates
+
+**Generated:** 2026-05-27 · read-only research. Only this file written. NO writes to GHL / Gmail / Notion / Xero.
+**Scope:** commercial demand for beds + washing machines in remote/First Nations communities — councils, ACCHOs/health services, land councils, remote stores, Aboriginal corporations.
+
+> **No name, email, or phone below was invented.** "none found" = no real contact located in any source consulted. Scores are GrantScope-author-set unless marked **inferred**.
+
+---
+
+## Buyer source + dedup baseline
+
+**GrantScope buyer scoring is TWO tables in the shared ACT DB (`tednluwflfhxyucgwigh`, verified via `get_project_url`):**
+
+1. **`goods_communities`** — 1,542 communities, 1,537 with `demand_beds > 0`. This is what `grantscope/scripts/push-ghl-targets.mjs` scores. The scoring formula (`scoreCommunity()`):
+   `score = (beds×$850 + washers×$1,200 + fridges×$1,500) × remoteness_mult × entity_mult × funding_signal`
+   - remoteness: Very Remote ×2.0 / Remote ×1.5 / Outer Regional ×1.0 / else ×0.8
+   - entity_mult: `min(2.0, 1 + community_controlled_org_count×0.1)`
+   - funding_signal: ×1.3 if `total_govt_contract_value > 0` else ×1.0
+   - tier: demand $ > $500K = hot, > $100K = warm, else nurture
+   - **The 61 `"<COMMUNITY> — Goods Demand $XK"` rows in the Demand Register are this script's output** — it upserts a *community* as a GHL contact with a synthetic `<slug>@goods.civicgraph.io` email. These are signal placeholders, NOT buyers, exactly as the operating model says.
+
+2. **`goods_procurement_entities`** — 4,553 rows, the *named* buyer orgs mapped to communities (`buyer_role`, `fit_score`, `govt_contract_value`, `estimated_annual_spend`, `is_community_controlled`). This is what the **grantscope `/api/goods/buyer/push-ghl` route** (`pushGoodsBuyerToGHL`) and **`sync-ghl-goods-buyers.mjs`** operate on — a named entity graduates to the **Buyer Pipeline** with `ghl_stage_name='Outreach Queued'`. Only **26 of 4,553** have a `ghl_opportunity_id`; **18 are stores** (the named "… Community Store Aboriginal Corporation" rows in the Demand Register), 5 council, 2 health, 1 housing.
+   - `buyer_role` distribution: community_org 2,392 · council 925 · health_service 419 · education 375 · other 220 · government 115 · housing_provider 51 · store 23 · land_council 19 · aged_care 12.
+   - **`fit_score` is sparse**: only **15 distinct named entities score ≥ 60**; the 50-59 band adds just 2 (both QLD regional councils). Everything else is sub-50 or AusTender contract noise (defence: Sikorsky, QinetiQ, maritime — `buyer_role='other'`, ignore).
+
+3. **Goods v2 `outreach-targets.ts`** (475-line hand-curated list, "synced from grantscope intelligence Mar 16 2026") is the *richer* buyer source — it has named humans + relationship status the auto-scored DB lacks. v2's `/api/admin/targets/push-outreach` maps `category` → `buyer/capital/partner` and pushes via `ghl.createStrategicTargetContact`. Its `procurement_buyer` + `health_buyer` categories are the warm commercial buyers (Centrebuild, WHSAC/Groote, Outback Stores, ALPA, Tangentyere, West Arnhem council, Anyinginyi, Miwatj, Purple House). **These two systems are NOT cross-synced** — the v2 curated buyers mostly are NOT in the GrantScope `goods_procurement_entities` scoring.
+
+**Dedup baseline (live GHL, location `agzsSZWgovjwgpcoASWG`, fetched this session):**
+- **Demand Register (`UQsrmuqzxMSdCTklxEcG`): 86** — ~25 named per-community store/health/council Aboriginal Corporations + ~61 `"<COMMUNITY> — Goods Demand $XK"` community placeholders.
+- **Buyer Pipeline (`FjMyJM3YzWQFmKqR9fur`): 1** — `Northern Land Council — GAPUWIYAK` (Matthew Ryan). **NLC is therefore already worked — excluded from new prospects below.**
+
+---
+
+## Table 1 — NEW commercial-buyer prospects (deduped vs the 86 + the 1)
+
+Ranked by GrantScope `fit_score` then govt-contract value. All are NOT in the Demand Register and NOT in the Buyer Pipeline (one NLC row excepted — already in BP). **No real contact is on record in `goods_procurement_entities` for any of these (`contact_surface` is null across the board) — contacts shown are cross-referenced from the warm Gmail mine / v2 curated list where a real one exists; otherwise "none found — needs sourcing".**
+
+| # | Entity | Type / buyer_role | Fit (author-set) | Geography | Govt contract signal | Named contact on record | Proposed pipeline + reasoning |
+|---|---|---|---|---|---|---|---|
+| 1 | **Canteen Creek Store Charitable Trust** | remote store | 86 | Canteen Creek, NT (Very Remote) | $0 | none found | **Demand Register** — top auto-score but no human, no live thread. Signal only until a contact + reason exist. |
+| 2 | **The Arnhem Land Progress Aboriginal Corporation (ALPA)** | store network (CC) | 85 | NT (Arnhem Land, multi-store) | $15.5M | none found in DB; v2 lists as `procurement_buyer` prospect, no email | **Demand Register → fast-track** — anchor distribution channel (see Table 3). Largest Aboriginal-owned store network. Graduate to Buyer Pipeline the moment a named buyer/procurement lead is sourced. |
+| 3 | **Tangentyere Council Aboriginal Corporation** | council (CC) | 85 | Alice Springs town camps, NT | $3.11M | none found in DB; v2 `procurement_buyer` prospect, no email | **Demand Register → fast-track** — town-camp housing/services buyer, in v2 curated list. Needs named contact. |
+| 4 | **Outback Stores Pty Ltd** | remote store operator | 85 | NT/QLD/WA/SA (national remote) | $92K | none found in DB; v2 `procurement_buyer` prospect, no email | **Demand Register → fast-track** — key distribution-channel anchor (Table 3). |
+| 5 | **Miwatj Health Aboriginal Corporation** | ACCHO (CC) | 85 | Galiwin'ku / East Arnhem, NT | $48K | **Madelyn Hay** `madelyn.hay@miwatj.com.au` (warm — "beds and washing machines east arnhem", to Nov 2025); v2 lists "Jessica Allardyce" | **BUYER PIPELINE** — named human + live East Arnhem beds/washers thread = graduation rule met. RHD-prevention fleet across 8 clinics (v2). Strongest scored-buyer + warm-contact overlap. |
+| 6 | **Aputula Housing Assoc Inc** | housing provider | 78 | Finke, NT (Very Remote) | $0 | none found | **Demand Register** — housing buyer, no contact/thread. (NB partial-dup: "Aputula Housing Aboriginal Corporation — FINKE" already a DR store row; confirm same entity before any push.) |
+| 7 | **Ntaria School Council Inc** | council | 78 | Hermannsburg, NT (Very Remote) | $0 | none found | **Demand Register** — signal only. |
+| 8 | **Central Land Council** | land council (CC) | 74 | NT (271 communities) | $20.8M | none found | **Demand Register** — peak land council, huge footprint, but a land council is a representative body, not a direct bed/washer buyer; treat as channel/intro until a named procurement reason appears. |
+| 9 | **Anindilyakwa Housing Aboriginal Corporation** | housing provider (CC) | 74 | Groote Eylandt, NT (17 communities) | $3.10M | none found in DB — but see Groote/WHSAC v2 demand (500 mattresses + 300 washers) | **Demand Register → high-priority** — Groote is the flagship demand signal in v2 (`whsac-groote`, Simone Grimmond). Housing arm is a real buyer; pair with WHSAC + Groote Trust. Graduate once Simone Grimmond contact is confirmed. |
+| 10 | **Tiwi Land Council** | land council (CC) | 74 | Tiwi Islands, NT (9 communities) | $3.02M | none found | **Demand Register** — channel/intro body. |
+| 11 | **Aboriginal Medical Services Alliance NT (AMSANT)** | ACCHO peak body (CC) | 74 | NT (338 communities) | $2.12M | none found | **Demand Register** — peak body / sector door-opener, not a per-community buyer; use for warm intros to member ACCHOs. |
+| 12 | **Anindilyakwa Land Council** | land council (CC) | 74 | Groote Eylandt, NT | $270K | none found | **Demand Register** — pair with Groote cluster (#9). |
+| 13 | **Central Desert Regional (Shire) Council** | regional council | 66 | NT (271 communities, Very Remote) | $16.85M | none found | **Demand Register → high-priority** — large remote-council procurement budget, multiple communities. Classic commercial buyer; needs a named procurement/assets contact. |
+| 14 | **Tiwi Islands Regional Council** | regional council | 66 | Tiwi Islands, NT | $6.72M | none found | **Demand Register** — remote council, multi-community. Needs contact. |
+| 15 | **Torres Strait Island Regional Council** | regional council | 50 | QLD (Torres Strait, 9 islands) | $5.54M (spend $833K) | none found | **Demand Register → high-priority** — only material QLD remote-council buyer in the scoring; ~$833K estimated annual spend. Needs contact. |
+| 16 | **Northern Peninsula Area Regional Council** | regional council | 50 | Cape York / NPA, QLD | $1.74M (spend $413K) | none found | **Demand Register** — QLD remote council, real spend. Needs contact. |
+
+**Reality check on count:** GrantScope's *scored named-buyer universe* is far thinner than the 4,553 row total suggests — only **16 distinct named entities** clear a fit ≥ 50 and survive noise-filtering. To reach "~25 NEW prospects" I add the **v2 curated `procurement_buyer`/`health_buyer` targets that are NOT in GHL and NOT scored in `goods_procurement_entities`** — these are real, warm, and named, just living in `outreach-targets.ts` instead of the DB:
+
+| # | Entity (from v2 curated list) | Type | Signal | Named contact | Proposed pipeline + reasoning |
+|---|---|---|---|---|---|
+| 17 | **Centrebuild Pty Ltd** | procurement buyer | "109 beds sold; 107-bed Utopia pathway active" | none named in v2 | **BUYER PIPELINE** — strongest *commercial* signal in the whole set (already buying). Graduation rule met on "reason to talk"; source the buyer contact. |
+| 18 | **WHSAC (Groote Archipelago)** | procurement buyer | "500 mattresses + 300 washing machines (~$1.7M)" | **Simone Grimmond** | **BUYER PIPELINE** — named human + the single largest stated order. Pair with #9/#12 Groote cluster. |
+| 19 | **Tangentyere Council** *(v2 dup of #3)* | procurement buyer | town-camp households | none | — (same entity as #3; merge) |
+| 20 | **Purple House** | health buyer | "dialysis patients need quality beds" | none named | **Demand Register** — real buyer thesis, no contact yet. |
+| 21 | **West Arnhem Regional Council** | procurement buyer | "multiple remote communities" | none named | **Demand Register** — remote council buyer; **NOT in GrantScope scoring (gap)**. |
+| 22 | **NPY Women's Council** | community buyer | "always looking for beds" (3 jurisdictions) | **Angela Lynch** | **BUYER PIPELINE** — named human + standing demand; cross-border NT/SA/WA. (Verify Angela Lynch still current.) |
+| 23 | **NDIS Assistive Technology pathway** | govt procurement channel | recurring procurement | none (program) | **Demand Register** — channel research, not an org. |
+| 24 | **Anyinginyi Health Aboriginal Corp** | health buyer | "5 washers deployed, quote for 4 more Feb 2026" | **Tony Miles** `tony.miles@anyinginyi.com.au` | **see Table 2** — already buying washers commercially (warm). Classification nuance below. |
+| 25 | **QIC** | corporate buyer | "50-bed staff-build NAIDOC interest" | **Justin Welfare** `jwelfare@qic.com` et al | **see Table 2** — corporate procurement/CSR buyer, warm. |
+
+---
+
+## Table 2 — Warm Gmail-org classification (the operating-model crux)
+
+Decision per the rules: **Buyer Pipeline** = commercial, named human, reason to talk · **Demand Register** = signal · **delivery partner** = grant-funded delivery (NOT a buyer).
+
+| Org | Named human(s) on record | Verdict | Why |
+|---|---|---|---|
+| **PICC (Palm Island Community Company)** | Narelle Gleeson-Henaway `Narelle@picc.com.au`; Mislam Sam `mislams@picc.com.au` | **delivery partner** (with a commercial tail) | Backing-the-Future / FRRR-funded delivery site — beds delivered TO Palm Island via grant. BUT v2 records "141 beds deployed + 40-bed order + 'we'll buy the facility'" → there IS a genuine commercial buyer signal emerging. **Classify as delivery partner now; flag the 40-bed re-order + facility interest as the trigger to spin up a *separate* Buyer-Pipeline record** when the order is commercial (not grant-funded). |
+| **Oonchiumpa (Kristy Bloomfield, Tanya Turner)** | Kristy `kristy.bloomfield@oonchiumpa.com.au`; Tanya `tanya.turner@oonchiumpa.com.au` | **delivery partner** | Co-applicant on the REAL Innovation Fund Goods grant (Utopia/Sandover). Aboriginal-owned community-led design partner / lead applicant — delivers WITH us via grant, does not pay its own way. Not a buyer. |
+| **Anyinginyi Health (Tony Miles)** | Tony Miles `tony.miles@anyinginyi.com.au` | **BUYER PIPELINE** (lean) | The clearest *commercial* ACCHO buyer: "5 washers deployed, quote for 4 more sent Feb 2026" (v2) — paying for washers. Named human + live quote = graduation rule met. (Also appears on the Rotary Global Grant route — that's a funder thread, keep separate.) |
+| **Miwatj Health (Madelyn Hay)** | Madelyn Hay `madelyn.hay@miwatj.com.au` | **BUYER PIPELINE** | Named human + live "beds and washing machines east arnhem" thread + GrantScope fit 85. RHD-prevention fleet across 8 clinics. (= Table 1 #5.) |
+| **NT Govt (Amy Elson)** | Amy Elson `amy.elson@nt.gov.au` (Gmail); v2 lists Anna Philip `anna.philip2@nt.gov.au` | **Demand Register** (funder/govt-channel, not commercial buyer) | East-Arnhem beds/washers coordination + state-govt backing. Government relationship is a funding/endorsement channel, not a self-paying commercial buyer. Keep as signal/relationship; route grant asks to the funder pipeline. |
+| **Bawinanga Aboriginal Corp (Alice Benchoam, Shannon Inder)** | Alice `gm@bawinanga.org.au`; Shannon `shannon.inder@bawinanga.org.au` | **delivery partner** | BAC laundromat launch/monitoring — grant-supported delivery/distribution model (v2 `distribution_partner` prospect). Not paying its own way for beds/washers. Watch for a commercial distribution deal as the trigger to reclassify. |
+| **Wilya Janta (Simon Quilty)** | Simon Quilty `sq@wilyajanta.org`; Norman Frank Jupurrurla | **delivery partner / advisor** | Housing-health research + demonstration home, active bed testing, Tennant Creek anchor. Advocacy/advisor + delivery, explicitly "not a funder" and not a commercial buyer. |
+| **Outback Stores** | none found | **Demand Register → fast-track** | Distribution-channel anchor (Table 1 #4, Table 3). Real commercial-channel potential but no named human yet → can't graduate to Buyer Pipeline. |
+| **Charles Darwin University (CDU)** | none found in mine | **Demand Register** (research/partner, weak buyer signal) | Surfaced as ecosystem; no commercial bed/washer buying signal or named buyer contact located. Hold as signal. |
+
+**Net of the named warm orgs: 3 are true Buyer-Pipeline (Anyinginyi, Miwatj, + emerging PICC-commercial), the rest are delivery partners / govt-funding channels / advisors.** This matches the operating model's prediction that PICC/Oonchiumpa/Bawinanga are grant-delivery, not buyers.
+
+---
+
+## Table 3 — Anchor-gap status (Outback Stores, Centrecorp, Miwatj, ALPA, Tangentyere)
+
+| Anchor entity | In `goods_procurement_entities` (scored)? | In GHL? | Status / gap |
+|---|---|---|---|
+| **Outback Stores Pty Ltd** | **Yes** — fit 85, store, $92K govt | No | **Scored, not in GHL.** Gap = no named contact. Add to Demand Register, fast-track to Buyer Pipeline on contact. National remote-retail distribution channel. |
+| **Centrecorp Foundation** | **No** — not found as a procurement entity (it's a funder/Aboriginal-trust, lives in v2 `aboriginal_trust` + Gmail funder mine: Randle Walker `randle@centrecorp.com.au`) | No (funder side) | **Anchor-gap = mis-bucketed, by design.** Centrecorp is a *capital* anchor (Tennant Creek bed funding, $123K paid / $420K commitment), not a commercial buyer. Belongs in the FUNDER/foundation pipeline, NOT the Buyer Pipeline. Its commercial twin is **Centrebuild Pty Ltd** (v2, 109 beds sold) — that's the buyer. |
+| **Miwatj Health** | **Yes** — fit 85, health_service, CC | No | **Scored + warm contact (Madelyn Hay).** Ready to graduate to Buyer Pipeline now (Table 1 #5 / Table 2). |
+| **ALPA (Arnhem Land Progress)** | **Yes** — fit 85, store, $15.5M govt, CC | No | **Scored, not in GHL.** Gap = no named contact. Highest-value Aboriginal-owned store network; key distribution anchor. |
+| **Tangentyere Council** | **Yes** — fit 85, council, $3.11M, CC | No | **Scored, not in GHL.** Gap = no named contact. Also in v2 curated list. |
+
+**Other anchors the operating model implies but GrantScope is MISSING entirely (scoring gap — flag for backfill):** the marquee remote-council buyers **West Daly, Roper Gulf, MacDonnell, East Arnhem, Barkly, Victoria Daly Regional Councils** and big ACCHOs **Sunrise Health, Katherine West Health, Central Australian Aboriginal Congress, Laynhapuy Homelands, Mala'la Health** are **not present as scored procurement entities** (only AMSANT the peak body is). These are textbook commercial bed/washer buyers and should be added to `goods_procurement_entities` so they get scored rather than relying on the per-community store-corp rows.
+
+---
+
+## Open items / gaps
+- **No contact data in `goods_procurement_entities`** — every scored buyer has `contact_surface = null`. The buyer scoring identifies *which orgs* but carries *zero humans*; contacts only exist in the v2 curated list + Gmail mine. Closing the named-human gap is the blocker on graduating scored buyers to the Buyer Pipeline.
+- **GrantScope vs v2 are not synced** — the warm commercial buyers (Centrebuild, WHSAC, Anyinginyi, Purple House, West Arnhem, NPY) live only in `outreach-targets.ts`; the scored buyers (ALPA, Tangentyere, Central Desert, Tiwi, Torres Strait) live only in the DB. A reconcile pass would de-risk double-entry.
+- **Source not reached:** none — Supabase, both GHL pipelines, both scripts, the v2 route + data files, and both Gmail handoffs were all read. The only data *absence* is genuine (null contacts in the scoring table), not an access failure.

--- a/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/enrichment.md
+++ b/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/enrichment.md
@@ -1,0 +1,78 @@
+# Goods on Country — Foundation Shell Enrichment + Nic's Recent Goods People
+
+**Generated:** 2026-05-27 · read-only research, NO writes to GHL/Gmail/Notion/Xero. Only local file.
+
+> ## ✅ EXECUTED 2026-05-27 — `scripts/enrich-goods-foundation-contacts-2026-05-27.mjs --apply`
+> Supporter Journey **32 → 35**. 0 errors.
+> - **2 shells promoted to real humans** (updateContact, tags VERIFIED preserved): Minderoo → Lucy Stronach; Paul Ramsay → William Frazer.
+> - **3 NEW foundation opps + contacts**: The Bryan Foundation (Matthew Cox, Cultivating), The Ian Potter Foundation (Alberto Furlan, Cultivating), Brian M Davis Charitable Foundation (Sarah Bartak, Ask made).
+> - **7 new + 2 re-tagged secondary/route contacts**: Anita Hopkins (BMDCF), Jonas Kubitscheck (PRF), Jay Boolkin + Matt Allen (Social Impact Hub = QBE route), Marty Taylor + Narelle Anderson (Envirobank).
+> - **QBE shell left as company-record** — route is via Social Impact Hub (Jay Boolkin), now captured as contacts.
+> - **11 shells still have no real contact** (Rio Tinto, BHP, Fortescue, Frontier Services, Community Resources, Yeperenye, Nova Peris, ACF, NAACT, Country Connect, Mjd) — no published decision-maker email; need warm intro or program-inbox/web-form approach, NOT a fabricated contact.
+
+## Method & sources
+
+- **Primary:** Supabase `communications_history` (Gmail sync, project `tednluwflfhxyucgwigh` — verified). Mailbox identified by `metadata->>'from'`/`->>'to'` containing `nicholas@act.place`; counterparty humans read from those same headers. No `mailbox` column exists; `metadata->>'handle'` is phone numbers (iMessage rows), not mail. 13,614 synced emails, Jul 2025 → 25 May 2026. nicholas@-involved Goods-ish mail since 2025-11-01: **238 messages**.
+- **Live `scripts/gmail-deep-search.mjs`:** NOT run. It is a receipt-by-vendor-and-date matcher (Xero-attachment workflow), not a free-text funder/person discovery tool, and the synced DB already holds full from/to/subject for all four mailboxes. Recency is covered to 25 May 2026 in the sync. **Coverage gap unchanged from the prior mine:** accounts@ (181) and hi@ (283) are thinly synced; a funder thread living only there could be missed. Not a blocker for nicholas@, which is well covered (1,752 rows).
+- **Web research:** used for the shells with zero email presence. Foundation aggregator sites (ZoomInfo/RocketReach) name people but **redact the actual email and conflict on current role-holders** — those are recorded as "name only / web — verify", never as a usable address.
+- **GHL / Notion:** not separately queried for shell contacts — the email DB resolved the high-value shells (QBE, Minderoo, Paul Ramsay) with real verified humans, and the rest have no individual published email regardless of source. Flag if a GHL/Notion pass is wanted for the unresolved 10.
+
+**No name, email, or phone below was invented. "NONE FOUND" means no real published contact was located in any source consulted.**
+
+---
+
+## 1. Shell enrichment (the 15 GHL company-shell foundations)
+
+| Shell org | Real contact found (name / email) | Source | Confidence |
+|---|---|---|---|
+| **QBE Foundation** | Route is via **Social Impact Hub**, which administers QBE's "Catalysing Impact" program ACT was *selected into*: **Jay Boolkin** `jay@socialimpacthub.org`, **Matt Allen** `matt.allen@socialimpacthub.org` (also Malcolm Aikman `malcolm.aikman@socialimpacthub.org`). QBE's own foundation has no individual ACT contact — only comms staff (Alyssia El Gawly `alyssia.elgawly@qbe.com`, Sophia Elliott `sophia.elliott@qbe.com`, web-listed, low value). | mail (SIH) + web (QBE comms) | **verified** (SIH humans, live threads) / web-verify (QBE comms) |
+| **Minderoo Foundation** | **Lucy Stronach** `lstronach@minderoo.org` (primary, ~25 threads incl. "Goods. and thank you" 2026-04-08); **Roy McNamara-Smith** `rsmith@minderoo.org` (cc'd on JusticeHub overview). Bulk of relationship is JusticeHub/CONTAINED, but Goods is explicitly on the table with Lucy. | mail | **verified** |
+| **Paul Ramsay Foundation** | **William Frazer** `wfrazer@paulramsayfoundation.org.au` and **Jonas Kubitscheck** `jonas@paulramsayfoundation.org.au` — ACT (Nic + Ben) + Oonchiumpa met with them ("Lunch at PRF" Oct 2025 → "Thank you for meeting with us" through Mar 2026). PRF also runs a **First Nations Targeted Grant Round** (up to $500K, remote NT/Qld/SA) under Chief First Nations Officer **Michelle Steele** (web; no published email). | mail (Frazer/Kubitscheck) + web (Steele) | **verified** (Frazer/Kubitscheck) / web-verify (Steele) |
+| **Developing East Arnhem Limited (DEAL)** | DEAL the org: **NONE FOUND** direct. Web names the CEO inconsistently (**Luke Walker** per ZoomInfo vs **Paul Dobing** per RocketReach) — unverifiable, no email. NB: ACT's *East Arnhem Goods threads* are with the **region's delivery bodies**, not DEAL: **Madelyn Hay** (Miwatj Health) `madelyn.hay@miwatj.com.au`; **Amy Elson** (NT Govt) `amy.elson@nt.gov.au` — "beds and washing machines east arnhem communities", to Nov 2025. | web (DEAL name) / mail (region delivery) | web-verify only (DEAL); verified (region contacts) |
+| **Mjd Foundation Limited** | **NONE FOUND** (no published email). Web names a CEO — sources conflict (**Jacquie Hatt** current per one listing; co-founder **Nadia Lindop OAM** departed early 2024). Org email format published as `first.last@mjd.org.au`; general line +61 1300 584 122. No live ACT thread. | web | web-verify (name only, no email) |
+| **Northern Australian Aboriginal Charitable Trust (NAACT)** | **NONE FOUND.** = charitable arm of **Aboriginal Investment Group (AIG)**; runs the **Remote Laundries Project** (`remotelaundries.org.au`) — Goods' exact domain, a peer/partner as much as a funder. A "Brittany Ciupka, Project Officer" is referenced online but no email. No ACT email thread. | web | none found (no individual email) |
+| **Fortescue Foundation** | **NONE FOUND.** Community Grants run through `fmgl.com.au/communitygrants`; no individual philanthropy-manager email published. Parent of Minderoo (Forrest family). No ACT email thread. | web | none found |
+| **Rio Tinto Foundation** | **NONE FOUND.** No individual contact published; no ACT email thread. | — | none found |
+| **BHP Foundation** | **NONE FOUND.** No individual contact published; no ACT email thread. | — | none found |
+| **Country Connect Foundation Limited** | **NONE FOUND** (no decision-maker email). First Nations-led NT remote-services org; founders **Troy Barrett** & **Louise Lethbridge** (2020, web); only `recruitment@countryconnect.org.au` published. No ACT email thread. | web | web-verify (founder names only, no usable email) |
+| **Uniting Church Australia Frontier Services** | **NONE FOUND.** No individual contact located; no ACT email thread. | — | none found |
+| **Community Resources Limited** | **NONE FOUND.** No individual contact located; no ACT email thread. | — | none found |
+| **The Trustee For Yeperenye Charitable Trust** | **NONE FOUND.** Central Australian (Alice Springs) Indigenous community trust; no individual email; no ACT email thread. | — | none found |
+| **Nova Peris Foundation** | **NONE FOUND.** Founder **Nova Peris OAM** (LinkedIn); foundation contact page exists (`novaperisfoundation.org.au/contact-us`) but no individual email surfaced. No ACT email thread. | web | web-verify (founder name only, no email) |
+| **Australian Communities Foundation** | **NONE FOUND** (individual). ACF has a First Nations giving focus area + grant rounds; Philanthropy Team line 03 9412 0412, individual emails redacted on web. No ACT email thread. | web | none found (no individual email) |
+
+**Scoreboard:** 3 shells fully resolved with verified humans (QBE-via-SIH, Minderoo, Paul Ramsay). 1 partial (DEAL — region delivery contacts found, the foundation itself not). 11 = no real individual contact found (web names where they exist are aggregator-sourced and unverifiable / no email).
+
+---
+
+## 2. Nic's recent Goods people (NEW — not in GHL Goods Supporter Journey or the prior gmail mine)
+
+Swept nicholas@act.place Goods-ish mail since Nov 2025. Excludes everyone already in the dedup list and everyone already captured in `gmail-funders.md` (Snow, Centrecorp, QIC, FRRR, VFFF, TFN, Red Dust, John Villiers, Philanthropy Australia, Rotary, AMP, Julalikari, Our Community Shed, PICC, Oonchiumpa, Anyinginyi, Zinus, REAL Innovation Fund).
+
+| Person | Email | Org / family | Last contact | Context (1-line) | Why philanthropist / funder |
+|---|---|---|---|---|---|
+| **Matthew Cox** | `mcox@thebryanfoundation.org.au` | **The Bryan Foundation** (Brisbane; Bryan Family Group — `mtaylor@bryanfamilygroup.com.au` also on thread) | 2025-11-06 | "BFF + Goods" — direct Goods funder thread. | **Family foundation, direct Goods ask.** Standout NEW funder. |
+| **William Frazer** | `wfrazer@paulramsayfoundation.org.au` | **Paul Ramsay Foundation** | 2026-03-24 | "Lunch at PRF" → "Thank you for meeting with us" (with Oonchiumpa). | Major foundation; in-person meetings, warm. Also resolves the PRF shell. |
+| **Jonas Kubitscheck** | `jonas@paulramsayfoundation.org.au` | **Paul Ramsay Foundation** | 2026-03-24 | On the same PRF meeting thread. | Major foundation contact. |
+| **Sarah Bartak** | `sarah.bartak@brianmdavis.org.au` | **Brian M Davis Charitable Foundation** (BMDCF) | 2026-04-30 | "Good Design Feedback" — a Goods design/application review (apps inbox `applications@brianmdavis.org.au`). | **Charitable foundation reviewing a Goods application.** NEW funder. |
+| **Anita Hopkins** | `anita.hopkins@brianmdavis.org.au` | **Brian M Davis Charitable Foundation** | 2026-04-30 | Same BMDCF "Good Design Feedback" thread. | Foundation staff on a live Goods app. |
+| **Alberto Furlan** | `alberto.furlan@ianpotter.org.au` | **The Ian Potter Foundation** | 2026-04-26 | "Goods Check in and Hi" (Nic → Alberto). | **Major national foundation, direct Goods check-in.** Standout NEW funder. |
+| **Teya Dusseldorp** | `teya@dusseldorp.org.au` | **Dusseldorp Forum** (family foundation; CEO, Dusseldorp family) | 2026-04-01 | "CONTAINED Tour // Reconnection" + "DF, Mounty, ACT catch up" (with Margot Beach `margotbeach@`, Jessica Duffy `jessicaduffy@`, Scarlett Steven `scarlettsteven@`). | **Family-foundation CEO, warm active relationship.** Thread is CONTAINED/Mounty Yarns (JusticeHub-side) more than Goods — funder relationship, Goods-adjacent. |
+| **Marty Taylor** | `mtaylor@envirobank.com.au` | **Envirobank** (Narelle Anderson `nanderson@envirobank.com.au` also) | 2026-02-26 | "Envirobank + Goods" — sustained back-and-forth (13 msgs). | Corporate partner/funder exploring a Goods tie-up. NEW. |
+| **Jay Boolkin** | `jay@socialimpacthub.org` | **Social Impact Hub** (admins QBE "Catalysing Impact") | 2026-04-13 | "Catalysing Impact" selection + "QBE Program Induction" + "Investment Readiness Diagnostic". | **Door to QBE Foundation funding** + investment-readiness support. Standout — resolves the QBE shell. |
+| **Matt Allen** | `matt.allen@socialimpacthub.org` | **Social Impact Hub** | 2026-04-28 | "ACT Diagnostic Session" — investment-readiness diagnostic for ACT. | Capacity/funder-readiness partner; QBE program route. |
+
+### Seen but NOT classified as new funders (logged for completeness)
+- **Simon Quilty** `sq@wilyajanta.org` (Wilya Janta) — housing/health researcher & advocate, Tennant Creek; **partner/advisor**, not a funder.
+- **Alice Benchoam** `gm@bawinanga.org.au` / **Shannon Inder** `shannon.inder@bawinanga.org.au` (Bawinanga Aboriginal Corp) — **delivery partner** (BAC laundromat launch/monitoring), not a funder.
+- **Mark @ Speed Queen** `mark@speedqueenlaundry.com.au` — laundry-equipment **vendor**, not funder.
+- **Sam/Millie/Todd/Will @ Defy Design** `*@defydesign.org` — Goods design/build **collaborators**, not funders.
+- Dusseldorp's `daniel@justreinvest.org.au` / `nicole@justreinvest.org.au` (Just Reinvest) sit on the CONTAINED/JusticeHub thread — **JusticeHub-side**, not Goods funders.
+
+---
+
+## Notes for the GHL/pipeline pass
+- **3 standout NEW philanthropic foundations to add to the Goods journey:** **The Bryan Foundation** (Matthew Cox — direct "BFF + Goods"), **The Ian Potter Foundation** (Alberto Furlan — "Goods Check in"), **Brian M Davis Charitable Foundation** (Sarah Bartak / Anita Hopkins — live "Good Design Feedback" application). All three are genuinely new, named-human, Goods-specific.
+- **Two of the 15 shells are really resolved through intermediaries, not the foundation directly:** QBE → Social Impact Hub (Jay Boolkin), and DEAL → the East Arnhem region's Miwatj/NT-Govt contacts. Tag accordingly so outreach goes to the live human, not a dead foundation inbox.
+- **Paul Ramsay shell** has two warm, email-verified humans (Frazer, Kubitscheck) — promote from shell to active.
+- **10 shells have no individual contact in any source** (Rio Tinto, BHP, Fortescue, Frontier Services, Community Resources, Yeperenye, Nova Peris, Australian Communities Foundation, NAACT, Country Connect). These need either a direct web-form/program-inbox approach or a warm intro — no decision-maker email is published. Do NOT fabricate one.

--- a/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/gmail-funders.md
+++ b/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/gmail-funders.md
@@ -1,0 +1,71 @@
+# Goods on Country — Foundation / Funder Email Mining
+
+**Generated:** 2026-05-27 · read-only mine, no Gmail writes performed.
+
+## Coverage
+
+Source: **Supabase `communications_history` table** (the Gmail sync target — `scripts/sync-gmail-to-supabase.mjs` writes here via service-account domain-wide delegation across all four mailboxes). Querying the synced DB was chosen over live `gmail-deep-search.mjs` runs because that script is purpose-built for receipt-by-vendor-and-date matching, not free-text funder discovery, and the DB already holds the full body of synced mail. All four ACT mailboxes are represented in the data:
+
+| Mailbox | Emails synced (in DB) |
+|---|---|
+| benjamin@act.place | 8,705 |
+| nicholas@act.place | 1,390 |
+| hi@act.place | 283 |
+| accounts@act.place | 181 |
+| (cc-only / metadata-empty) | 3,055 |
+
+- **Total synced email:** 13,614 rows · **date range Jul 2025 → 25 May 2026.**
+- **COVERAGE CAVEAT:** the sync is heavily benjamin@-weighted; `accounts@` (181) and `hi@` (283) are thinly represented. Funder threads that lived *only* in accounts@ or hi@ (e.g. acquittal invoices, application-portal confirmations) may be under-counted. Most Goods funder relationships run through nicholas@ and benjamin@, which are well covered, so the funder list below is believed near-complete — but a live `gmail-deep-search`-style sweep of accounts@/hi@ would be the way to close the gap. No auth failures encountered (DB path needed no Gmail auth).
+- Sender/recipient humans were read from `metadata->>'from'` / `metadata->>'to'` (the `contact_name`/`contact_email` columns are largely null on these rows). Every name/email/date below is copied from email metadata — none invented.
+
+---
+
+## NEW funders (not in the 13-funder GHL Goods Supporter Journey)
+
+| Org | Named contact(s) | Email / phone | Mailbox(es) | Most recent msg | Thread state (1-line) | Warmth | Funder/Buyer |
+|---|---|---|---|---|---|---|---|
+| **REAL Innovation Fund (DEWR — federal grant program)** | "DEWR - REAL Innovation Fund" (program inbox) | REALInnovationFund@dewr.gov.au | benjamin@ | 2026-03-27 | EOI + request-for-additional-info exchange for "Goods Project" via Palm Island Community Company / Oonchiumpa; Ben chasing status. No named human — program inbox only. | active conversation | funder (govt grant) |
+| **The John Villiers Trust** | Fiona Maxwell (CEO) | ceo@jvtrust.org.au | nicholas@, benjamin@ | 2026-04-29 ("Checking in") | Warm relationship via Philanthropy Australia intro; funding a video project + asking about travel costs. Not (yet) a Goods bed/washer $ ask — adjacent funder, relationship-building. | active conversation | funder |
+| **Philanthropy Australia (peak body / convener)** | Kim Harland | kim@philanthropy.org.au | nicholas@, benjamin@ | 2026-05-05 | "Introducing A Curious Tractor and Philanthropy Australia" thread + PA Conference video featuring Goods. Convener/network, not a grant-maker itself, but a live $-adjacent door-opener. | active conversation | funder-adjacent (convener) |
+| **Rotary Global Grant (application network)** | Pene Curtis; Tony Miles (Anyinginyi Health); Greg (Marlow Canete); Anne Gripper | pene.curtis@bigpond.com · tony.miles@anyinginyi.com.au · greg@marlowcanete.com.au · anne.gripper@outlook.com | nicholas@, benjamin@ | 2026-04-20 | Active "Rotary Global Grant Application" drafting thread (washing machines / beds angle) — multiple advisors helping ACT structure a Rotary global grant. NB: distinct from the GHL "Rotary Eclub Outback Australia" entry; could not confirm Eclub Outback specifically in mail. | active conversation | funder (grant route) |
+
+---
+
+## KNOWN funders (in the GHL Goods Supporter Journey) — confirmed in email
+
+| Org | Named contact(s) | Email / phone | Mailbox(es) | Most recent msg | Thread state (1-line) | Warmth | Funder/Buyer |
+|---|---|---|---|---|---|---|---|
+| **Snow Foundation** | Sally Grimsley-Ballard; Georgina Byron; Ashley Machuca | S.Grimsley-Ballard@snowfoundation.org.au · g.byron@snowfoundation.org.au · A.Machuca@snowfoundation.org.au | nicholas@, benjamin@ | 2026-04-13 | "DRAFT Snow Foundation Principles / Goods Draft Proposal" — live proposal drafting; Sally supported a bed at their RHD event; warm, supportive. | active conversation | funder |
+| **FRRR (Foundation for Rural & Regional Renewal)** | Steph Pearson | s.pearson@frrr.org.au · application portals: mail@grantapplication.com, noreply@yourcause.com | nicholas@, hi@ | 2026-03-31 | "Backing the Future acquittal — Goods, Palm Island" — acquittal completed & praised; Steph wants to keep finding ways to work together. **Preview reveals VFFF is FRRR's co-funder on this program.** | active conversation | funder |
+| **Vincent Fairfax Family Foundation (VFFF)** | (via FRRR — no direct ACT thread found) | — (referenced, not corresponded with directly in synced mail) | nicholas@ (indirect) | 2026-03-29 (mention) | Steph Pearson (FRRR): "I have passed onto VFFF, will share your media with them too when we meet this arv." VFFF is the co-funder behind Backing the Future; warm by proxy, no direct VFFF email in DB. | warm (indirect) | funder |
+| **The Funding Network (TFN)** | Madeline Alderuccio | madeline.alderuccio@thefundingnetwork.com.au · info@thefundingnetwork.com.au (newsletter) | nicholas@, benjamin@ | 2026-03-30 | "Healthy People Healthy Planet" TFN-pitched grant — FINAL GRANT DISTRIBUTION done Dec 2025; ongoing 6-month impact-update loop. Cohort includes Farm My School / Corena Fund. | active (post-grant reporting) | funder |
+| **Red Dust** | Bridgit McMullen; Fiona Scicluna | bridgit@reddust.org.au · fiona@reddust.org.au | nicholas@ | 2026-03-10 | "Washing Machine" thread (+ Kintore Programs) — active coordination on washing-machine placement. | active conversation | funder/partner |
+| **QIC (Queensland Investment Corp — corporate giving)** | Justin Welfare; Cat Vecchio; Cat Sullivan | jwelfare@qic.com · cvecchio@qic.com · C.Sullivan@qic.com | nicholas@, benjamin@ | 2026-02-15 | "NAIDOC Week Bed Project + 2026 opportunities" and "Laundry Gallery / Print Shop / Nina + QIC" — active corporate-giving relationship, exploring 2026 opportunities. | active conversation | funder (corporate) |
+| **Centrecorp Foundation** | Randle Walker | randle@centrecorp.com.au | nicholas@ | 2026-04-13 | "Tennant Creek Bed Funding" — Randle confirms May Centrecorp Foundation board meeting (applications close 17/05), Board likely OK with reports+photos as acquittal. ACT delivering Utopia homeland beds w/o 18/05. | active conversation — application window open | funder |
+| **AMP Foundation** | (program inbox — no named human) | amp_foundation@amp.com.au | nicholas@ | 2026-02-26 | "AMP Foundation Tomorrow Makers IGNITE – Expression of Interest" — EOI submitted/replied. Generic program address only, no human contact in thread. | awaiting reply / dormant | funder |
+| **Our Community Shed** | "chair@ourshed.org"; Lucy McGarry (coordinator) | chair@ourshed.org · coordinator@ourshed.org.au | benjamin@, nicholas@ | 2026-04-25 | "Our Community Shed + Goods Project" — long active thread; collaboration/partner. (Listed as funder in GHL; reads more like a delivery/community partner.) | active conversation | funder/partner |
+| **Julalikari Council** | Lachlan Wilkins (CEO) | ceo@julalikari.com.au | benjamin@ | 2026-04-14 | Only an auto-reply captured (re Nyinkka Nyunyu cultural reopening invite). Relationship exists but no live Goods-funding thread in synced mail. | dormant / no active Goods thread | buyer/partner (council) |
+
+### KNOWN funders NOT found in synced email
+No Goods-context email found for: **Mala'la Health Service**, **Rotary Eclub Outback Australia** (a separate Rotary-Global-Grant thread exists but not the Eclub specifically), **Homeland School**. Absence here ≠ absence in Gmail — could be in the thinly-synced accounts@/hi@ mailboxes, or pre-Jul-2025 (before sync coverage starts). Flag for a live `gmail-deep-search` sweep if these matter.
+
+---
+
+## Buyers / delivery partners seen (not funders)
+
+| Org | Contact(s) | Email | Role |
+|---|---|---|---|
+| **Palm Island Community Company (PICC)** | Narelle Gleeson-Henaway; Mislam Sam | Narelle@picc.com.au · mislams@picc.com.au | Delivery partner / buyer — "Goods Stretch Beds PICC", Backing-the-Future delivery site (Palm Island), annual-report + Elders work. Heavy active thread w/ benjamin@. |
+| **Oonchiumpa Consultancy** | Kristy Bloomfield; Tanya Turner | Kristy.Bloomfield@oonchiumpa.com.au · Tanya.Turner@oonchiumpa.com.au | Delivery partner — co-applicant on REAL Innovation Fund Goods Project (Utopia / Sandover). Active. |
+| **Anyinginyi Health** | Tony Miles | tony.miles@anyinginyi.com.au | Partner on Rotary Global Grant route (Tennant Creek region). |
+| **Zinus** | Daniel Pittman | daniel.pittman@zinus.com | Bed supplier (on Goods Advisory Group) — vendor, not funder/buyer. |
+
+*Other names on the "Goods // Advisory Group" email (Orange Sky, DeadlyScience, Defy Design, Nina Fitzgerald, SRAU, CYP, Cape York Partnership contacts) are advisors/ecosystem, not funder conversations.*
+
+---
+
+## Notes for the dedup/GHL pass
+- **VFFF** should be tagged "warm via FRRR" not "direct conversation" — there is no direct VFFF↔ACT email in the synced data; the signal is FRRR's Steph Pearson saying she'd pass ACT's Goods media to VFFF.
+- **Centrecorp** has a live application deadline (17/05) — the most time-sensitive open funder loop in this set.
+- **REAL Innovation Fund** and **Rotary Global Grant** are the two most active *new* grant routes.
+- **The John Villiers Trust (Fiona Maxwell)** is the clearest genuinely-new foundation relationship worth adding to the journey — warm, CEO-level, currently funding a video project and "checking in."

--- a/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/grantscope-foundations.md
+++ b/thoughts/shared/handoffs/goods-foundation-pipeline-2026-05-27/grantscope-foundations.md
@@ -1,0 +1,107 @@
+# Goods on Country — Foundation Prospect List (from GrantScope)
+
+**Date:** 2026-05-27
+**Purpose:** Ranked foundation/philanthropic prospects to fund "Goods on Country" (social enterprise making beds + washing machines for remote/First Nations communities, NT/remote focus, community-controlled). Candidates for GHL's **Goods Supporter Journey** pipeline.
+
+## Data source & confidence
+
+| Item | Value |
+|---|---|
+| **Supabase project** | `tednluwflfhxyucgwigh` (shared ACT DB — GrantScope `.env` `SUPABASE_URL` matches the connected MCP project; **Verified**) |
+| **Master catalogue** | `foundations` table — **11,010 rows**, of which **2,045** carry `indigenous` in `thematic_focus` |
+| **Goods scored shortlist** | `org_project_foundations` filtered to the `goods` project (`org_profiles.slug='act'` → `org_projects.slug='goods'`) — **6 rows**, all seeded by `scripts/seed-goods-foundation-contacts.mjs` |
+| **Scoring source** | `fit_score` (0-100) on the 6 shortlisted rows is **author-set in the seeder** (hardcoded), not algorithmic. For the other ~37 prospects below, fit is **inferred** by me from `thematic_focus`/`geographic_focus`/`total_giving_annual` — flagged "inferred" per row block. |
+| **Contacts (named human + email)** | **NONE in this data source.** `foundations` has **no** contact/email/phone/person column (Verified via `information_schema.columns`). The 6 seeded rows carry relationship *narrative* (e.g. Snow via "Sally Grimsley-Ballard") in `notes`/`research.relationship_path` but no structured email. **No contact has been invented.** |
+| **GHL push status** | The GrantScope seeder does **NOT** push to GHL. It only writes `org_project_foundations` / `_research` / `_interactions` in Supabase. A separate `org_pipeline` → foundation import path exists (the `/foundations` API `import_pipeline_candidates`), still Supabase-only. **No evidence any of these foundations have been pushed to GHL from GrantScope.** |
+
+**`total_giving_annual` caveat:** many rows show a flat `500000.00` / `100000.00` / `25000.00` — these are **banded/estimated** ACNC-derived values, not exact. Treat as order-of-magnitude only. Land-council / mining-benefit trusts (e.g. Tiwi, Anindilyakwa, Mirarr) are **grant-makers to community AND community-controlled bodies** — they are as much potential *partners/co-owners* as funders; flagged inline.
+
+## How to read KNOWN vs NEW
+- **KNOWN** = already in GHL's Goods Supporter Journey (the 13 supplied) OR already a seeded Goods shortlist row in GrantScope.
+- **NEW** = surfaced from the `foundations` catalogue, not yet in GHL and not on the Goods shortlist.
+
+---
+
+## TABLE A — NEW prospects (not in GHL Goods Supporter Journey, not on Goods shortlist)
+
+Ranked by inferred fit. Fit rationale is **inferred** from catalogue fields unless noted.
+
+| # | Foundation | Type | Giving (est.) | Geo | Themes (fit signal) | Inferred fit & rationale | Contact on record |
+|---|---|---|---|---|---|---|---|
+| 1 | **Northern Australian Aboriginal Charitable Trust** | trust | ~$100K band | AU-NT | community, indigenous | **Highest thematic bullseye.** Website = `remotelaundries.org.au` — this trust literally funds **remote-community laundries/washing**, Goods' exact product domain (washing machines). NT + Indigenous + the precise use-case. Likely a peer/partner/co-funder, not just a grant source. | none in data |
+| 2 | **Developing East Arnhem Limited** | grantmaker | $2.0M | AU-NT | indigenous, community, education, health, rural_remote | NT-only grant-maker funding remote Arnhem economic + community infrastructure. Strong remote-NT enterprise/employment alignment. | none in data |
+| 3 | **Fortescue Foundation** | corporate_foundation | $54.9M | AU-WA | indigenous, community, education, environment, youth, human_rights | Mining-corporate philanthropy, large budget, explicit Indigenous-community focus; RAP-procurement route named in Goods decision profile. WA not NT but remote-Indigenous mandate transfers. | none in data |
+| 4 | **Rio Tinto Foundation** | corporate_foundation | $153.7M | AU-WA/QLD/National | indigenous, community, **employment**, **economic_development**, cultural_heritage | One of two corporates explicitly carrying `employment` + `economic_development` themes — matches Goods' on-Country manufacturing/jobs thesis. Named in decision profile's Corporate RAP route. | none in data |
+| 5 | **BHP Foundation** | corporate_foundation | $195.1M | International/National/QLD/SA/WA | indigenous, community, rural_remote, human_rights, education | Largest corporate budget with `rural_remote` + indigenous; named in decision profile's Corporate RAP procurement route. Hard to access but high ceiling. | none in data |
+| 6 | **Country Connect Foundation Limited** | corporate_foundation | ~$500K band | AU-NT | community, indigenous, health, youth, disability, **rural_remote, homelessness** | NT-only, remote + homelessness focus — beds/household goods map directly to remote-housing/homelessness outcomes. | none in data |
+| 7 | **Uniting Church Australia Frontier Services** | religious_org | $1.9M | National (all states incl NT) | community, indigenous, **rural_remote**, health | Long-standing remote-Australia service body; rural_remote + Indigenous + health. Possible delivery partner as well as funder. | none in data |
+| 8 | **Community Resources Limited** | service_delivery | $3.1M | National incl NT | employment, community, indigenous, youth, **social-enterprise** | Only catalogue hit carrying `social-enterprise` tag + Indigenous + employment + NT reach — closest thematic mirror to Goods as a social enterprise. | none in data |
+| 9 | **The Trustee For Yeperenye Charitable Trust** | trust | ~$500K band | AU-NT | community, indigenous | Central Australian (Alice Springs) Indigenous community trust; remote-NT community capital. | none in data |
+| 10 | **Central Aboriginal Charitable Trust** | trust | ~$500K band | AU-NT | community, indigenous | Website `centrecorpfoundation.com.au` — **Centrecorp-family trust** (Centrecorp itself is KNOWN/in GHL). Related vehicle worth tracking; may be same network — verify before separate outreach. | none in data |
+| 11 | **The Trustee For Central Australian Aboriginal Charitable Trust** | trust | ~$500K band | AU-NT | community, indigenous | Same Centrecorp network (`centrecorpfoundation.com.au`). Likely duplicate/related to #10 + the KNOWN Centrecorp. Dedup before outreach. | none in data |
+| 12 | **Mjd Foundation Limited** | corporate_foundation | ~$500K band | AU-NT/QLD | health, indigenous | Machado-Joseph Disease Foundation — Groote Eylandt / remote-NT Indigenous health body. Beds/healthy-homes angle (environmental health). | none in data |
+| 13 | **Redtails Pinktails Right Tracks Foundation** | corporate_foundation | ~$500K band | AU-NT | health, community, indigenous | Central Australian Indigenous health/community foundation (AFL-linked). NT remote community fit. | none in data |
+| 14 | **Mirarr Charitable Trust** | trust | ~$500K band | AU-NT | arts, education, health, community, indigenous | Kakadu/Jabiru Mirarr traditional-owner trust. Community-controlled; partner-or-funder. | none in data |
+| 15 | **Tiwi Land Council** | grantmaker | $1.57M | AU-NT | indigenous, community, arts, environment | Tiwi Islands community-controlled grant-maker. Remote-island household-goods demand + community ownership thesis. Partner-or-funder. | none in data |
+| 16 | **Karrkad-Kanjdji Limited** | grantmaker | $1.45M | AU-NT (Arnhem Land) | environment, indigenous, education, community, **employment** | Arnhem Land Indigenous-led grant-maker with employment focus; remote on-Country jobs alignment. | none in data |
+| 17 | **The Trustee For Anindilyakwa Mining Trust** | trust | ~$500K band | AU-NT | community, indigenous | Groote Eylandt mining-benefit trust — community-controlled remote capital. Partner-or-funder. | none in data |
+| 18 | **The Goodman Foundation** | corporate_foundation | ~$500K band | NSW/NT/QLD/VIC | community, indigenous | National corporate foundation funding community + Indigenous; logistics-parent (Goodman) could align with manufacturing/distribution. | none in data |
+| 19 | **Moriarty Foundation** | corporate_foundation | ~$500K band | NSW/NT/QLD | community, indigenous | Indigenous-led (John Moriarty) foundation, NT reach, community focus. | none in data |
+| 20 | **Bupa Foundation (Australia) Limited** | corporate_foundation | ~$500K band | NSW/NT/VIC | health, indigenous | Health-corporate foundation with NT + Indigenous; beds-as-preventive-health (environmental health) framing. | none in data |
+| 21 | **Territory Natural Resource Management Inc** | environmental | $2.4M | AU-NT | environment, indigenous, community, rural_remote | NT-wide remote-community + Indigenous grant body; environment-led but community/remote reach. Weaker product fit (env focus). | none in data |
+| 22 | **EON Aboriginal Corporation (EON Foundation)** | (n/a) | ~$100K band | AU-NT/WA | health, community, indigenous | Remote-community Indigenous health/nutrition body (healthy-homes adjacent). | none in data |
+| 23 | **The Walkatjara Trust** | trust | ~$500K band | AU-NT | arts, community, indigenous | Uluru/Mutitjulu community trust. Community-controlled remote capital; arts-led. | none in data |
+| 24 | **The Trustee For McArthur River Mine Community Benefits Trust** | trust | ~$100K band | AU-NT | arts, health, environment, community, indigenous | Borroloola-region mining-benefit trust; remote-NT community capital. Partner-or-funder. | none in data |
+| 25 | **The Eddie Betts Foundation** | corporate_foundation | ~$100K band | NT/QLD/SA/VIC/WA | education, community, indigenous | Indigenous-athlete-led; youth/community; NT reach. Smaller, story-aligned. | none in data |
+| 26 | **The Ininti Store Trust** | trust | ~$500K band | AU-NT | arts, community, indigenous | Uluru community store trust — community-controlled remote retail/economic body. Partner-or-funder. | none in data |
+| 27 | **Aboriginal Sea Company Operations Trust** | trust | ~$100K band | AU-NT | community, indigenous | NT Indigenous economic-development (sea-country enterprise) trust; enterprise/ownership thesis. | none in data |
+| 28 | **The Trustee For Jawoyn Aboriginal Charitable Trust No 4** | trust | ~$100K band | AU-NT | arts, environment, indigenous, community | Katherine-region Jawoyn community-controlled trust. Partner-or-funder. | none in data |
+| 29 | **The Saville Foundation Ltd** | corporate_foundation | ~$100K band | AU-NT | education, community, indigenous | NT-only education/community/Indigenous foundation. | none in data |
+| 30 | **The Regional & First Nations Community Foundation** | corporate_foundation | unknown | ACT/NSW/NT/QLD/SA/VIC | education, health, community, indigenous | First-Nations community foundation w/ NT reach; community-led giving route. Giving figure unknown. | none in data |
+| 31 | **Strong Brother Strong Sister Foundation** | corporate_foundation | ~$25K band | NT/VIC | arts, community, indigenous | Indigenous youth/community; small budget. | none in data |
+| 32 | **Miriam Rose Foundation** | corporate_foundation | ~$25K band | AU-NT | education, health, community, indigenous | Daly River (NT) Indigenous-led foundation; small but deeply remote-NT. | none in data |
+| 33 | **Namatjira Legacy Trust** | trust | ~$25K band | AU-NT | arts, education, indigenous, community | Central Australian Indigenous legacy trust; small, arts-led. | none in data |
+| 34 | **GEBIE Investment Charitable Trust** | trust | ~$25K band | AU-NT | arts, education, health, community, indigenous | Groote Eylandt (Angurugu) community trust. Community-controlled. | none in data |
+| 35 | **Ninti One Foundation Limited** | corporate_foundation | ~$25K band | AU-NT | education, health, community, indigenous | Remote-Australia Indigenous research/training body (CRC-CI lineage). | none in data |
+| 36 | **The Ian Potter Foundation** | corporate_foundation | $38M | AU-National | arts, indigenous, health, education, community, research | Major national foundation; Indigenous among themes. Broad, competitive, no NT-specific signal but large ceiling. **Lower remote-fit.** | none in data |
+| 37 | **Kinghorn Foundation** | private_ancillary_fund | $31M | National/Intl | indigenous, health, education, community | Large PAF; Indigenous among themes; national. Broad, low remote-specificity. | none in data |
+
+**Deferred / flagged, not ranked as direct asks:**
+- **Yajilarra Trust** ($214M) and **Minderoo Pictures** ($210M) are both **Forrest-family / Minderoo group** vehicles — Minderoo is already on the Goods shortlist (#3, KNOWN below). Route through the existing Minderoo relationship, not as separate cold prospects.
+- **Charles Darwin University** ($9.1M, NT, indigenous/research) and **Outback Stores Pty Ltd** ($1.8M, NT, indigenous/employment) scored high on the heuristic but are a **university** and a **remote-retail operator** respectively — better framed as **delivery/distribution partners** (Outback Stores = remote-community retail network = a distribution channel for Goods) than as grant funders. Worth a partner conversation, not a Supporter-Journey funder slot.
+
+---
+
+## TABLE B — KNOWN prospects (already in GHL Goods Supporter Journey OR already on Goods shortlist) — with fresh GrantScope intel
+
+| Foundation | KNOWN via | GrantScope fit_score | Stage / engagement | Fresh intel from GrantScope |
+|---|---|---|---|---|
+| **The Trustee For The Snow Foundation** | GHL list **+** Goods shortlist | **97** | in_conversation / proposal | Anchor funder, ~$193,785 to date, Round 4 proposal live. Relationship via **Sally Grimsley-Ballard** (narrative only, no email in data). Tennant Creek deployment proof. Next: blended-capital framing alongside QBE + SEFA. |
+| **QBE Foundation** | Goods shortlist (NEW vs GHL-13) | **93** | in_conversation / proposal | In QBE **Catalysing Impact** cohort; working toward an **up-to-$200K match grant**. Active program relationship via Social Impact Hub. **NEW to the GHL Supporter Journey** — add it. |
+| **Minderoo Foundation** | Goods shortlist (NEW vs GHL-13) | **91** | priority / approached | Warm catalytic/recoverable-grant target (~$200K). Missing: locked decision-maker. Note Yajilarra Trust + Minderoo Pictures are same group. **NEW to GHL Supporter Journey** — add it. |
+| **Paul Ramsay Foundation Limited** | Goods shortlist (NEW vs GHL-13) | **89** | approach_now / ready_to_approach | $183M national funder. Goods-specific systems-change/procurement prospect already framed in ACT pipeline. Needs a named intro. **NEW to GHL Supporter Journey** — add it. |
+| **Australian Communities Foundation** | Goods shortlist (NEW vs GHL-13) | **84** | approach_now / ready_to_approach | Pooled-giving/donor-collaborative route. Needs Goods-specific donor pathway. **NEW to GHL Supporter Journey** — add it. |
+| **Nova Peris Foundation Limited** | Goods shortlist (NEW vs GHL-13) | **76** | saved / researching | NT-based Indigenous economic-empowerment; route possibly via PICC enterprise. **NEW to GHL Supporter Journey** — add it. |
+| **Vincent Fairfax Family Foundation (VFFF)** | GHL list | — (not on Goods shortlist) | not shortlisted | In catalogue as **Vincent Fairfax Family Trust**, $15M, national/NSW. Not yet scored for Goods — consider adding to the GrantScope Goods shortlist. |
+| **FRRR (Foundation for Rural & Regional Renewal)** | GHL list | — | not shortlisted | Catalogue: **Foundation For Rural And Regional Renewal**, ~$500K band, NSW/VIC. Rural-remote grant intermediary. |
+| **AMP Foundation** | GHL list | — | not shortlisted | Catalogue: **AMP Foundation Charitable Trust**, ~$500K band, national. |
+| **The Funding Network** | GHL list | — | not shortlisted | Catalogue: **The Funding Network Australia Limited**, $1.5M, national — live-crowdfunding/grant intermediary. |
+| **Centrecorp Foundation** | GHL list | — | not shortlisted | Catalogue: **Centrecorp Foundation**, ~$100K band, national. NB two related Central-Australian trusts (#10, #11 above) share the `centrecorpfoundation.com.au` domain — dedup. |
+| **Mala'la Health Service** | GHL list | not in foundations catalogue | — | No `foundations` row found (it's a Maningrida ACCHO, not a philanthropic funder — sits in the buyer/partner side, not foundation prospects). |
+| **Rotary Eclub Outback Australia** | GHL list | not in foundations catalogue | — | No `foundations` row matched. Community/service-club funder; not in this catalogue. |
+| **Red Dust** | GHL list | not in foundations catalogue | — | No clear `foundations` row matched (Red Dust Role Models = remote-health NFP). |
+| **QIC** | GHL list | not in foundations catalogue | — | No `foundations` row matched (QIC = Queensland Investment Corp; corporate, not a charity-registered foundation). |
+| **Julalikari Council** | GHL list | not in foundations catalogue | — | No `foundations` row matched (Tennant Creek Aboriginal corporation — partner/community body, not a foundation). |
+| **Our Community Shed** | GHL list | not in foundations catalogue | — | No `foundations` row matched. |
+| **Homeland School** | GHL list | not in foundations catalogue | — | No `foundations` row matched — Homeland Schools Company is a **buyer** (65-bed pathway in Goods decision profile), not a foundation funder. |
+
+---
+
+## Gaps & caveats (explicit)
+
+1. **No contact data exists in this source.** `foundations` has no email/phone/person columns. Any named human you want must come from elsewhere (GHL, web research, or the Goods wiki narrative). Snow's "Sally Grimsley-Ballard" is the only named relationship and it's free-text in `notes`, no email.
+2. **`fit_score` is hardcoded** in `seed-goods-foundation-contacts.mjs` for the 6 shortlisted rows — author judgment, not algorithmic. All Table-A fit assessments are **inferred by me** from catalogue `thematic_focus`/`geographic_focus`/`total_giving_annual`.
+3. **`total_giving_annual` is banded/estimated** (many flat $500K/$100K/$25K values from ACNC processing). Do not quote as exact figures.
+4. **Land-council & mining-benefit trusts** (Tiwi, Anindilyakwa, Mirarr, Walkatjara, Ininti, Jawoyn, McArthur River, GEBIE) are **community-controlled** — they fit Goods' ownership-transfer thesis as **partners/co-owners** as much as funders. Frame accordingly.
+5. **Some Table-A rows are likely the same network** (Centrecorp #10/#11 + KNOWN Centrecorp; Minderoo group Yajilarra/Pictures). Dedup before separate outreach.
+6. **No GHL push from GrantScope.** Nothing here has been pushed to GHL by the seeder/API — all writes are Supabase-only (`org_project_foundations`).


### PR DESCRIPTION
Builds out the Goods on Country CRM pipelines in GHL, review-first from Gmail + GrantScope mining.

## What
- **Supporter Journey 13 → 35 funders** — seed 19 (4 warm w/ contacts, 5 high-fit, 10 cold) + enrich 3 from Nic's recent mail (Bryan, Ian Potter, Brian M Davis) + promote 2 shells to real humans (Minderoo/Stronach, Paul Ramsay/Frazer).
- **Buyer Pipeline 1 → 6** — commercial buyers only per the operating model (Miwatj, Anyinginyi, WHSAC/Groote, NPY, Centrebuild→Randle Walker). Grant-delivery partners deliberately excluded.
- **Demand Register +14** — scored cold prospects as company-shell signal records.

## How
Three idempotent, dry-run-first seeders using the act-infra GHL service (GHL MCP can't create opportunities). No contacts fabricated — contactless shells flagged for warm-intro enrichment. Mining handoffs + review docs with provenance included.

## Notes
- Commits originally landed on local `main` (a parallel session checked out main mid-work); isolated here onto a feature branch. Local `main` is still ahead 2 — reset to origin/main after merge.
- GHL traps documented in the scripts (opp requires contactId; lookupContactByEmail broken; tag updates overwrite; search index lags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)