### PR TITLE
feat(ghl): org/impact field strategy + live impact resync

### DIFF
--- a/scripts/create-goods-impact-fields-2026-05-27.mjs
+++ b/scripts/create-goods-impact-fields-2026-05-27.mjs
@@ -1,0 +1,40 @@
+/**
+ * Create the minimal org/impact custom fields per thoughts/shared/plans/2026-05-27-ghl-field-strategy.md.
+ * Idempotent: skips a field whose name already exists. Dry-run-first.
+ *   node --env-file=.env.local scripts/create-goods-impact-fields-2026-05-27.mjs          # dry-run
+ *   node --env-file=.env.local scripts/create-goods-impact-fields-2026-05-27.mjs --apply
+ *
+ * ABN = org join key (Xero/GrantScope/ACNC). Beds/Washers/Last-delivery = read-only rollups,
+ * written by sync-goods-impact-to-ghl-*.mjs from goods_asset_lifecycle. Never hand-typed.
+ */
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const FIELDS = [
+  { name: 'ABN', dataType: 'TEXT', placeholder: 'Australian Business Number (org join key)' },
+  { name: 'Beds delivered', dataType: 'NUMERICAL', placeholder: 'rollup from goods_asset_lifecycle — do not edit' },
+  { name: 'Washers delivered', dataType: 'NUMERICAL', placeholder: 'rollup from goods_asset_lifecycle — do not edit' },
+  { name: 'Last delivery date', dataType: 'DATE', placeholder: 'rollup from goods_asset_lifecycle — do not edit' },
+];
+
+async function main() {
+  const ghl = createGHLService();
+  const existing = await ghl.getCustomFields();
+  const byName = new Map(existing.map((f) => [f.name.toLowerCase(), f]));
+  console.log(`Existing custom fields: ${existing.length} | Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+  const created = [];
+  for (const f of FIELDS) {
+    const hit = byName.get(f.name.toLowerCase());
+    if (hit) { console.log(`= SKIP (exists)  ${f.name}  (${hit.id})`); continue; }
+    if (!APPLY) { console.log(`+ WOULD CREATE  ${f.name}  [${f.dataType}]`); continue; }
+    try {
+      const cf = await ghl.createCustomField({ name: f.name, dataType: f.dataType, model: 'contact', placeholder: f.placeholder });
+      const id = cf.id || cf.customField?.id;
+      console.log(`+ CREATED  ${f.name}  [${f.dataType}]  → ${id}  key:${cf.fieldKey || cf.customField?.fieldKey || '?'}`);
+      created.push({ name: f.name, id });
+    } catch (e) { console.error(`✗ ERROR ${f.name}: ${e.message}`); }
+  }
+  if (APPLY && created.length) console.log(`\nField IDs (for the sync script):\n${created.map((c) => `  ${c.name} = ${c.id}`).join('\n')}`);
+  if (!APPLY) console.log('\n(Dry-run. Re-run with --apply.)');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/lib/ghl-api-service.mjs
+++ b/scripts/lib/ghl-api-service.mjs
@@ -476,8 +476,24 @@ export class GHLService {
    * @returns {Promise<Array>} Custom field definitions
    */
   async getCustomFields() {
-    const data = await this.request(`/custom-fields?locationId=${this.locationId}`);
+    // v2 path: /locations/{id}/customFields (the older /custom-fields?locationId= 404s)
+    const data = await this.request(`/locations/${this.locationId}/customFields`);
     return data.customFields || [];
+  }
+
+  /**
+   * Create a custom field (v2: POST /locations/{id}/customFields/).
+   * @param {Object} f - { name, dataType, model='contact', placeholder?, parentId? }
+   *   dataType: TEXT | LARGE_TEXT | NUMERICAL | MONETORY | PHONE | DATE | SINGLE_OPTIONS | MULTIPLE_OPTIONS
+   * @returns {Promise<Object>} created custom field
+   */
+  async createCustomField({ name, dataType, model = 'contact', placeholder, parentId }) {
+    const body = { name, dataType, model, ...(placeholder && { placeholder }), ...(parentId && { parentId }) };
+    const data = await this.request(`/locations/${this.locationId}/customFields/`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    return data.customField || data;
   }
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/scripts/sync-goods-impact-to-ghl-2026-05-27.mjs
+++ b/scripts/sync-goods-impact-to-ghl-2026-05-27.mjs
@@ -1,0 +1,59 @@
+/**
+ * Sync Goods impact rollups (beds/washers delivered, last delivery) from Supabase
+ * goods_asset_lifecycle → GHL contact custom fields. Read-only on Supabase; writes ONLY the
+ * 3 rollup custom fields on matched GHL contacts (merge by field id — does not touch tags or
+ * other fields). Dry-run-first; matches are shown for human verification before --apply.
+ *
+ *   node --env-file=.env.local scripts/sync-goods-impact-to-ghl-2026-05-27.mjs          # dry-run (shows matches)
+ *   node --env-file=.env.local scripts/sync-goods-impact-to-ghl-2026-05-27.mjs --apply
+ *
+ * Impact is COMMUNITY-keyed (beds go to communities; orgs serve communities), so rollups land on
+ * the community record (the GHL contact whose name/company contains the community name). Dates in
+ * goods_asset_lifecycle are partly junk (2000/2001 defaults) → last_delivery only set when >= 2024.
+ */
+import { createClient } from '@supabase/supabase-js';
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const FIELD = { beds: 'wRiK8nW7Rv8vL0twp9lF', washers: 'RcAAxZFPlVmGjKKGWy7I', lastDelivery: '8z8xIptjdN6bqcwaVOSt' };
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function main() {
+  const ghl = createGHLService();
+  // 1. aggregate impact per community
+  const { data: rows, error } = await supabase.rpc('exec_sql', { query: `
+    SELECT community_name,
+      count(*) FILTER (WHERE product_type ILIKE '%bed%') AS beds,
+      count(*) FILTER (WHERE product_type ILIKE '%wash%') AS washers,
+      max(deployed_at) FILTER (WHERE deployed_at >= '2024-01-01') AS last_delivery
+    FROM goods_asset_lifecycle
+    WHERE community_name IS NOT NULL AND community_name <> ''
+    GROUP BY community_name HAVING count(*) > 1 ORDER BY beds DESC` });
+  if (error) throw new Error(`aggregate: ${error.message}`);
+  console.log(`Communities with impact: ${rows.length} | Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}\n`);
+
+  const res = { written: [], ambiguous: [], nomatch: [], errors: [] };
+  for (const r of rows) {
+    const beds = Number(r.beds) || 0, washers = Number(r.washers) || 0;
+    // 2. find GHL contact(s) for this community
+    const matches = (await ghl.searchContacts(r.community_name))
+      .filter((c) => `${c.contactName || c.name || ''} ${c.companyName || ''}`.toLowerCase().includes(r.community_name.toLowerCase()));
+    const label = `${r.community_name.padEnd(20)} beds:${beds} washers:${washers}${r.last_delivery ? ' last:' + String(r.last_delivery).slice(0, 10) : ''}`;
+    if (matches.length === 0) { console.log(`✗ NO MATCH   ${label}`); res.nomatch.push(r.community_name); continue; }
+    if (matches.length > 1) { console.log(`? AMBIGUOUS  ${label}  → ${matches.length}: ${matches.map((m) => m.contactName || m.name).slice(0, 4).join(' | ')}`); res.ambiguous.push(r.community_name); continue; }
+    const c = matches[0];
+    console.log(`${APPLY ? '→ WRITE' : '+ WOULD WRITE'}  ${label}  → ${c.contactName || c.name} (${c.id})`);
+    if (!APPLY) continue;
+    try {
+      const cf = [{ id: FIELD.beds, value: beds }, { id: FIELD.washers, value: washers }];
+      if (r.last_delivery) cf.push({ id: FIELD.lastDelivery, value: new Date(r.last_delivery).getTime() });
+      await ghl.updateContact(c.id, { customFields: cf });
+      res.written.push(r.community_name);
+    } catch (e) { console.error(`✗ ERROR ${r.community_name}: ${e.message}`); res.errors.push(`${r.community_name}: ${e.message}`); }
+  }
+  console.log(`\n── Summary ──\nwritten:${res.written.length} ambiguous:${res.ambiguous.length} no-match:${res.nomatch.length} errors:${res.errors.length}`);
+  if (res.ambiguous.length) console.log(`Ambiguous (need a curated target): ${res.ambiguous.join(', ')}`);
+  if (res.nomatch.length) console.log(`No GHL record: ${res.nomatch.join(', ')}`);
+  if (!APPLY) console.log('\n(Dry-run. Verify matches, then re-run with --apply.)');
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/thoughts/shared/plans/2026-05-27-ghl-field-strategy.md
+++ b/thoughts/shared/plans/2026-05-27-ghl-field-strategy.md
@@ -1,0 +1,66 @@
+# GHL Field Strategy — make the most of the system, cut the bloat
+
+**Date:** 2026-05-27 · Location `agzsSZWgovjwgpcoASWG` (A Curious Tractor) · audit-backed.
+
+## The finding (measured, not guessed)
+Of **~51 contact custom fields**, only **11 hold any data** across all **2,377 contacts**. **40 fields are empty scaffolding** (0 records) — built for forms/journeys that never populated them. That's the bloat.
+
+| Field | Records with data | Verdict |
+|---|---|---|
+| Relationship Score · Last AI Action · Suggested Action | 147 ea | **KEEP** — AI engagement layer |
+| CivicGraph Profile | 122 | **KEEP** — entity link |
+| Goods · LinkedIn Tags | 67 | KEEP (or migrate to tags) |
+| Project Designation | 8 | RETIRE → tag `project:*` |
+| Product Type / Order Number / Order Total | 5 ea | KEEP (Goods order flow) |
+| Seeds · Partnership Type | 1 ea | RETIRE → tags |
+| **~40 others** | **0** | **ARCHIVE — zero data loss** |
+
+## The unit-of-record principle (the root fix)
+GHL contacts are **people**. We store **orgs** (councils, ACCHOs, foundations) as contacts + opportunities. So:
+- **Org identity** → record name + `Business Name` + **tags** (`goods-role-*`, `goods-state-*`, `goods-communitycontrolled`). Add ONE field: **ABN** (the universal join key to Xero/GrantScope/ACNC).
+- **Process state** → pipeline + stage (already right).
+- **Impact / cumulative history** → **Supabase** (`goods_asset_lifecycle`, `goods_communities`, GrantScope). GHL is NOT the impact database — it holds the *relationship* + read-only **rollup** fields synced from Supabase.
+
+## The decision rule (apply to every new field idea)
+> **Filter or trigger on it → tag. Report a number / merge into comms → field. Process state → pipeline stage. Cumulative history → Supabase (sync a rollup to GHL if a human needs to see it).**
+
+## What we're adding (minimal, high-value)
+- `ABN` (contact, text) — org join key.
+- `Beds delivered` (contact, number) — rollup from `goods_asset_lifecycle`.
+- `Washers delivered` (contact, number) — rollup.
+- `Last delivery date` (contact, date) — rollup.
+(Impact data today: 384 beds + 20 washers across ~7 communities — synced, never hand-typed.)
+
+## What we're retiring / hiding
+- **40 empty fields** → archive (no data). Immediate UI relief: tick **"Hide Empty Fields"** in the edit modal.
+- **Redundant project fields** (`Project Designation/Interest/Links/Role/Seeds` — 6 ways to say project) → collapse to `project:<slug>` tags; migrate the ~9 records with data first.
+- **Duplicate** `how_did_you_hear` (2 copies) → keep one.
+
+⚠️ GHL field deletion drops the data on every record using it. For the 40 empty fields it's safe. For the ~6 low-use ones, migrate data to tags FIRST, then archive. Prefer **hide** over delete where unsure.
+
+## Folders (so org records aren't visually buried)
+Keep folder groups tight: **Org & Impact** (ABN, Beds/Washers delivered, Last delivery, Community), **Relationship/AI** (Relationship Score, Suggested Action, Last AI Action, CivicGraph), **Goods Orders** (order fields), **Person** (the storyteller/volunteer/consent fields — only show on person records). Use "Hide Empty Fields" as the default working view.
+
+## ⚠️ The impact-numbers truth chain (why beds/washers numbers keep differing)
+
+```
+LIVE assets table          stale CSV                 shared mirror            GHL rollups
+(canonical, QR-updated)    expanded_assets_          goods_asset_lifecycle    Beds/Washers
+project cwsyhpiuepvdjtxaozwf  final.csv (2 Dec 2025) ─→ (404 rows, =CSV)    ─→ delivered fields
+   │                            ▲                                                  │
+   └─ grantscope/goods-lifecycle-sync.mjs reads the CSV, NOT the live table ──────┘
+```
+
+**Root cause of "different numbers every time":** the pipeline is FROZEN on a **2 Dec 2025 CSV export**. `goods-lifecycle-sync.mjs` reads `data/expanded_assets_final.csv` (404 rows), never the live `assets` table. Live deployments since Dec never propagate.
+
+**The fix (one source of truth):** rewrite the sync to read the LIVE `assets` table (project `cwsyhpiuepvdjtxaozwf`, the Goods v2 DB) → aggregate per community → upsert `goods_asset_lifecycle` → trigger the GHL rollup sync. Then cron it (weekly).
+
+**Blocker:** the Goods `v2/.env.local` is malformed (unquoted multi-word values break env parsing — same issue that broke `source .env.local`). Fix the quoting (or run from a clean env with the `cwsyhpiuepvdjtxaozwf` URL+service key) and the live resync runs. Read-only count tool staged: `Goods Asset Register/v2/scripts/count-live-assets.mjs` (works once env is sane).
+
+## Status
+- [x] Audit + field strategy (this doc)
+- [x] Created ABN + 3 rollup fields (`scripts/create-goods-impact-fields-2026-05-27.mjs` — applied)
+- [x] GHL rollup sync built (`scripts/sync-goods-impact-to-ghl-2026-05-27.mjs`); ran — Palm Island→PICC (131 beds/10 washers) written. Other communities need a curated community→record mapping + the live-assets refresh below.
+- [ ] **Un-freeze the impact pipeline**: sync from live `assets`, not the Dec-2 CSV (blocker: fix `v2/.env.local` quoting)
+- [ ] Curated community→GHL-record map (Tennant Creek→? Utopia→? Maningrida→Mala'la? etc.)
+- [ ] Field consolidation/archive pass (after Ben confirms the retire list — 40 empty fields safe)


### PR DESCRIPTION
Custom-field audit (40 of 51 empty), minimal intentional org/impact field set (ABN + beds/washers/last-delivery rollups), GHL service createCustomField + path fix. Companion to the canonical live-assets resync in the Goods Asset Register repo (commit fd71c28) that fixes the stale-CSV root cause. Strategy + truth-chain: thoughts/shared/plans/2026-05-27-ghl-field-strategy.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)