### PR TITLE
feat(goods): anchor councils/ACCHOs → Demand Register + warm-intro worksheet

### DIFF
--- a/scripts/push-goods-anchors-to-demand-register-2026-05-27.mjs
+++ b/scripts/push-goods-anchors-to-demand-register-2026-05-27.mjs
@@ -1,0 +1,53 @@
+/**
+ * Push the 9 anchor councils/ACCHOs (backfilled into GrantScope's goods_procurement_entities
+ * by grantscope/scripts/backfill-goods-anchor-councils-acchos-2026-05-27.mjs) into the GHL
+ * Goods — Demand Register as company-shell signal records. Company shells (no human yet);
+ * real contacts come via the warm-intro worksheet. Idempotent (skip if opp name exists),
+ * dry-run-first.
+ *   node --env-file=.env.local scripts/push-goods-anchors-to-demand-register-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env.local scripts/push-goods-anchors-to-demand-register-2026-05-27.mjs --apply
+ */
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const norm = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const BASE = ['goods', 'act-gd', 'project:act-gd', 'goods-stage-prospect'];
+
+const ANCHORS = [
+  { name: 'MacDonnell Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Roper Gulf Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Victoria Daly Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'West Daly Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Barkly Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'East Arnhem Regional Council', tags: ['goods-role-council', 'goods-state-nt'] },
+  { name: 'Central Australian Aboriginal Congress', tags: ['goods-role-health', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Laynhapuy Homelands Aboriginal Corporation', tags: ['goods-role-corp', 'goods-state-nt', 'goods-communitycontrolled'] },
+  { name: 'Katherine West Health Board Aboriginal Corporation', tags: ['goods-role-health', 'goods-state-nt', 'goods-communitycontrolled'] },
+];
+
+async function main() {
+  const ghl = createGHLService();
+  const dr = await ghl.getPipelineByName('Demand Register');
+  if (!dr) { console.error('✗ Demand Register pipeline not found'); process.exit(1); }
+  const signal = dr.stages.find((s) => norm(s.name) === 'signal');
+  if (!signal) { console.error('✗ Signal stage not found'); process.exit(1); }
+  const existing = new Set((await ghl.getOpportunities(dr.id, { limit: 100 })).map((o) => norm(o.name)));
+  console.log(`Demand Register (${dr.id}) existing: ${existing.size} | Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+  const res = { created: [], skipped: [], errors: [] };
+
+  for (const a of ANCHORS) {
+    if (existing.has(norm(a.name))) { console.log(`= SKIP (exists)  ${a.name}`); res.skipped.push(a.name); continue; }
+    if (!APPLY) { console.log(`+ WOULD CREATE  ${a.name}  → Signal  [${a.tags.join(',')}]`); continue; }
+    try {
+      const c = await ghl.createContact({ firstName: a.name, companyName: a.name, tags: [...BASE, ...a.tags] });
+      const cid = c.id || c.contact?.id;
+      if (!cid) throw new Error('no contact id');
+      const opp = await ghl.createOpportunity({ pipelineId: dr.id, stageId: signal.id, name: a.name, monetaryValue: 0, status: 'open', contactId: cid });
+      console.log(`+ CREATED  ${a.name}  (contact ${cid}, opp ${opp.id})`); res.created.push(a.name);
+    } catch (e) { console.error(`✗ ERROR ${a.name}: ${e.message}`); res.errors.push(`${a.name}: ${e.message}`); }
+  }
+  console.log(`\nCreated: ${res.created.length} | skipped: ${res.skipped.length} | errors: ${res.errors.length}`);
+  if (res.errors.length) console.log(res.errors.join('\n'));
+  if (!APPLY) console.log('\n(Dry-run. Re-run with --apply.)');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/thoughts/shared/drafts/goods-warm-intro-worksheet-2026-05-27.md
+++ b/thoughts/shared/drafts/goods-warm-intro-worksheet-2026-05-27.md
@@ -1,0 +1,52 @@
+# Goods on Country — Warm-Intro Worksheet (contactless pipeline records)
+
+**Date:** 2026-05-27 · **Purpose:** turn the contactless GHL shells into live conversations. Each row has what we know, a web-found starting point (where one exists — **unverified**, confirm before use), and a suggested leverage path from our *existing* warm relationships. **Ben: fill the "Who opens this door" column.**
+
+> No contact below is confirmed/usable as-is — these are research starting points + intro strategy, not verified contacts. Sourced from the mining handoffs (`gmail-funders.md`, `enrichment.md`, `buyers-candidates.md`).
+
+## Leverage map (our warmest doors that open others)
+- **Minderoo / Lucy Stronach** → **Fortescue Foundation** (both Forrest-family / Minderoo group — strongest single lever).
+- **Philanthropy Australia / Kim Harland** → convener; can open most foundations (PA Conference already featured Goods).
+- **AMSANT** (peak ACCHO body) → warm intros to member health services (Sunrise, Katherine West, Congress, Miwatj-adjacent).
+- **Snow Foundation / Centrecorp (Randle Walker)** → Central Australian philanthropic + Aboriginal-trust network.
+- **Social Impact Hub / Jay Boolkin** → QBE + investment-readiness funder network.
+
+---
+
+## A. Funder shells needing a contact (Supporter Journey)
+
+| Foundation | What we know / web starting point (UNVERIFIED) | Suggested intro path | Who opens this door (Ben) |
+|---|---|---|---|
+| **Fortescue Foundation** | Community Grants via `fmgl.com.au/communitygrants`; Forrest-family, parent of Minderoo | **Via Minderoo / Lucy Stronach** — same group | |
+| **Rio Tinto Foundation** | No individual published; $153M corporate | Corporate RAP/procurement route; cold | |
+| **BHP Foundation** | No individual published; $195M, rural_remote + Indigenous | Cold — needs a board/exec intro | |
+| **Paul Ramsay Foundation** *(has Frazer now)* | First Nations Targeted Grant Round (≤$500K) under CFNO **Michelle Steele** (web, no email) | Already warm via William Frazer / Jonas — ask them to route to the FN round | |
+| **Nova Peris Foundation** | Founder **Nova Peris OAM**; `novaperisfoundation.org.au/contact-us` | NT Indigenous network; possible via PICC enterprise | |
+| **Australian Communities Foundation** | Philanthropy Team line 03 9412 0412; First Nations giving focus | Pooled-giving route; via Philanthropy Australia | |
+| **Mjd Foundation** | CEO possibly **Jacquie Hatt** (web, conflicting); email format `first.last@mjd.org.au`; 1300 584 122 | Groote Eylandt health network; pair w/ Anindilyakwa cluster | |
+| **Northern Aust. Aboriginal Charitable Trust (NAACT)** | = **Aboriginal Investment Group**; runs **Remote Laundries** (`remotelaundries.org.au`); "Brittany Ciupka, Project Officer" (web) | **Peer/partner** — they literally fund remote washing. Direct approach via Remote Laundries | |
+| **Country Connect Foundation** | Founders **Troy Barrett** & **Louise Lethbridge**; `recruitment@countryconnect.org.au` only | First Nations-led NT remote services; cold | |
+| **Uniting Church Frontier Services** | No individual; national remote-Australia body | Possible delivery partner too; via Uniting network | |
+| **Community Resources Ltd** | No individual; only catalogue social-enterprise + Indigenous + NT hit | Cold — sector-peer intro | |
+| **Yeperenye Charitable Trust** | Alice Springs Indigenous community trust; no individual | **Via Centrecorp/Randle** (Central Australian network) | |
+
+## B. Buyer shells needing a contact
+
+| Buyer | Pipeline | What we know (UNVERIFIED) | Suggested intro path | Who opens this door (Ben) |
+|---|---|---|---|---|
+| **WHSAC / Groote** | Buyer Pipeline | **Simone Grimmond** named, no email; 500 mattresses + 300 washers (~$1.7M) | Confirm Simone's email; pair w/ Anindilyakwa Housing + Mjd (Groote cluster) | |
+| **NPY Women's Council** | Buyer Pipeline | **Angela Lynch** named, no email; standing demand, NT/SA/WA | Verify Angela current; cross-border women's council | |
+| **ALPA** | Demand Register | $15.5M store network, no contact | Largest Aboriginal-owned stores — distribution anchor; needs procurement lead | |
+| **Outback Stores** | Demand Register | National remote-retail operator, no contact | Distribution channel; board/exec intro | |
+| **Tangentyere Council** | Demand Register | Alice Springs town camps, no contact | **Via Centrecorp/Randle** (Central Australia) | |
+| **Central Desert / Tiwi Islands / Torres Strait / NPA Councils** | Demand Register | Remote councils w/ real procurement budgets, no contacts | Council procurement/assets managers — needs named contacts | |
+| **Central Land / Tiwi Land / Anindilyakwa Land Councils** | Demand Register | Representative bodies (channel, not direct buyer) | Use for intros to their communities | |
+| **AMSANT** | Demand Register | ACCHO peak body | **Door-opener** to member health services, not a per-community buyer | |
+| **Anindilyakwa Housing / Canteen Creek / Ntaria** | Demand Register | Housing/store/council signals, no contacts | Pair w/ regional clusters | |
+
+---
+
+## How to use
+1. Fill "Who opens this door" with the person in our network (or a board member / advisor) who can make a warm intro.
+2. For the **starred leverage plays** — Fortescue-via-Minderoo, member-ACCHOs-via-AMSANT, Central-Australia-via-Centrecorp — those are actionable now with relationships we already hold.
+3. Once a real contact is confirmed, update the GHL record: shells take a real human via the same `searchContacts`→`updateContact`/`addTagToContact` pattern (see `enrich-goods-foundation-contacts-2026-05-27.mjs`). Do NOT fabricate — leave the shell until a real contact exists.


### PR DESCRIPTION
Follow-up to #108. Pushes the 9 GrantScope-backfilled anchor buyers (6 NT regional councils + Congress, Laynhapuy, Katherine West Health) into the GHL Demand Register as company-shell signal records, and adds the warm-intro worksheet for the contactless shells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)