### PR TITLE
feat(comms): audience segmentation taxonomy + script

### DIFF
--- a/config/audience-segments.json
+++ b/config/audience-segments.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "updated": "2026-05-28",
+  "description": "Canonical audience taxonomy for the ACT communication pipeline. Each contact in GHL gets zero or more `audience-*` tags computed from their pipelines, flags and tags. These tags ARE the recipient lists the newsletter/social system sends to. See Notion: Comms & CRM Operating System > Newsletter + social audience system. Closes the open item from plan act-communication-pipeline-2026-05-23-locked ('which GHL tags map to each audience').",
+  "tagPrefix": "audience-",
+  "rules": {
+    "respectUnsubscribe": true,
+    "_comment_respectUnsubscribe": "If newsletter_unsubscribed_at is set, the contact is excluded from ALL audiences (no mass send of any kind)."
+  },
+  "audiences": {
+    "funder": {
+      "tag": "audience-funder",
+      "label": "Funder",
+      "description": "Grant + philanthropic funders. Quarterly, per-recipient editions. Private.",
+      "pipelines": ["Goods Supporter Journey", "Grants"],
+      "tagPatterns": ["funder", "philanthropy", "philanthropic", "grant-funder"],
+      "wonOpportunityWithValue": true,
+      "_comment": "wonOpportunityWithValue: any won opportunity with monetary_value > 0 marks the contact as a funder."
+    },
+    "partner": {
+      "tag": "audience-partner",
+      "label": "Partner",
+      "description": "Delivery partners, commercial buyers, demand orgs, event collaborators. Monthly, per-recipient. Private.",
+      "pipelines": [
+        "Goods — Buyer Pipeline",
+        "Goods — Demand Register",
+        "ACT Events",
+        "Festivals",
+        "Mukurtu Node Activation",
+        "A Curious Tractor"
+      ],
+      "tagPatterns": ["partner", "buyer", "goods-stage-active", "goods-stage-customer", "collaborator"],
+      "wonOpportunityWithValue": false
+    },
+    "storyteller": {
+      "tag": "audience-storyteller",
+      "label": "Storyteller",
+      "description": "Empathy Ledger storytellers. Event-triggered, OCAP-strict. Private. Never receives mass brand sends unless also consented.",
+      "pipelines": ["Empathy Ledger"],
+      "flags": ["is_storyteller"],
+      "tagPatterns": ["storyteller"],
+      "wonOpportunityWithValue": false
+    },
+    "brand": {
+      "tag": "audience-brand",
+      "label": "Brand",
+      "description": "Public newsletter audience. Fortnightly, per-audience, publicly archived. CONSENT REQUIRED.",
+      "requiresNewsletterConsent": true,
+      "pipelines": [],
+      "tagPatterns": [],
+      "wonOpportunityWithValue": false,
+      "_comment": "Brand is the only mass-public audience, so it gates strictly on newsletter_consent=true. Pipeline/tag membership never auto-adds a contact to brand."
+    }
+  }
+}

