### PR TITLE
chore(goods): dedupe double-listed Demand Register communities

### DIFF
--- a/scripts/goods-dedup-demand-register.mjs
+++ b/scripts/goods-dedup-demand-register.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * goods-dedup-demand-register.mjs — one-off: dedupe double-listed communities in
+ * the GHL Goods Demand Register (pipeline UQsrmuqzxMSdCTklxEcG).
+ *
+ * Rule: one row per community. Where a community has a store/council row (further
+ * along, "Buyer Matched") AND a "$-demand" Signal row, keep the matched row and
+ * carry the $ onto it, delete the Signal row. Where two rows are the same entity,
+ * keep the canonical-named one. Genuinely different orgs in one community are NOT
+ * duplicates and are left alone.
+ *
+ * Deletes are captured to a restore JSON first (hard to reverse otherwise).
+ * Review-first: DRY RUN by default; --apply to execute.
+ *
+ * Plan: thoughts/shared/plans/2026-05-28-goods-three-pipeline-operating-model.md
+ */
+import { createGHLService } from './lib/ghl-api-service.mjs';
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+
+const APPLY = process.argv.includes('--apply');
+const ghl = createGHLService();
+
+// keepId gets the $ (from valueFrom), deleteId is removed. Decisions from the
+// 2026-05-28 audit (see report). Peppimenarti + Kaltukatjara deliberately excluded.
+const ACTIONS = [
+  { community: 'PAPUNYA',     keepId: 'EgkXFugnS2xxR9wYaWVh', setValue: 192550, deleteId: 'pItYrdA1TvqqZogYiYjU', why: 'store row (Buyer Matched) + $-demand Signal row → keep store, carry $, delete demand' },
+  { community: 'BARUNGA',     keepId: 'YKQwyI2TwAi8f1b0iWcW', setValue: 172700, deleteId: 'sVyQaulOXIzAwrm0VpGv', why: 'store row (Buyer Matched) + $-demand Signal row → keep store, carry $, delete demand' },
+  { community: 'MOUNT LIEBIG', keepId: '8q4kQlIXJXAz3XjYjZDW', setValue: null, deleteId: 'xD3M6SAfpIPmis7jav1h', why: 'same store twice → keep Amundurrngu (canonical corp), delete generic dup' },
+];
+
+async function main() {
+  console.log(`=== Dedup Goods Demand Register (${APPLY ? 'APPLY' : 'DRY RUN'}) ===\n`);
+  const restore = [];
+  for (const a of ACTIONS) {
+    // capture the opp we'll delete
+    let del = null;
+    try { del = await ghl.getOpportunityById(a.deleteId); } catch (e) { console.log(`  ⚠ ${a.community}: could not fetch delete target ${a.deleteId} (${e.message.slice(0,60)}) — skipping`); continue; }
+    restore.push({ community: a.community, action: a, deletedOpp: del });
+    const valStr = a.setValue != null ? ` · set keep $${a.setValue.toLocaleString()}` : '';
+    console.log(`  ${a.community}: keep ${a.keepId}${valStr} · delete ${a.deleteId} ("${del?.name}")`);
+    console.log(`     ${a.why}`);
+    if (!APPLY) continue;
+    if (a.setValue != null) await ghl.updateOpportunity(a.keepId, { monetaryValue: a.setValue });
+    await ghl.deleteOpportunity(a.deleteId);
+    console.log(`     ✓ applied`);
+  }
+  // always write the restore capture (even dry run, for the record)
+  const path = `thoughts/shared/data/goods-demand-dedup-restore-2026-05-28.json`;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify({ generatedAt: new Date().toISOString(), applied: APPLY, restore }, null, 2));
+  console.log(`\n✓ Restore capture: ${path}`);
+  console.log('  KEPT BOTH (not dups): PEPPIMENARTI (Health Services + Store).');
+  console.log('  FLAGGED (not touched): KALTUKATJARA (Nguratjaku Council vs Community Council) — confirm if same entity.');
+  console.log(APPLY ? '\nDone.' : '\nDry run — re-run with --apply.');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/thoughts/shared/data/goods-demand-dedup-restore-2026-05-28.json
+++ b/thoughts/shared/data/goods-demand-dedup-restore-2026-05-28.json
@@ -1,0 +1,154 @@
+{
+  "generatedAt": "2026-05-27T21:06:47.871Z",
+  "applied": true,
+  "restore": [
+    {
+      "community": "PAPUNYA",
+      "action": {
+        "community": "PAPUNYA",
+        "keepId": "EgkXFugnS2xxR9wYaWVh",
+        "setValue": 192550,
+        "deleteId": "pItYrdA1TvqqZogYiYjU",
+        "why": "store row (Buyer Matched) + $-demand Signal row → keep store, carry $, delete demand"
+      },
+      "deletedOpp": {
+        "id": "pItYrdA1TvqqZogYiYjU",
+        "name": "PAPUNYA — Goods Demand $193K",
+        "monetaryValue": 192550,
+        "pipelineId": "UQsrmuqzxMSdCTklxEcG",
+        "pipelineStageId": "0c5ed787-2015-4af0-b2ad-a916e40879db",
+        "status": "open",
+        "lastStatusChangeAt": "2026-03-13T22:29:29.321Z",
+        "lastStageChangeAt": "2026-04-23T20:10:18.173Z",
+        "createdAt": "2026-03-13T22:29:29.321Z",
+        "updatedAt": "2026-04-23T20:10:18.184Z",
+        "contactId": "sTvgHaWnDeaKnCayvyf8",
+        "isAttribute": false,
+        "internalSource": {
+          "type": "CREATED",
+          "id": "695cb35c2eda1cb50c2dd51f",
+          "apiVersion": "2021-07-28",
+          "channel": "OAUTH",
+          "source": "INTEGRATION"
+        },
+        "locationId": "agzsSZWgovjwgpcoASWG",
+        "lastActionDate": "2026-04-23T20:10:18.173Z",
+        "followers": [],
+        "contact": {
+          "id": "sTvgHaWnDeaKnCayvyf8",
+          "name": "PAPUNYA NT",
+          "companyName": "PAPUNYA, NT",
+          "email": "papunya@goods.civicgraph.io",
+          "tags": [
+            "goods-warm",
+            "act-gd",
+            "project:act-gd",
+            "audience-partner"
+          ],
+          "followers": []
+        }
+      }
+    },
+    {
+      "community": "BARUNGA",
+      "action": {
+        "community": "BARUNGA",
+        "keepId": "YKQwyI2TwAi8f1b0iWcW",
+        "setValue": 172700,
+        "deleteId": "sVyQaulOXIzAwrm0VpGv",
+        "why": "store row (Buyer Matched) + $-demand Signal row → keep store, carry $, delete demand"
+      },
+      "deletedOpp": {
+        "id": "sVyQaulOXIzAwrm0VpGv",
+        "name": "BARUNGA — Goods Demand $173K",
+        "monetaryValue": 172700,
+        "pipelineId": "UQsrmuqzxMSdCTklxEcG",
+        "pipelineStageId": "0c5ed787-2015-4af0-b2ad-a916e40879db",
+        "status": "open",
+        "lastStatusChangeAt": "2026-03-13T22:29:37.644Z",
+        "lastStageChangeAt": "2026-04-23T20:10:25.637Z",
+        "createdAt": "2026-03-13T22:29:37.644Z",
+        "updatedAt": "2026-04-23T20:10:25.653Z",
+        "contactId": "uPpIqeOMahVTSBk5N3j3",
+        "isAttribute": false,
+        "internalSource": {
+          "type": "CREATED",
+          "id": "695cb35c2eda1cb50c2dd51f",
+          "apiVersion": "2021-07-28",
+          "channel": "OAUTH",
+          "source": "INTEGRATION"
+        },
+        "locationId": "agzsSZWgovjwgpcoASWG",
+        "lastActionDate": "2026-04-23T20:10:25.637Z",
+        "followers": [],
+        "contact": {
+          "id": "uPpIqeOMahVTSBk5N3j3",
+          "name": "BARUNGA NT",
+          "companyName": "BARUNGA, NT",
+          "email": "barunga@goods.civicgraph.io",
+          "tags": [
+            "goods-warm",
+            "act-gd",
+            "project:act-gd",
+            "audience-partner"
+          ],
+          "followers": []
+        }
+      }
+    },
+    {
+      "community": "MOUNT LIEBIG",
+      "action": {
+        "community": "MOUNT LIEBIG",
+        "keepId": "8q4kQlIXJXAz3XjYjZDW",
+        "setValue": null,
+        "deleteId": "xD3M6SAfpIPmis7jav1h",
+        "why": "same store twice → keep Amundurrngu (canonical corp), delete generic dup"
+      },
+      "deletedOpp": {
+        "id": "xD3M6SAfpIPmis7jav1h",
+        "name": "Mt Liebig Community Store Aboriginal Corporation — MOUNT LIEBIG",
+        "monetaryValue": 0,
+        "pipelineId": "UQsrmuqzxMSdCTklxEcG",
+        "pipelineStageId": "02502aa3-9a0d-4ddd-b1f0-c1e836838426",
+        "status": "open",
+        "source": "Goods top-25 activation",
+        "lastStatusChangeAt": "2026-05-27T06:07:12.495Z",
+        "lastStageChangeAt": "2026-05-27T06:07:12.495Z",
+        "createdAt": "2026-05-27T06:07:12.495Z",
+        "updatedAt": "2026-05-27T06:07:12.495Z",
+        "contactId": "HAN2VLPXisHJErXrXkhy",
+        "isAttribute": false,
+        "internalSource": {
+          "type": "CREATED",
+          "id": "695cb35c2eda1cb50c2dd51f",
+          "source": "INTEGRATION",
+          "apiVersion": "2021-07-28",
+          "channel": "OAUTH"
+        },
+        "locationId": "agzsSZWgovjwgpcoASWG",
+        "lastActionDate": "2026-05-27T06:07:12.495Z",
+        "followers": [],
+        "contact": {
+          "id": "HAN2VLPXisHJErXrXkhy",
+          "name": "Mt Liebig Community Store Aboriginal Corporation",
+          "companyName": "Mt Liebig Community Store Aboriginal Corporation",
+          "email": "mt-liebig-community-store-aboriginal-corporation-mount-liebig@goods.civicgraph.io",
+          "tags": [
+            "civicgraph",
+            "goods",
+            "act-gd",
+            "project:act-gd",
+            "goods-community-mount-liebig",
+            "goods-state-nt",
+            "goods-role-store",
+            "goods-communitycontrolled",
+            "goods-stage-prospect",
+            "audience-partner"
+          ],
+          "followers": []
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
One-off GHL cleanup. 3 communities had two opps for the same need → consolidated to one row each (Papunya/Barunga kept the store row + carried the $-demand value; Mount Liebig kept the canonical corp). Peppimenarti left alone (two real orgs); Kaltukatjara flagged. Deleted opps captured to a restore JSON (reversible). Demand Register 100→97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)