### PR TITLE
fix(storytellers): repair EL-v2 sync, add OCAP filters, disable GHL push

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -34,11 +34,15 @@ const cronScripts = [
     script: 'scripts/daily-briefing.mjs',
     cron_restart: '0 7 * * *', // Daily 7am AEST
   },
-  {
-    name: 'storyteller-sync',
-    script: 'scripts/sync-storytellers-to-ghl.mjs',
-    cron_restart: '30 4 * * *', // Daily 4:30am AEST (before embed)
-  },
+  // DISABLED 2026-05-28: storytellers are NOT pushed to GHL — their data stays
+  // in Empathy Ledger / Supabase per ACT data protocol. The push script is kept
+  // (schema-fixed + OCAP-filtered) for manual/dry-run use, but the daily GHL push
+  // is off. The Supabase-only `storyteller-link` below stays on.
+  // {
+  //   name: 'storyteller-sync',
+  //   script: 'scripts/sync-storytellers-to-ghl.mjs',
+  //   cron_restart: '30 4 * * *', // Daily 4:30am AEST (before embed)
+  // },
   {
     name: 'storyteller-link',
     script: 'scripts/link-storytellers-to-contacts.mjs',

--- a/scripts/sync-storytellers-to-ghl.mjs
+++ b/scripts/sync-storytellers-to-ghl.mjs
@@ -115,16 +115,14 @@ async function getStorytellersWithCounts(elClient, options = {}) {
       display_name,
       bio,
       location,
-      cultural_background,
-      language_skills,
-      areas_of_expertise,
       public_avatar_url,
       is_active,
+      is_ancestor,
+      deleted_at,
       is_elder,
       is_featured,
       is_justicehub_featured,
       justicehub_enabled,
-      author_role,
       created_at,
       updated_at,
       profiles:profile_id (
@@ -133,6 +131,8 @@ async function getStorytellersWithCounts(elClient, options = {}) {
       )
     `)
     .eq('is_active', true)
+    .is('deleted_at', null) // exclude soft-deleted storytellers
+    .not('is_ancestor', 'is', true) // OCAP: never CRM-contact deceased ancestors
     .order('updated_at', { ascending: false });
 
   if (limit) {
@@ -233,18 +233,10 @@ function storytellerToGHLContact(storyteller) {
     [CONFIG.CUSTOM_FIELDS.PUBLISHED_STORIES]: String(storyteller.published_stories || 0)
   };
 
-  if (storyteller.cultural_background?.length > 0) {
-    customFields[CONFIG.CUSTOM_FIELDS.CULTURAL_BACKGROUND] =
-      storyteller.cultural_background.join(', ');
-  }
-  if (storyteller.language_skills?.length > 0) {
-    customFields[CONFIG.CUSTOM_FIELDS.LANGUAGES] =
-      storyteller.language_skills.join(', ');
-  }
-  if (storyteller.areas_of_expertise?.length > 0) {
-    customFields[CONFIG.CUSTOM_FIELDS.EXPERTISE] =
-      storyteller.areas_of_expertise.join(', ');
-  }
+  // Cultural data (cultural_background, languages, expertise) is intentionally
+  // NOT pushed to GHL — it stays in Empathy Ledger / Supabase per ACT's data
+  // protocol (decision 2026-05-28). The languages/expertise columns no longer
+  // exist in EL v2 either.
 
   return {
     firstName,


### PR DESCRIPTION
## Why

The storyteller→GHL sync (`storyteller-sync` PM2 cron, daily 4:30am) has been **silently failing** — it queries `storytellers.language_skills` / `areas_of_expertise` / `author_role`, columns that no longer exist in Empathy Ledger v2. This is a cause of stale storyteller data in GHL (277 storyteller `ghl_contacts` rows now resolve to deleted GHL contacts).

## Decisions encoded (2026-05-28)

- **Storytellers are NOT pushed to GHL** — they're reached via Empathy Ledger, their data stays in EL/Supabase per ACT's data protocol. So the daily `storyteller-sync` cron is **disabled** (commented out). The Supabase-only `storyteller-link` cron stays on.
- **OCAP filters added** — exclude `is_ancestor` (deceased) and `deleted_at` storytellers. Never CRM-contact a deceased person.
- **Cultural data withheld from GHL** — stop pushing `cultural_background` / languages / expertise into the CRM.

## What changed

- `scripts/sync-storytellers-to-ghl.mjs` — remove 3 dead columns; add `is_ancestor`/`deleted_at` filters; drop cultural-data custom fields. Script still runs (manual/dry-run) but is no longer cron-driven.
- `ecosystem.config.cjs` — comment out the `storyteller-sync` cron entry.

## Verification

Dry-run after fix: **266 active storytellers** (ancestors/deleted excluded), 21 elders, 778 stories. Confirmed the data is unfit for a CRM send list anyway — many have no email, some are `@placeholder.local` or test accounts.

## Note

This does **not** unwind the 277 `gone-from-ghl` tags from the audience-segmentation cleanup (PR #114) — those rows correctly stay quarantined; storytellers simply aren't a GHL audience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)