--- a/scripts/assign-audience-segments.mjs
+++ b/scripts/assign-audience-segments.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Audience segmentation for the ACT communication pipeline.
+ *
+ * Computes which audience(s) each GHL contact belongs to — funder, partner,
+ * brand, storyteller — from their pipelines, flags and tags, then writes
+ * canonical `audience-*` tags to GHL. Those tags ARE the recipient lists the
+ * newsletter/social system sends to.
+ *
+ * Rules live in config/audience-segments.json (data-driven; tune without code).
+ * Closes the open item from plan act-communication-pipeline-2026-05-23-locked:
+ * "which GHL lists/tags map to each audience".
+ *
+ * Membership signals per audience (any match qualifies):
+ *   - pipelines: contact has an open/any opp in one of these pipeline_names
+ *   - flags: a boolean column on ghl_contacts (e.g. is_storyteller)
+ *   - tagPatterns: a case-insensitive substring of any existing tag
+ *   - wonOpportunityWithValue: contact has a won opp with monetary_value > 0
+ *   - requiresNewsletterConsent: newsletter_consent=true is the signal (brand)
+ * Gate: requiresNewsletterConsent=true AND consent=false → excluded from that audience.
+ * Unsubscribed contacts (newsletter_unsubscribed_at set) → excluded from ALL audiences.
+ *
+ * Usage:
+ *   node scripts/assign-audience-segments.mjs                 # dry-run report (default, no writes)
+ *   node scripts/assign-audience-segments.mjs --apply         # push audience-* tags to GHL
+ *   node scripts/assign-audience-segments.mjs --limit 50      # process N contacts only
+ *   node scripts/assign-audience-segments.mjs --verbose       # show per-contact detail
+ *
+ * Env: SUPABASE_SHARED_URL/SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL ·
+ *      SUPABASE_SHARED_SERVICE_ROLE_KEY/SUPABASE_SERVICE_ROLE_KEY ·
+ *      GHL_PRIVATE_TOKEN or GHL_API_KEY · GHL_LOCATION_ID (only needed for --apply)
+ */
+
+import '../lib/load-env.mjs';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { createClient } from '@supabase/supabase-js';
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const args = new Set(process.argv.slice(2));
+const APPLY = args.has('--apply');
+const VERBOSE = args.has('--verbose');
+const LIMIT_IDX = process.argv.indexOf('--limit');
+const LIMIT = LIMIT_IDX > -1 ? parseInt(process.argv[LIMIT_IDX + 1], 10) : null;
+
+const SUPABASE_URL =
+  process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY =
+  process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing Supabase env vars (SUPABASE_SHARED_URL / SUPABASE_SHARED_SERVICE_ROLE_KEY).');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+const config = JSON.parse(readFileSync(join(__dirname, '..', 'config', 'audience-segments.json'), 'utf8'));
+const PREFIX = config.tagPrefix || 'audience-';
+const RESPECT_UNSUB = config.rules?.respectUnsubscribe !== false;
+const AUDIENCES = config.audiences;
+
+const norm = (s) => (s || '').toString().toLowerCase().trim();
+
+// ── Load all contacts (paginate past the 1000-row default) ──────────────
+async function loadContacts() {
+  const rows = [];
+  const page = 1000;
+  for (let offset = 0; ; offset += page) {
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, full_name, email, tags, is_storyteller, newsletter_consent, newsletter_unsubscribed_at')
+      .order('id', { ascending: true })
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    rows.push(...data);
+    if (data.length < page) break;
+    if (LIMIT && rows.length >= LIMIT) break;
+  }
+  return LIMIT ? rows.slice(0, LIMIT) : rows;
+}
+
+// ── Load opportunities → map ghl_contact_id → { pipelines:Set, hasWonValue } ─
+async function loadOppIndex() {
+  const index = new Map();
+  const page = 1000;
+  for (let offset = 0; ; offset += page) {
+    const { data, error } = await supabase
+      .from('ghl_opportunities')
+      .select('ghl_contact_id, pipeline_name, status, monetary_value')
+      .order('ghl_contact_id', { ascending: true })
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    for (const o of data) {
+      if (!o.ghl_contact_id) continue;
+      let e = index.get(o.ghl_contact_id);
+      if (!e) {
+        e = { pipelines: new Set(), hasWonValue: false };
+        index.set(o.ghl_contact_id, e);
+      }
+      if (o.pipeline_name) e.pipelines.add(norm(o.pipeline_name));
+      if (norm(o.status) === 'won' && Number(o.monetary_value) > 0) e.hasWonValue = true;
+    }
+    if (data.length < page) break;
+  }
+  return index;
+}
+
+// ── Decide a contact's audiences ────────────────────────────────────────
+function audiencesFor(contact, opp) {
+  if (RESPECT_UNSUB && contact.newsletter_unsubscribed_at) return [];
+  const tags = (contact.tags || []).map(norm);
+  const pipelines = opp ? opp.pipelines : new Set();
+  const result = [];
+
+  for (const [key, a] of Object.entries(AUDIENCES)) {
+    // hard consent gate
+    if (a.requiresNewsletterConsent && contact.newsletter_consent !== true) continue;
+
+    let signal = false;
+    if (a.requiresNewsletterConsent && contact.newsletter_consent === true) signal = true;
+    if (!signal && Array.isArray(a.flags)) {
+      for (const f of a.flags) if (contact[f] === true) signal = true;
+    }
+    if (!signal && Array.isArray(a.pipelines)) {
+      for (const p of a.pipelines) if (pipelines.has(norm(p))) signal = true;
+    }
+    if (!signal && Array.isArray(a.tagPatterns)) {
+      for (const pat of a.tagPatterns) if (tags.some((t) => t.includes(norm(pat)))) signal = true;
+    }
+    if (!signal && a.wonOpportunityWithValue && opp?.hasWonValue) signal = true;
+
+    if (signal) result.push(key);
+  }
+  return result;
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+(async () => {
+  console.log(`\n🎯 Audience segmentation — ${APPLY ? 'APPLY (writing tags to GHL)' : 'DRY-RUN (no writes)'}`);
+  console.log(`   config v${config.version} · ${Object.keys(AUDIENCES).length} audiences · prefix "${PREFIX}"\n`);
+
+  const [contacts, oppIndex] = await Promise.all([loadContacts(), loadOppIndex()]);
+  console.log(`Loaded ${contacts.length} contacts · ${oppIndex.size} contacts with opportunities\n`);
+
+  const counts = Object.fromEntries(Object.keys(AUDIENCES).map((k) => [k, 0]));
+  const sizeDist = {}; // number-of-audiences → count
+  let noAudience = 0;
+  const plan = []; // { contact, target:Set, add:[], remove:[] }
+
+  for (const c of contacts) {
+    const auds = audiencesFor(c, oppIndex.get(c.ghl_id));
+    for (const a of auds) counts[a]++;
+    sizeDist[auds.length] = (sizeDist[auds.length] || 0) + 1;
+    if (auds.length === 0) noAudience++;
+
+    const targetTags = new Set(auds.map((k) => AUDIENCES[k].tag));
+    const existingAudienceTags = (c.tags || []).filter((t) => norm(t).startsWith(norm(PREFIX)));
+    const add = [...targetTags].filter((t) => !existingAudienceTags.map(norm).includes(norm(t)));
+    const remove = existingAudienceTags.filter((t) => !targetTags.has(t));
+    if (add.length || remove.length) plan.push({ contact: c, add, remove });
+  }
+
+  // Report
+  console.log('Audience membership:');
+  for (const [k, a] of Object.entries(AUDIENCES)) {
+    const pct = ((counts[k] / contacts.length) * 100).toFixed(1);
+    console.log(`  ${a.tag.padEnd(22)} ${String(counts[k]).padStart(5)}  (${pct}%)  — ${a.label}`);
+  }
+  console.log(`\nAudiences per contact:`);
+  for (const n of Object.keys(sizeDist).sort()) {
+    console.log(`  ${n} audience(s): ${sizeDist[n]}`);
+  }
+  console.log(`  → ${noAudience} contacts in no audience (not on any send list yet)`);
+
+  console.log(`\nTag changes needed: ${plan.length} contacts`);
+  const totalAdd = plan.reduce((s, p) => s + p.add.length, 0);
+  const totalRemove = plan.reduce((s, p) => s + p.remove.length, 0);
+  console.log(`  ${totalAdd} tag adds · ${totalRemove} tag removes`);
+
+  if (VERBOSE) {
+    for (const p of plan.slice(0, 30)) {
+      const id = p.contact.full_name || p.contact.email || p.contact.ghl_id;
+      console.log(`  • ${id}: +[${p.add.join(', ')}]${p.remove.length ? ` -[${p.remove.join(', ')}]` : ''}`);
+    }
+    if (plan.length > 30) console.log(`  …and ${plan.length - 30} more`);
+  }
+
+  if (!APPLY) {
+    console.log(`\nDry-run only. Re-run with --apply to write these audience-* tags to GHL.`);
+    console.log(`(--apply performs ${totalAdd + totalRemove} GHL writes — a shared-state bulk operation.)\n`);
+    return;
+  }
+
+  // Apply: push audience-* tags to GHL (add then remove, within the audience-* namespace only)
+  const ghl = createGHLService();
+  let applied = 0;
+  let skippedNoId = 0;
+  let errors = 0;
+  for (const p of plan) {
+    if (!p.contact.ghl_id) {
+      skippedNoId++;
+      continue;
+    }
+    try {
+      for (const t of p.add) await ghl.addTagToContact(p.contact.ghl_id, t);
+      for (const t of p.remove) await ghl.removeTagFromContact(p.contact.ghl_id, t);
+      applied++;
+      if (applied % 50 === 0) console.log(`  …${applied}/${plan.length} contacts updated`);
+    } catch (e) {
+      errors++;
+      console.error(`  ✗ ${p.contact.ghl_id}: ${e.message}`);
+    }
+  }
+  console.log(`\n✅ Applied to ${applied} contacts · ${skippedNoId} skipped (no ghl_id) · ${errors} errors\n`);
+})().catch((e) => {
+  console.error('Fatal:', e);
+  process.exit(1);
+});

--- a/scripts/assign-audience-segments.mjs
+++ b/scripts/assign-audience-segments.mjs
@@ -221,8 +221,10 @@ function audiencesFor(contact, opp) {
 
   // Apply: push audience-* tags to GHL (add then remove, within the audience-* namespace only)
   const ghl = createGHLService();
+  const today = new Date().toISOString().slice(0, 10);
   let applied = 0;
   let skippedNoId = 0;
+  let ghostsMarked = 0;
   let errors = 0;
   for (const p of plan) {
     if (!p.contact.ghl_id) {
@@ -239,11 +241,20 @@ function audiencesFor(contact, opp) {
       applied++;
       if (applied % 50 === 0) console.log(`  …${applied}/${plan.length} contacts updated`);
     } catch (e) {
-      errors++;
-      console.error(`  ✗ ${p.contact.ghl_id}: ${e.message}`);
+      // Contact deleted/merged out of GHL → soft-mark it so future runs skip it
+      if (/not found/i.test(e.message)) {
+        const goneTags = [...new Set([...(p.contact.tags || []), GONE_TAG, `${GONE_TAG}-${today}`])];
+        await supabase.from('ghl_contacts').update({ tags: goneTags }).eq('id', p.contact.id);
+        ghostsMarked++;
+      } else {
+        errors++;
+        console.error(`  ✗ ${p.contact.ghl_id}: ${e.message}`);
+      }
     }
   }
-  console.log(`\n✅ Applied to ${applied} contacts · ${skippedNoId} skipped (no ghl_id) · ${errors} errors\n`);
+  console.log(
+    `\n✅ Applied to ${applied} contacts · ${ghostsMarked} ghosts marked '${GONE_TAG}' · ${skippedNoId} no-id · ${errors} other errors\n`
+  );
 })().catch((e) => {
   console.error('Fatal:', e);
   process.exit(1);

--- a/scripts/assign-audience-segments.mjs
+++ b/scripts/assign-audience-segments.mjs
@@ -32,7 +32,7 @@
  */
 
 import '../lib/load-env.mjs';
-import { readFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { createClient } from '@supabase/supabase-js';
@@ -46,6 +46,9 @@ const APPLY = args.has('--apply');
 const VERBOSE = args.has('--verbose');
 const LIMIT_IDX = process.argv.indexOf('--limit');
 const LIMIT = LIMIT_IDX > -1 ? parseInt(process.argv[LIMIT_IDX + 1], 10) : null;
+const DUMP_IDX = process.argv.indexOf('--dump-stale-candidates');
+const DUMP_PATH = DUMP_IDX > -1 ? process.argv[DUMP_IDX + 1] : null;
+const GONE_TAG = 'gone-from-ghl';
 
 const SUPABASE_URL =
   process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -149,9 +152,15 @@ function audiencesFor(contact, opp) {
   const counts = Object.fromEntries(Object.keys(AUDIENCES).map((k) => [k, 0]));
   const sizeDist = {}; // number-of-audiences → count
   let noAudience = 0;
+  let goneCount = 0;
   const plan = []; // { contact, target:Set, add:[], remove:[] }
 
   for (const c of contacts) {
+    // Skip contacts that no longer exist in GHL (soft-deleted by clean-stale-ghl-contacts)
+    if ((c.tags || []).some((t) => norm(t) === GONE_TAG)) {
+      goneCount++;
+      continue;
+    }
     const auds = audiencesFor(c, oppIndex.get(c.ghl_id));
     for (const a of auds) counts[a]++;
     sizeDist[auds.length] = (sizeDist[auds.length] || 0) + 1;
@@ -162,6 +171,20 @@ function audiencesFor(contact, opp) {
     const add = [...targetTags].filter((t) => !existingAudienceTags.map(norm).includes(norm(t)));
     const remove = existingAudienceTags.filter((t) => !targetTags.has(t));
     if (add.length || remove.length) plan.push({ contact: c, add, remove });
+  }
+
+  // Dump candidate manifest for clean-stale-ghl-contacts-from-manifest.mjs and exit
+  if (DUMP_PATH) {
+    const entries = plan
+      .filter((p) => p.contact.ghl_id)
+      .map((p) => ({ status: 'failed', error: 'Contact not found', ghl_contact_id: p.contact.ghl_id }));
+    writeFileSync(
+      DUMP_PATH,
+      JSON.stringify({ generated_at: new Date().toISOString(), source: 'assign-audience-segments.mjs', entries }, null, 2)
+    );
+    console.log(`Wrote ${entries.length} candidate ids to ${DUMP_PATH}`);
+    console.log(`Next: node scripts/clean-stale-ghl-contacts-from-manifest.mjs ${DUMP_PATH} --apply`);
+    return;
   }
 
   // Report
@@ -175,6 +198,7 @@ function audiencesFor(contact, opp) {
     console.log(`  ${n} audience(s): ${sizeDist[n]}`);
   }
   console.log(`  → ${noAudience} contacts in no audience (not on any send list yet)`);
+  if (goneCount) console.log(`  (skipped ${goneCount} contacts tagged '${GONE_TAG}' — no longer in GHL)`);
 
   console.log(`\nTag changes needed: ${plan.length} contacts`);
   const totalAdd = plan.reduce((s, p) => s + p.add.length, 0);
@@ -208,6 +232,10 @@ function audiencesFor(contact, opp) {
     try {
       for (const t of p.add) await ghl.addTagToContact(p.contact.ghl_id, t);
       for (const t of p.remove) await ghl.removeTagFromContact(p.contact.ghl_id, t);
+      // Mirror into Supabase so ghl_contacts.tags reflects GHL (keeps re-runs idempotent)
+      const removeSet = new Set(p.remove.map(norm));
+      const mirrored = [...new Set([...(p.contact.tags || []).filter((t) => !removeSet.has(norm(t))), ...p.add])];
+      await supabase.from('ghl_contacts').update({ tags: mirrored }).eq('id', p.contact.id);
       applied++;
       if (applied % 50 === 0) console.log(`  …${applied}/${plan.length} contacts updated`);
     } catch (e) {


### PR DESCRIPTION
## What

The audience-segmentation foundation for the ACT communication pipeline — closes the open item in `act-communication-pipeline-2026-05-23-locked` ("which GHL tags map to each audience").

- **`config/audience-segments.json`** — data-driven taxonomy (funder / partner / brand / storyteller) with per-audience rules (pipelines, flags, tag patterns, consent gate).
- **`scripts/assign-audience-segments.mjs`** — computes each GHL contact's audience(s) and writes canonical `audience-*` tags to GHL. These tags *are* each newsletter's recipient list. Dry-run by default; `--apply` writes; mirrors tags into `ghl_contacts.tags` for idempotent re-runs; `--dump-stale-candidates` emits a clean-stale manifest; skips `gone-from-ghl` ghosts.

## Result

Dry-run segmentation: **funder 88 · partner 290 · storyteller 315 · brand 116** (brand consent-gated). 1,652 contacts in no audience (cold inbound, correctly off all lists).

`--apply` ran 2026-05-28: **422 contacts tagged in GHL**. 308 errors were all `Contact not found` — stale `ghl_contacts` rows from earlier dedup runs. Follow-up (operational, not code): run `clean-stale-ghl-contacts-from-manifest.mjs` to soft-mark the ghosts, then re-apply.

## Docs

Operator guide: Notion → ACT Communications Hub → ⚙️ Comms & CRM Operating System → Newsletter + social audience system.

Plan: act-communication-pipeline-2026-05-23-locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)