### PR TITLE
Comms: partner + brand newsletter drafters, public archive, unified content calendar

### DIFF
--- a/apps/website/src/app/newsletters/[slug]/page.tsx
+++ b/apps/website/src/app/newsletters/[slug]/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import {
+  fetchBrandEditionBySlug,
+  fetchSentBrandEditions,
+} from "../../../lib/newsletters";
+
+export const revalidate = 60;
+
+export async function generateStaticParams() {
+  try {
+    const editions = await fetchSentBrandEditions(200);
+    return editions.map((edition) => ({ slug: edition.editionSlug }));
+  } catch (error) {
+    console.error("Failed to generate static params for newsletters:", error);
+    return [];
+  }
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleDateString("en-AU", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export default async function NewsletterEditionPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const edition = await fetchBrandEditionBySlug(slug);
+
+  if (!edition) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-12">
+      <section className="rounded-[32px] border border-[#E3D4BA] bg-gradient-to-br from-[#F6F1E7] via-[#E7DDC7] to-[#D7C4A2] p-8 md:p-12">
+        <Link
+          href="/newsletters"
+          className="text-xs uppercase tracking-[0.3em] text-[#4CAF50]"
+        >
+          Back to newsletter
+        </Link>
+        <h1 className="mt-4 text-3xl font-semibold text-[#2F3E2E] md:text-5xl font-[var(--font-display)]">
+          {edition.subject}
+        </h1>
+        <div className="mt-4 flex flex-wrap items-center gap-4 text-xs uppercase tracking-[0.3em] text-[#6B5A45]">
+          {edition.editionPeriod ? <span>{edition.editionPeriod}</span> : null}
+          {edition.sentAt ? <span>{formatDate(edition.sentAt)}</span> : null}
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-2xl">
+        <article className="rounded-3xl border border-[#E3D4BA] bg-white/70 p-6 text-sm text-[#4D3F33] md:p-8">
+          {edition.bodyMd ? (
+            <div className="rich-text prose prose-sm max-w-none">
+              <ReactMarkdown>{edition.bodyMd}</ReactMarkdown>
+            </div>
+          ) : (
+            <p>No body content available.</p>
+          )}
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/apps/website/src/app/newsletters/page.tsx
+++ b/apps/website/src/app/newsletters/page.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { fetchSentBrandEditions } from "../../lib/newsletters";
+
+export const revalidate = 60;
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  try {
+    return new Date(iso).toLocaleDateString("en-AU", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export default async function NewslettersPage() {
+  const editions = await fetchSentBrandEditions(60);
+
+  return (
+    <div className="space-y-16">
+      <section className="rounded-[32px] border border-[#E3D4BA] bg-gradient-to-br from-[#F6F1E7] via-[#E7DDC7] to-[#D7C4A2] p-8 md:p-12">
+        <p className="text-xs uppercase tracking-[0.4em] text-[#6B5A45]">
+          ACT Newsletter
+        </p>
+        <h1 className="mt-4 text-3xl font-semibold text-[#2F3E2E] md:text-5xl font-[var(--font-display)]">
+          Field notes, every fortnight
+        </h1>
+        <p className="mt-4 max-w-2xl text-sm text-[#4D3F33] md:text-base">
+          What moved across the farm, the studio and the projects. The public
+          archive of our fortnightly note.
+        </p>
+      </section>
+
+      <section className="space-y-4">
+        {editions.map((edition) => (
+          <Link
+            key={edition.editionSlug}
+            href={`/newsletters/${edition.editionSlug}`}
+            className="group flex flex-col gap-2 rounded-3xl border border-[#E1D3BA] bg-white/70 p-6 transition hover:-translate-y-1 hover:border-[#4CAF50] hover:shadow-[0_18px_45px_rgba(50,42,31,0.12)] md:flex-row md:items-center md:justify-between"
+          >
+            <div className="flex flex-col gap-1">
+              <span className="text-xs uppercase tracking-[0.3em] text-[#6B5A45]">
+                {edition.editionPeriod || "Edition"}
+              </span>
+              <h2 className="text-xl font-semibold text-[#2F3E2E] font-[var(--font-display)]">
+                {edition.subject}
+              </h2>
+            </div>
+            <div className="flex items-center gap-4 text-xs text-[#6B5A45]">
+              {edition.sentAt ? <span>{formatDate(edition.sentAt)}</span> : null}
+              <span className="inline-flex items-center gap-2 font-semibold uppercase tracking-[0.3em] text-[#4CAF50]">
+                Read
+                <span aria-hidden="true">-&gt;</span>
+              </span>
+            </div>
+          </Link>
+        ))}
+        {editions.length === 0 ? (
+          <div className="rounded-3xl border border-[#E1D3BA] bg-white/70 p-6 text-sm text-[#4D3F33]">
+            No editions published yet. The fortnightly note will appear here once
+            the first one is sent.
+          </div>
+        ) : null}
+      </section>
+    </div>
+  );
+}

--- a/apps/website/src/lib/newsletters.ts
+++ b/apps/website/src/lib/newsletters.ts
@@ -1,0 +1,72 @@
+import "server-only";
+import { getSupabaseServerClient } from "./supabase/server";
+
+export type BrandEdition = {
+  editionSlug: string;
+  subject: string;
+  editionPeriod: string | null;
+  sentAt: string | null;
+  bodyMd: string;
+};
+
+type DraftRow = {
+  edition_slug: string;
+  selected_subject: string | null;
+  subject_candidates: string[] | null;
+  edition_period: string | null;
+  sent_at: string | null;
+  body_md: string | null;
+};
+
+const COLUMNS =
+  "edition_slug, selected_subject, subject_candidates, edition_period, sent_at, body_md";
+
+function toEdition(row: DraftRow): BrandEdition {
+  const subject =
+    row.selected_subject ||
+    (row.subject_candidates && row.subject_candidates[0]) ||
+    row.edition_period ||
+    "ACT newsletter";
+  return {
+    editionSlug: row.edition_slug,
+    subject,
+    editionPeriod: row.edition_period ?? null,
+    sentAt: row.sent_at ?? null,
+    bodyMd: row.body_md || "",
+  };
+}
+
+// Sent brand editions only — funder/partner editions are private and never archived.
+export async function fetchSentBrandEditions(limit = 60): Promise<BrandEdition[]> {
+  const supabase = getSupabaseServerClient();
+  if (!supabase) return [];
+  const { data, error } = await supabase
+    .from("newsletter_drafts")
+    .select(COLUMNS)
+    .eq("audience", "brand")
+    .eq("status", "sent")
+    .order("sent_at", { ascending: false })
+    .limit(limit);
+  if (error || !data) {
+    if (error) console.error("Failed to fetch brand editions:", error.message);
+    return [];
+  }
+  return (data as DraftRow[]).map(toEdition);
+}
+
+export async function fetchBrandEditionBySlug(slug: string): Promise<BrandEdition | null> {
+  const supabase = getSupabaseServerClient();
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from("newsletter_drafts")
+    .select(COLUMNS)
+    .eq("audience", "brand")
+    .eq("status", "sent")
+    .eq("edition_slug", slug)
+    .maybeSingle();
+  if (error || !data) {
+    if (error) console.error("Failed to fetch brand edition:", error.message);
+    return null;
+  }
+  return toEdition(data as DraftRow);
+}

--- a/config/comms-cadence.json
+++ b/config/comms-cadence.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "updated": "2026-05-28",
+  "description": "Per-audience newsletter cadence + candidate thresholds (locked plan act-communication-pipeline-2026-05-23-locked, Q5). Drives scripts/comms-calendar.mjs (the scheduling engine) and the Notion Comms Content Calendar view. cadence = how often an edition is due; intervalDays = days between editions (null for event-triggered); minCandidates = the threshold below which the engine recommends skipping; mode = per-recipient (one edition each) | per-audience (one edition for all) | event; drafter = the script the engine recommends running (null when not built).",
+  "audiences": {
+    "funder": {
+      "label": "Funder",
+      "cadence": "quarterly",
+      "intervalDays": 91,
+      "minCandidates": 3,
+      "mode": "per-recipient",
+      "drafter": "scripts/draft-funder-newsletter.mjs",
+      "private": true
+    },
+    "partner": {
+      "label": "Partner",
+      "cadence": "monthly",
+      "intervalDays": 30,
+      "minCandidates": 2,
+      "mode": "per-recipient",
+      "drafter": "scripts/draft-partner-newsletter.mjs",
+      "private": true
+    },
+    "brand": {
+      "label": "Brand",
+      "cadence": "fortnightly",
+      "intervalDays": 14,
+      "minCandidates": 3,
+      "mode": "per-audience",
+      "drafter": "scripts/draft-brand-newsletter.mjs",
+      "private": false
+    },
+    "storyteller": {
+      "label": "Storyteller",
+      "cadence": "event-triggered",
+      "intervalDays": null,
+      "minCandidates": 1,
+      "mode": "event",
+      "drafter": null,
+      "private": true
+    }
+  }
+}

--- a/config/notion-database-ids.json
+++ b/config/notion-database-ids.json
@@ -1,6 +1,7 @@
 {
   "newsletterCandidates": "4aeef939-d85e-4bdd-a5ed-11271f5e1272",
   "newsletterDrafts": "e09b6798-9770-4a4c-a9f8-99f3e698edcc",
+  "commsContentCalendar": "36eebcf9-81cf-8136-9a2a-ce9f6d69c532",
   "supporters": "718602b1-222d-4772-845f-ba99db40f929",
   "actProjects": "177ebcf9-81cf-80dd-9514-f1ec32f3314c",
   "missionControl": "305ebcf9-81cf-81e9-8d08-e30d3f3416b1",

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -143,6 +143,17 @@ const cronScripts = [
     cron_restart: '*/10 * * * *',
   },
   {
+    // Daily 7:40am AEST (after newsletter-candidates-to-notion at 7:35):
+    // Recompute per-audience comms cadence (last sent → next due → candidates
+    // ready vs threshold) and sync the 4 rows to the Notion Comms Content
+    // Calendar. Read-only on Supabase; no sends. Engine: locked plan Q5.
+    // Plan: 2026-05-28-unified-content-calendar
+    name: 'comms-content-calendar',
+    script: 'scripts/comms-calendar.mjs',
+    args: '--sync-notion',
+    cron_restart: '40 7 * * *',
+  },
+  {
     // Daily 06:00am AEST: rebuild the supporter intelligence view.
     // Joins Xero invoices + funders.json + GHL contacts into one row per
     // supporter org. Output: supporters_intelligence Supabase table +

--- a/scripts/comms-calendar.mjs
+++ b/scripts/comms-calendar.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+/**
+ * Unified content calendar — the comms scheduling ENGINE + Notion VIEW sync.
+ *
+ * Implements the locked plan's Q5: per-audience cadence + candidate threshold.
+ * For each newsletter audience it computes, from live Supabase data:
+ *   - last sent edition  (newsletter_drafts, status='sent')
+ *   - next due date      (last sent + intervalDays, or due-now if never sent)
+ *   - candidates ready   (status='include' candidates for the audience since last sent)
+ *   - status             (Ready | Under threshold | Not due yet | Event-triggered)
+ *   - recommended action (the drafter command, or "Skip — N/min")
+ *
+ * Reads:  config/comms-cadence.json, newsletter_drafts, newsletter_candidates
+ * Writes: (default) nothing — prints a report.
+ *         --sync-notion : upserts one row per audience into the Notion
+ *                         "Comms Content Calendar" DB (commsContentCalendar).
+ *         --run-brand   : if brand is due AND ready, runs the brand drafter for
+ *                         the current fortnight slug (per-recipient stays manual).
+ *
+ * Usage:
+ *   node scripts/comms-calendar.mjs                 # report only (read-only)
+ *   node scripts/comms-calendar.mjs --sync-notion   # + push the 4 rows to Notion
+ *   node scripts/comms-calendar.mjs --run-brand      # + fire a due+ready brand edition
+ *
+ * PM2 cron (proposed): 40 7 * * *  (after newsletter-candidates-to-notion at 7:35)
+ *
+ * Plan: 2026-05-28-unified-content-calendar
+ *       act-communication-pipeline-2026-05-23-locked (Q5)
+ */
+
+import 'dotenv/config';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+import { getSupabase } from './lib/newsletter-drafter.mjs';
+
+const args = process.argv.slice(2);
+const syncNotion = args.includes('--sync-notion');
+const runBrand = args.includes('--run-brand');
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const CADENCE_PATH = `${ROOT}config/comms-cadence.json`;
+const NOTION_IDS_PATH = `${ROOT}config/notion-database-ids.json`;
+
+const supabase = getSupabase();
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// DATE / PERIOD HELPERS
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const today = new Date();
+const isoDate = (d) => (d ? new Date(d).toISOString().slice(0, 10) : null);
+
+function addDays(date, days) {
+  return new Date(date.getTime() + days * DAY_MS);
+}
+
+// Australian financial year + quarter (FY starts 1 Jul). May 2026 → Q4-FY26.
+function auFinancialQuarter(date) {
+  const m = date.getMonth(); // 0-11
+  const y = date.getFullYear();
+  const fy = m >= 6 ? y + 1 : y; // Jul (6) onward belongs to next FY
+  const q = m >= 6 ? Math.floor((m - 6) / 3) + 1 : Math.floor((m + 6) / 3) + 1;
+  return { q, fy: String(fy).slice(-2) };
+}
+
+// Suggested edition-period slug for the recommended drafter command.
+function suggestPeriod(audienceKey, date) {
+  const y = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  if (audienceKey === 'brand') return `${y}-${mm}-${date.getDate() <= 15 ? 'A' : 'B'}`;
+  if (audienceKey === 'partner') return `${y}-${mm}`;
+  if (audienceKey === 'funder') {
+    const { q, fy } = auFinancialQuarter(date);
+    return `Q${q}-FY${fy}`;
+  }
+  return `${y}-${mm}`;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PER-AUDIENCE COMPUTATION
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+async function lastSentAt(audienceKey) {
+  const { data } = await supabase
+    .from('newsletter_drafts')
+    .select('sent_at')
+    .eq('audience', audienceKey)
+    .eq('status', 'sent')
+    .not('sent_at', 'is', null)
+    .order('sent_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return data?.sent_at || null;
+}
+
+// audiences IS NULL XOR NOT NULL partitions the rows, so manual + auto counts
+// never overlap — summing them is safe.
+async function countIncludeCandidates(audienceKey, sinceDate) {
+  const base = () =>
+    supabase
+      .from('newsletter_candidates')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'include')
+      .gte('event_date', sinceDate);
+
+  const { count: manual = 0 } = await base().contains('audiences', [audienceKey]);
+  const { count: auto = 0 } = await base().is('audiences', null).contains('auto_audiences', [audienceKey]);
+  return (manual || 0) + (auto || 0);
+}
+
+async function computeAudience(key, cfg) {
+  const sentAt = await lastSentAt(key);
+  const isEvent = cfg.mode === 'event' || !cfg.intervalDays;
+  const sinceDate = isoDate(sentAt) || '2026-01-01';
+  const candidatesReady = await countIncludeCandidates(key, sinceDate);
+
+  let nextDue = null;
+  let status;
+  let action;
+
+  if (isEvent || !cfg.drafter) {
+    status = cfg.drafter ? 'Event-triggered' : 'Event-triggered (no drafter)';
+    action = cfg.drafter
+      ? 'Fires on storyteller event'
+      : `Not built — ${candidatesReady} candidate(s) waiting`;
+  } else {
+    nextDue = sentAt ? addDays(new Date(sentAt), cfg.intervalDays) : new Date(today);
+    const dueNow = nextDue.getTime() <= today.getTime();
+    if (!dueNow) {
+      status = 'Not due yet';
+      action = `Next due ${isoDate(nextDue)}`;
+    } else if (candidatesReady >= cfg.minCandidates) {
+      status = 'Ready';
+      const period = suggestPeriod(key, today);
+      action = cfg.mode === 'per-audience'
+        ? `node ${cfg.drafter} ${period}`
+        : `node ${cfg.drafter} <recipient> ${period}`;
+    } else {
+      status = 'Under threshold';
+      action = `Skip — ${candidatesReady}/${cfg.minCandidates} candidates`;
+    }
+  }
+
+  return {
+    key,
+    label: cfg.label,
+    cadence: cfg.cadence,
+    mode: cfg.mode,
+    lastSent: isoDate(sentAt),
+    nextDue: isoDate(nextDue),
+    candidatesReady,
+    threshold: cfg.minCandidates,
+    status,
+    action,
+    drafter: cfg.drafter || '(not built)',
+  };
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// NOTION SYNC  (raw fetch, mirrors scripts/sync-candidates-to-notion.mjs)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const NOTION_API = 'https://api.notion.com/v1';
+const NOTION_VERSION = '2022-06-28';
+const NOTION_TOKEN = process.env.NOTION_MIRROR_TOKEN;
+
+let lastNotionAt = 0;
+async function notionFetch(path, init = {}, attempt = 0) {
+  const dt = Date.now() - lastNotionAt;
+  if (dt < 350) await new Promise((r) => setTimeout(r, 350 - dt));
+  lastNotionAt = Date.now();
+  let r;
+  try {
+    r = await fetch(`${NOTION_API}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${NOTION_TOKEN}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+        ...(init.headers || {}),
+      },
+    });
+  } catch (netErr) {
+    if (attempt < 4) {
+      await new Promise((res) => setTimeout(res, 1000 * 2 ** attempt));
+      return notionFetch(path, init, attempt + 1);
+    }
+    throw netErr;
+  }
+  if ((r.status >= 500 || r.status === 429) && attempt < 4) {
+    await new Promise((res) => setTimeout(res, 1000 * 2 ** attempt));
+    return notionFetch(path, init, attempt + 1);
+  }
+  if (!r.ok) {
+    const body = await r.text();
+    throw new Error(`Notion ${r.status} ${path}: ${body.slice(0, 300)}`);
+  }
+  return r.json();
+}
+
+function rowToNotionProperties(row) {
+  return {
+    Audience: { title: [{ text: { content: row.label } }] },
+    'Next due': { date: row.nextDue ? { start: row.nextDue } : null },
+    Cadence: { select: { name: row.cadence } },
+    Mode: { select: { name: row.mode } },
+    'Last sent': { date: row.lastSent ? { start: row.lastSent } : null },
+    'Candidates ready': { number: row.candidatesReady },
+    Threshold: { number: row.threshold },
+    Status: { select: { name: row.status } },
+    'Recommended action': { rich_text: [{ text: { content: row.action.slice(0, 1900) } }] },
+    Drafter: { rich_text: [{ text: { content: row.drafter } }] },
+    'Synced at': { date: { start: new Date().toISOString() } },
+  };
+}
+
+function resolveCalendarDbId() {
+  let id = process.env.NOTION_COMMS_CONTENT_CALENDAR_DB_ID;
+  if (!id && existsSync(NOTION_IDS_PATH)) {
+    id = JSON.parse(readFileSync(NOTION_IDS_PATH, 'utf8')).commsContentCalendar;
+  }
+  return id;
+}
+
+async function syncToNotion(rows) {
+  if (!NOTION_TOKEN) throw new Error('Missing NOTION_MIRROR_TOKEN');
+  const DB = resolveCalendarDbId();
+  if (!DB) {
+    throw new Error(
+      'Missing commsContentCalendar DB id — set NOTION_COMMS_CONTENT_CALENDAR_DB_ID '
+      + 'or add { "commsContentCalendar": "<db-id>" } to config/notion-database-ids.json',
+    );
+  }
+  for (const row of rows) {
+    const found = await notionFetch(`/databases/${DB}/query`, {
+      method: 'POST',
+      body: JSON.stringify({ filter: { property: 'Audience', title: { equals: row.label } }, page_size: 1 }),
+    });
+    const props = rowToNotionProperties(row);
+    if (found.results[0]) {
+      await notionFetch(`/pages/${found.results[0].id}`, { method: 'PATCH', body: JSON.stringify({ properties: props }) });
+      console.log(`   ↻ updated ${row.label}`);
+    } else {
+      await notionFetch('/pages', { method: 'POST', body: JSON.stringify({ parent: { database_id: DB }, properties: props }) });
+      console.log(`   + created ${row.label}`);
+    }
+  }
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// MAIN
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+async function main() {
+  if (!existsSync(CADENCE_PATH)) throw new Error(`comms-cadence.json missing at ${CADENCE_PATH}`);
+  const cadence = JSON.parse(readFileSync(CADENCE_PATH, 'utf8'));
+
+  console.log(`\n━━━ Comms content calendar — ${isoDate(today)} ━━━\n`);
+
+  const rows = [];
+  for (const [key, cfg] of Object.entries(cadence.audiences)) {
+    rows.push(await computeAudience(key, cfg));
+  }
+
+  // Report
+  const pad = (s, n) => String(s ?? '—').padEnd(n);
+  console.log(
+    pad('Audience', 12) + pad('Cadence', 16) + pad('Last sent', 12)
+    + pad('Next due', 12) + pad('Ready', 8) + pad('Status', 22) + 'Action',
+  );
+  console.log('─'.repeat(120));
+  for (const r of rows) {
+    console.log(
+      pad(r.label, 12) + pad(r.cadence, 16) + pad(r.lastSent, 12)
+      + pad(r.nextDue, 12) + pad(`${r.candidatesReady}/${r.threshold}`, 8)
+      + pad(r.status, 22) + r.action,
+    );
+  }
+  console.log('');
+
+  if (syncNotion) {
+    console.log('📤 Syncing to Notion Comms Content Calendar...');
+    await syncToNotion(rows);
+    console.log('✓ Notion sync complete.\n');
+  }
+
+  if (runBrand) {
+    const brand = rows.find((r) => r.key === 'brand');
+    if (brand?.status === 'Ready') {
+      const period = suggestPeriod('brand', today);
+      console.log(`🚀 Brand edition due + ready — running drafter for ${period}...\n`);
+      execSync(`node scripts/draft-brand-newsletter.mjs ${period}`, { stdio: 'inherit', cwd: ROOT });
+    } else {
+      console.log(`⏭  --run-brand: brand not due+ready (status: ${brand?.status}). No action.\n`);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error('comms-calendar failed:', e);
+  process.exit(1);
+});

--- a/scripts/draft-brand-newsletter.mjs
+++ b/scripts/draft-brand-newsletter.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Brand newsletter drafter — per-audience, fortnightly, PUBLIC.
+ *
+ * One edition for the whole brand list (no per-recipient personalisation). The
+ * sent edition is also published to the public archive at act.place/newsletters.
+ * Because it is public, the OCAP gate is the strictest of all audiences: EL
+ * stories are only included when consent_visibility = 'public'.
+ *
+ * Reads:
+ *   - newsletter_candidates  (status='include', audiences/auto_audiences contains 'brand')
+ *   - OCAP guardrails on EL stories  (allowedVisibility = ['public'])
+ *
+ * Writes:
+ *   - newsletter_drafts (audience='brand', recipient_slug=NULL, edition_slug='brand-<period>')
+ *
+ * Usage:
+ *   node scripts/draft-brand-newsletter.mjs <edition-period> [--dry-run]
+ *   node scripts/draft-brand-newsletter.mjs 2026-06-A
+ *
+ * Plan: act-communication-pipeline-2026-05-23-locked
+ *       2026-05-28-partner-brand-newsletter-drafters
+ */
+
+import 'dotenv/config';
+import {
+  getSupabase,
+  loadCandidates,
+  ocapCheck,
+  voiceGrade,
+  draftBodyJSON,
+  saveDraft,
+} from './lib/newsletter-drafter.mjs';
+
+const args = process.argv.slice(2);
+const editionPeriod = args.find((a) => !a.startsWith('--'));
+const dryRun = args.includes('--dry-run');
+
+if (!editionPeriod) {
+  console.error('Usage: node scripts/draft-brand-newsletter.mjs <edition-period> [--dry-run]');
+  console.error('Example: node scripts/draft-brand-newsletter.mjs 2026-06-A');
+  process.exit(1);
+}
+
+const supabase = getSupabase();
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PROMPT (per-audience public note — no named recipient)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+function buildPrompt(candidates, period) {
+  const candidateLines = candidates.map((c) => {
+    const proj = c.project_codes?.length ? ` [${c.project_codes.join(',')}]` : '';
+    return `- (${c.source_type}, ${c.event_date}${proj}) ${c.title}${c.summary ? ` — ${c.summary}` : ''}${c.url ? ` [${c.url}]` : ''}`;
+  }).join('\n');
+
+  return `You are drafting the fortnightly PUBLIC newsletter from A Curious Tractor (ACT). One edition for everyone on the public list — no named recipient. It will also be published to a public web archive, so write for a general reader who follows ACT's work.
+
+EDITION: ${period}
+
+VOICE (ACT brand voice — Curtis method):
+- Grounded, plain, specific. Field-notes from real places, not a press release.
+- Name the room (the concrete place), name the body (the person + action), load the abstract noun against the concrete, stop the line before explanation.
+- Warm but not promotional. We are letting people in on the work, not selling.
+
+RECENT ACTIVITY ACROSS THE ECOSYSTEM (select the 3-5 strongest; skip the rest):
+${candidateLines}
+
+INSTRUCTIONS:
+1. Draft a public fortnightly note from ACT. Open without a named person — e.g. "Hi from the farm," or a concrete cold open. Do NOT write "Dear [name]".
+2. Format: 250-450 words. A short intro, then 3-5 short project highlights (each anchored to a place, a person, a number/date), then a one-line close inviting reply or a visit.
+3. VOICE DISCIPLINE (Curtis method): name the room, name the body, load the abstract noun against the concrete, stop the line before explanation.
+4. FORBIDDEN VOCAB (auto-fail if present): delve, crucial, pivotal, vital, tapestry, intricate, leverage, foster, cultivate, empower, unlock, transformative, journey, dedicated team
+5. Plain English. No pitch-deck phrasing, no marketing tone, no savior narrative, no overclaiming.
+6. ALWAYS spell out "Australian Living Map of Alternatives (ALMA)" on first use.
+7. Reference specific projects, not abstract ideas. Cite numbers/dates where they exist.
+8. Sign off as ACT (Ben + Nic).
+
+ALSO PRODUCE 3 SUBJECT-LINE CANDIDATES:
+- Each ≤ 80 characters
+- Each anchored to the most concrete moment in the body
+- Avoid: "Fortnightly update from...", rhetorical questions, exclamation marks
+- Variety: one factual, one anchored to a story moment, one straightforward
+
+OUTPUT FORMAT (STRICT JSON, no prose, no markdown fence):
+{
+  "subject_candidates": ["...", "...", "..."],
+  "body_md": "Hi from the farm,\\n\\n...body in markdown..."
+}`;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// MAIN
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+async function main() {
+  console.log(`\n━━━ Draft brand newsletter: ${editionPeriod} ━━━\n`);
+
+  const { candidates, sinceDate, lastEdition } = await loadCandidates(supabase, {
+    audience: 'brand',
+    recipientSlug: null,
+  });
+  console.log(`📦 Candidates: ${candidates.length} 'include' for brand audience (event_date >= ${sinceDate}, last edition: ${lastEdition?.edition_period || 'never'})`);
+  if (candidates.length === 0) {
+    console.error(`\n❌ No candidates with status='include' AND audiences/auto_audiences contains 'brand'.`);
+    console.error(`   Promote candidates in Notion, or via SQL:`);
+    console.error(`     UPDATE newsletter_candidates SET status='include' WHERE id IN (...);`);
+    process.exit(1);
+  }
+
+  // Brand is public → strictest gate: only 'public' EL stories.
+  const { allowed, softWarnings } = ocapCheck(candidates, { allowedVisibility: ['public'] });
+  console.log(`   After OCAP (public-only): ${allowed.length} allowed, ${candidates.length - allowed.length} hard-gated`);
+  if (Object.keys(softWarnings).length) {
+    console.log(`   ⚠️  Soft warnings: ${Object.keys(softWarnings).length} storytellers flagged`);
+    for (const [sid, ws] of Object.entries(softWarnings)) console.log(`      ${sid}: ${ws.join(', ')}`);
+  }
+
+  if (dryRun) {
+    console.log('\n[DRY RUN — no LLM call, no DB write]');
+    console.log(`  Would draft from ${allowed.length} candidates:`);
+    for (const c of allowed.slice(0, 5)) console.log(`    - ${c.title.slice(0, 80)}`);
+    return;
+  }
+
+  const { body_md, subject_candidates } = await draftBodyJSON(
+    buildPrompt(allowed, editionPeriod),
+    'draft-brand-newsletter',
+  );
+  console.log(`\n✓ Draft body: ${body_md.length} chars · ${subject_candidates.length} subject candidates`);
+  for (const s of subject_candidates) console.log(`    "${s}"`);
+
+  const grade = voiceGrade(body_md);
+  console.log(`\n📐 Voice grade: ${grade.score}/100 (${grade.word_count} words${grade.ai_tells.length ? `, AI tells: ${grade.ai_tells.join(', ')}` : ', no AI tells'})`);
+
+  const editionSlug = `brand-${editionPeriod.toLowerCase()}`;
+  const status = grade.score >= 80 ? 'graded' : 'drafting';
+
+  const data = await saveDraft(supabase, {
+    edition_slug: editionSlug,
+    audience: 'brand',
+    recipient_slug: null,
+    edition_period: editionPeriod,
+    subject_candidates,
+    selected_subject: subject_candidates[0],
+    body_md,
+    candidate_ids: allowed.map((c) => c.id),
+    consent_warnings: Object.keys(softWarnings).length ? softWarnings : null,
+    voice_grade_score: grade.score,
+    voice_grade_details: grade.details,
+    status,
+    status_changed_at: new Date().toISOString(),
+  });
+
+  console.log(`\n✓ Draft saved: ${editionSlug} (id=${data.id.slice(0, 8)}..., status=${status})`);
+  console.log(`   Public archive (after --mark-sent): act.place/newsletters/${editionSlug}`);
+  console.log(`\n--- DRAFT BODY ---\n${body_md}\n--- END ---`);
+  if (grade.score < 80) console.log(`\n⚠️  Voice grade ${grade.score}/100 below 80 — edit before sending.`);
+}
+
+main().catch((e) => {
+  console.error('Drafter failed:', e);
+  process.exit(1);
+});

--- a/scripts/draft-partner-newsletter.mjs
+++ b/scripts/draft-partner-newsletter.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+/**
+ * Partner newsletter drafter — per-recipient, monthly, private.
+ *
+ * Hybrid config (decided 2026-05-28): a bespoke entry in
+ * wiki/narrative/partners.json[partners][slug] overrides everything; partners
+ * with no entry fall back to `_default` + a live ghl_contacts lookup for the
+ * recipient's real name / email / org. Works for the whole audience-partner list
+ * (~271) without hand-curating each one, and never fabricates framing.
+ *
+ * Reads:
+ *   - wiki/narrative/partners.json  (bespoke profile or _default fallback)
+ *   - ghl_contacts                  (fallback name/email/org by email or ghl_id)
+ *   - newsletter_candidates         (status='include', audiences contains 'partner',
+ *                                    optionally filtered to the partner's project_codes)
+ *   - OCAP guardrails on EL stories  (allowedVisibility = ['partner','public'])
+ *
+ * Writes:
+ *   - newsletter_drafts (audience='partner', recipient_slug=<slug>)
+ *
+ * Usage:
+ *   node scripts/draft-partner-newsletter.mjs <partner-ref> <edition-period> [--dry-run]
+ *   node scripts/draft-partner-newsletter.mjs acme-recycling 2026-06
+ *   node scripts/draft-partner-newsletter.mjs jane@acme.com 2026-06      # email fallback
+ *   node scripts/draft-partner-newsletter.mjs <ghl-contact-id> 2026-06   # id fallback
+ *
+ * Plan: act-communication-pipeline-2026-05-23-locked
+ *       2026-05-28-partner-brand-newsletter-drafters
+ */
+
+import 'dotenv/config';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  getSupabase,
+  loadCandidates,
+  ocapCheck,
+  voiceGrade,
+  draftBodyJSON,
+  saveDraft,
+} from './lib/newsletter-drafter.mjs';
+
+const args = process.argv.slice(2);
+const partnerRef = args[0];
+const editionPeriod = args[1];
+const dryRun = args.includes('--dry-run');
+
+if (!partnerRef || !editionPeriod) {
+  console.error('Usage: node scripts/draft-partner-newsletter.mjs <partner-ref> <edition-period> [--dry-run]');
+  console.error('  <partner-ref> = partners.json slug, OR an email, OR a GHL contact id');
+  console.error('Example: node scripts/draft-partner-newsletter.mjs acme-recycling 2026-06');
+  process.exit(1);
+}
+
+const supabase = getSupabase();
+const PARTNERS_PATH = fileURLToPath(new URL('../wiki/narrative/partners.json', import.meta.url));
+
+function slugify(s) {
+  return String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60);
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// RESOLVE PARTNER PROFILE (hybrid: partners.json → ghl_contacts fallback)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+async function resolvePartner(ref) {
+  if (!existsSync(PARTNERS_PATH)) throw new Error(`partners.json missing at ${PARTNERS_PATH}`);
+  const config = JSON.parse(readFileSync(PARTNERS_PATH, 'utf8'));
+  const fallback = config._default || {};
+
+  // 1. Bespoke entry by slug
+  const bespoke = config.partners?.[ref];
+  if (bespoke) {
+    return {
+      slug: ref,
+      source: 'partners.json',
+      name: bespoke.name || ref,
+      primary_contact: bespoke.primary_contact || 'there',
+      primary_email: bespoke.primary_email || null,
+      stage: bespoke.stage || fallback.stage || 'active',
+      tone: bespoke.tone || fallback.tone,
+      framing_notes: bespoke.framing_notes || fallback.framing_notes,
+      claims_to_lead_with: bespoke.claims_to_lead_with || fallback.claims_to_lead_with || [],
+      claims_to_avoid: bespoke.claims_to_avoid || fallback.claims_to_avoid || [],
+      project_codes: bespoke.project_codes || null,
+    };
+  }
+
+  // 2. Fallback — look the contact up in GHL (by email, else by ghl_id)
+  const isEmail = ref.includes('@');
+  let q = supabase.from('ghl_contacts').select('ghl_id, full_name, first_name, last_name, email, company_name');
+  q = isEmail ? q.ilike('email', ref) : q.eq('ghl_id', ref);
+  const { data: contact, error } = await q.limit(1).maybeSingle();
+  if (error) throw error;
+
+  if (!contact) {
+    throw new Error(
+      `Partner '${ref}' not found in partners.json and no ghl_contacts match `
+      + `(${isEmail ? 'email' : 'ghl_id'}='${ref}'). Add a bespoke entry to partners.json, `
+      + `or pass an email / GHL contact id that exists in ghl_contacts.`,
+    );
+  }
+
+  const displayName = contact.company_name || contact.full_name
+    || [contact.first_name, contact.last_name].filter(Boolean).join(' ') || ref;
+  return {
+    slug: slugify(contact.ghl_id ? `ghl-${contact.ghl_id}` : (contact.email || ref)),
+    source: 'ghl_contacts',
+    name: displayName,
+    primary_contact: contact.first_name || contact.full_name || 'there',
+    primary_email: contact.email || null,
+    stage: fallback.stage || 'active',
+    tone: fallback.tone,
+    framing_notes: fallback.framing_notes,
+    claims_to_lead_with: fallback.claims_to_lead_with || [],
+    claims_to_avoid: fallback.claims_to_avoid || [],
+    project_codes: null,
+  };
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PROMPT (per-recipient partner update)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+function buildPrompt(partner, candidates, period) {
+  const candidateLines = candidates.map((c) => {
+    const proj = c.project_codes?.length ? ` [${c.project_codes.join(',')}]` : '';
+    return `- (${c.source_type}, ${c.event_date}${proj}) ${c.title}${c.summary ? ` — ${c.summary}` : ''}${c.url ? ` [${c.url}]` : ''}`;
+  }).join('\n');
+
+  return `You are drafting a monthly update from A Curious Tractor (ACT) to a delivery partner / collaborator.
+
+RECIPIENT: ${partner.name}
+PRIMARY CONTACT: ${partner.primary_contact}
+RELATIONSHIP STAGE: ${partner.stage}
+EDITION: ${period}
+
+VOICE TONE:
+${partner.tone}
+
+FRAMING NOTES (must shape every paragraph):
+${partner.framing_notes}
+
+CLAIMS TO LEAD WITH (feature where the content supports):
+${(partner.claims_to_lead_with || []).map((c) => `  - ${c}`).join('\n') || '  (none — let the content lead)'}
+
+CLAIMS TO AVOID:
+${(partner.claims_to_avoid || []).map((c) => `  - ${c}`).join('\n') || '  (none)'}
+
+RECENT ACTIVITY TO POTENTIALLY INCLUDE (use what's relevant to this partner; skip what isn't):
+${candidateLines}
+
+INSTRUCTIONS:
+1. Draft a short monthly update from ACT to ${partner.primary_contact}, written partner-to-partner (we are fellow workers, not a sponsor and not a marketing list).
+2. Format: 200-400 words. Three to four paragraphs. Greeting → what moved on the shared work → 1-2 specifics → the one thing next (an ask, an invite, or what we're bringing them).
+3. VOICE DISCIPLINE (Curtis method):
+   - Name the room (the concrete place where work happened)
+   - Name the body (the person + action)
+   - Load the abstract noun against the concrete
+   - Stop the line before explanation
+4. FORBIDDEN VOCAB (auto-fail if present): delve, crucial, pivotal, vital, tapestry, intricate, leverage, foster, cultivate, empower, unlock, transformative, journey, dedicated team
+5. Plain English. No pitch-deck phrasing, no marketing tone, no thanking-the-funder register.
+6. ALWAYS spell out "Australian Living Map of Alternatives (ALMA)" on first use.
+7. Reference specific projects, not abstract ideas. Cite numbers/dates where they exist.
+8. Sign off as ACT (Ben + Nic). Match the relationship stage's warmth.
+
+ALSO PRODUCE 3 SUBJECT-LINE CANDIDATES:
+- Each ≤ 80 characters
+- Each anchored to the most concrete moment in the body
+- Avoid: "Monthly update from...", rhetorical questions, exclamation marks
+- Variety: one factual, one anchored to a moment, one straightforward
+
+OUTPUT FORMAT (STRICT JSON, no prose, no markdown fence):
+{
+  "subject_candidates": ["...", "...", "..."],
+  "body_md": "Hi ...,\\n\\n...body in markdown..."
+}`;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// MAIN
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+async function main() {
+  console.log(`\n━━━ Draft partner newsletter: ${partnerRef} / ${editionPeriod} ━━━\n`);
+
+  const partner = await resolvePartner(partnerRef);
+  console.log(`📋 Partner: ${partner.name} (${partner.stage}) — resolved via ${partner.source}`);
+  console.log(`   Slug: ${partner.slug}`);
+  console.log(`   Primary contact: ${partner.primary_contact}${partner.primary_email ? ` <${partner.primary_email}>` : ' (no email on file)'}`);
+  if (partner.project_codes?.length) console.log(`   Project filter: ${partner.project_codes.join(', ')}`);
+
+  const { candidates, sinceDate, lastEdition } = await loadCandidates(supabase, {
+    audience: 'partner',
+    recipientSlug: partner.slug,
+    projectCodes: partner.project_codes,
+  });
+  console.log(`\n📦 Candidates: ${candidates.length} 'include' for partner audience (event_date >= ${sinceDate}, last edition: ${lastEdition?.edition_period || 'never'})`);
+  if (candidates.length === 0) {
+    console.error(`\n❌ No candidates with status='include' AND audiences/auto_audiences contains 'partner'${partner.project_codes ? ` AND project_codes overlapping [${partner.project_codes.join(',')}]` : ''}.`);
+    console.error(`   Promote candidates in Notion, or via SQL:`);
+    console.error(`     UPDATE newsletter_candidates SET status='include' WHERE id IN (...);`);
+    process.exit(1);
+  }
+
+  const { allowed, softWarnings } = ocapCheck(candidates, { allowedVisibility: ['partner', 'public'] });
+  console.log(`   After OCAP: ${allowed.length} allowed, ${candidates.length - allowed.length} hard-gated`);
+  if (Object.keys(softWarnings).length) {
+    console.log(`   ⚠️  Soft warnings: ${Object.keys(softWarnings).length} storytellers flagged`);
+    for (const [sid, ws] of Object.entries(softWarnings)) console.log(`      ${sid}: ${ws.join(', ')}`);
+  }
+
+  if (dryRun) {
+    console.log('\n[DRY RUN — no LLM call, no DB write]');
+    console.log(`  Would draft from ${allowed.length} candidates:`);
+    for (const c of allowed.slice(0, 5)) console.log(`    - ${c.title.slice(0, 80)}`);
+    return;
+  }
+
+  const { body_md, subject_candidates } = await draftBodyJSON(
+    buildPrompt(partner, allowed, editionPeriod),
+    'draft-partner-newsletter',
+  );
+  console.log(`\n✓ Draft body: ${body_md.length} chars · ${subject_candidates.length} subject candidates`);
+  for (const s of subject_candidates) console.log(`    "${s}"`);
+
+  const grade = voiceGrade(body_md);
+  console.log(`\n📐 Voice grade: ${grade.score}/100 (${grade.word_count} words${grade.ai_tells.length ? `, AI tells: ${grade.ai_tells.join(', ')}` : ', no AI tells'})`);
+
+  const editionSlug = `partner-${partner.slug}-${editionPeriod.toLowerCase()}`;
+  const status = grade.score >= 80 ? 'graded' : 'drafting';
+
+  const data = await saveDraft(supabase, {
+    edition_slug: editionSlug,
+    audience: 'partner',
+    recipient_slug: partner.slug,
+    edition_period: editionPeriod,
+    subject_candidates,
+    selected_subject: subject_candidates[0],
+    body_md,
+    candidate_ids: allowed.map((c) => c.id),
+    consent_warnings: Object.keys(softWarnings).length ? softWarnings : null,
+    voice_grade_score: grade.score,
+    voice_grade_details: grade.details,
+    status,
+    status_changed_at: new Date().toISOString(),
+  });
+
+  console.log(`\n✓ Draft saved: ${editionSlug} (id=${data.id.slice(0, 8)}..., status=${status})`);
+  console.log(`\n--- DRAFT BODY ---\n${body_md}\n--- END ---`);
+  if (grade.score < 80) console.log(`\n⚠️  Voice grade ${grade.score}/100 below 80 — edit before sending.`);
+}
+
+main().catch((e) => {
+  console.error('Drafter failed:', e);
+  process.exit(1);
+});

--- a/scripts/lib/newsletter-drafter.mjs
+++ b/scripts/lib/newsletter-drafter.mjs
@@ -1,0 +1,186 @@
+/**
+ * Shared building blocks for the ACT newsletter drafters.
+ *
+ * Extracted from scripts/draft-funder-newsletter.mjs so the partner + brand
+ * drafters don't re-duplicate candidate loading, the OCAP gate, voice grading,
+ * the LLM call and the DB write. The funder drafter is deliberately left on its
+ * own inline copy for now (it's the live "Snow MVP" — migrate it later).
+ *
+ * The prompt itself stays in each drafter (it's audience-specific); everything
+ * around the prompt lives here.
+ *
+ * Plan: act-communication-pipeline-2026-05-23-locked
+ *       2026-05-28-partner-brand-newsletter-drafters
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import {
+  trackedAgentCompletionWithFallback,
+  extractJson,
+} from './llm-client.mjs';
+
+export function getSupabase() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// CANDIDATE LOADING
+// Scopes by the last *sent* edition for this audience (+ recipient, when the
+// audience is per-recipient). Brand is per-audience → recipientSlug is null and
+// we scope by audience alone.
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export async function loadCandidates(
+  supabase,
+  { audience, recipientSlug = null, projectCodes = null, sinceFallback = '2026-01-01', limit = 40 },
+) {
+  let lastQ = supabase
+    .from('newsletter_drafts')
+    .select('sent_at, edition_period')
+    .eq('audience', audience)
+    .eq('status', 'sent')
+    .order('sent_at', { ascending: false })
+    .limit(1);
+  lastQ = recipientSlug ? lastQ.eq('recipient_slug', recipientSlug) : lastQ.is('recipient_slug', null);
+  const { data: lastEdition } = await lastQ.maybeSingle();
+
+  const sinceDate = lastEdition?.sent_at
+    ? new Date(lastEdition.sent_at).toISOString().slice(0, 10)
+    : sinceFallback;
+
+  const applyCommon = (q) => {
+    q = q.eq('status', 'include').gte('event_date', sinceDate).order('event_date', { ascending: false }).limit(limit);
+    if (projectCodes?.length) q = q.overlaps('project_codes', projectCodes);
+    return q;
+  };
+
+  // Manual audience override
+  const { data, error } = await applyCommon(
+    supabase.from('newsletter_candidates').select('*').contains('audiences', [audience]),
+  );
+  if (error) throw error;
+
+  // Auto-classified, no manual override
+  const { data: autoData } = await applyCommon(
+    supabase.from('newsletter_candidates').select('*').is('audiences', null).contains('auto_audiences', [audience]),
+  );
+
+  const byId = new Map();
+  for (const row of [...(data || []), ...(autoData || [])]) byId.set(row.id, row);
+  return { candidates: [...byId.values()], sinceDate, lastEdition };
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// OCAP GUARDRAILS (locked Q10), generalised per audience.
+//
+// allowedVisibility is the set of consent_visibility values an EL story may
+// carry to be included. funder→['funder','public'], partner→['partner','public'],
+// brand→['public'] (strictest, since brand is publicly archived). A null/unknown
+// visibility is always gated out. Non-EL candidates (payments, milestones) pass
+// unconditionally — they carry no storyteller consent.
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export function ocapCheck(candidates, { allowedVisibility = ['public'] } = {}) {
+  const allowed = [];
+  const softWarnings = {};
+  for (const c of candidates) {
+    if (c.source_type !== 'el_story_updated') {
+      allowed.push(c);
+      continue;
+    }
+    // HARD GATES (skip entirely)
+    if (c.consent_visibility === 'private') continue;
+    if (!allowedVisibility.includes(c.consent_visibility)) continue;
+    const payload = c.payload || {};
+    if (payload.consent_to_share === false) continue;
+    if (payload.requires_elder_review === true && !payload.elder_reviewed_at) continue;
+    // SOFT WARNINGS (allow but flag for double-confirm before send)
+    const warnings = [];
+    if (payload.elder_reviewed_at) {
+      const monthsAgo = (Date.now() - Date.parse(payload.elder_reviewed_at)) / (1000 * 60 * 60 * 24 * 30);
+      if (monthsAgo > 12) warnings.push('elder_review_stale');
+    }
+    if (c.event_date) {
+      const yearsAgo = (Date.now() - Date.parse(c.event_date)) / (1000 * 60 * 60 * 24 * 365);
+      if (yearsAgo > 2) warnings.push('story_age_2y_plus');
+    }
+    if (payload.cultural_sensitivity && /high|sensitive/i.test(payload.cultural_sensitivity)) {
+      warnings.push('cultural_sensitive');
+    }
+    if (warnings.length && c.storyteller_ids?.[0]) {
+      softWarnings[c.storyteller_ids[0]] = warnings;
+    }
+    allowed.push(c);
+  }
+  return { allowed, softWarnings };
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// VOICE GRADER — lightweight tier-1 forbidden-vocab + length check.
+// (Mirrors draft-funder-newsletter.mjs; the heavier LLM graders run separately.)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const FORBIDDEN = [
+  'delve', 'crucial', 'pivotal', 'vital', 'tapestry', 'intricate',
+  'leverage', 'foster', 'cultivate', 'empower', 'unlock',
+  'transformative', 'journey', 'dedicated team', 'showcase', 'underscore',
+  'meticulous', 'seamless', 'effortless', 'groundbreaking', 'renowned',
+  'nestled', 'bustling', 'thriving', 'vibrant', 'enduring', 'timeless',
+];
+
+export function voiceGrade(bodyText, { minWords = 200, maxWords = 500 } = {}) {
+  const lower = bodyText.toLowerCase();
+  const hits = FORBIDDEN.filter((w) => new RegExp(`\\b${w}\\w*\\b`, 'i').test(lower));
+  const wordCount = bodyText.split(/\s+/).filter(Boolean).length;
+  let score = 100;
+  score -= hits.length * 25;
+  if (wordCount < minWords || wordCount > maxWords) score -= 10;
+  if (score < 0) score = 0;
+  return {
+    score,
+    word_count: wordCount,
+    ai_tells: hits,
+    details: { forbidden_hits: hits, length_ok: wordCount >= minWords && wordCount <= maxWords },
+  };
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// LLM DRAFT — single call returns { subject_candidates[], body_md }.
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export async function draftBodyJSON(prompt, opName, opts = {}) {
+  const { maxTokens = 2500, temperature = 0.3, operation = 'draft-newsletter' } = opts;
+  console.log(`🤖 Drafting via LLM route (~${Math.round(prompt.length / 4)} input tokens)...`);
+  const raw = await trackedAgentCompletionWithFallback(prompt, opName, {
+    task: 'generate',
+    maxTokens,
+    temperature,
+    operation,
+  });
+  const parsed = extractJson(raw);
+  if (!parsed || !parsed.body_md || !Array.isArray(parsed.subject_candidates)) {
+    console.error('Raw LLM output:', String(raw).slice(0, 500));
+    throw new Error('Drafter returned malformed JSON — see raw output above');
+  }
+  return parsed;
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// SAVE — upsert keyed on edition_slug.
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+export async function saveDraft(supabase, fields) {
+  const { data, error } = await supabase
+    .from('newsletter_drafts')
+    .upsert(fields, { onConflict: 'edition_slug' })
+    .select()
+    .single();
+  if (error) {
+    console.error('DB write failed:', error.message);
+    throw error;
+  }
+  return data;
+}

--- a/thoughts/shared/plans/2026-05-28-partner-brand-newsletter-drafters.md
+++ b/thoughts/shared/plans/2026-05-28-partner-brand-newsletter-drafters.md
@@ -1,0 +1,104 @@
+---
+title: Partner + brand newsletter drafters + public brand archive
+slug: 2026-05-28-partner-brand-newsletter-drafters
+status: proposed
+created: 2026-05-28
+plan_trailer: partner-brand-newsletter-drafters
+related:
+  - act-communication-pipeline-2026-05-23-locked
+  - thoughts/shared/handoffs (comms-crm-operating-system memory)
+---
+
+# Partner + brand newsletter drafters + public brand archive
+
+## Goal
+
+Extend the ACT communication pipeline (funder drafter already live, "Snow MVP")
+with two more audiences from `config/audience-segments.json`:
+
+- **partner** — per-recipient monthly editions (hybrid config: `partners.json`
+  bespoke override + live `ghl_contacts` fallback for the long tail of ~271).
+- **brand** — per-audience fortnightly public edition, archived publicly at
+  `act.place/newsletters/<slug>`.
+
+Stop criteria: both drafter scripts run clean in `--dry-run`; the website
+`/newsletters` routes typecheck + build; plan committed on a feature branch.
+**Out of scope this session:** unified content calendar (next item), Gmail/GHL
+send automation, migrating the funder script onto the shared lib, storyteller
+own-story-back + delivery feedback loop.
+
+## Context (verified 2026-05-28)
+
+- `newsletter_drafts`: `recipient_slug` nullable ✓ (brand → null), unique on
+  `edition_slug`, already has `body_html`, `ghl_campaign_id`, `notion_page_id`.
+- `newsletter_candidates`: 207 rows. `auto_audiences` carries brand on 181,
+  partner on 30. Only 5 rows are `status='include'` (all funder); 202 `proposed`.
+  → drafters build correctly but produce real output only once brand/partner
+  candidates are promoted to `include` (same curation gate the funder MVP uses).
+- Website reads Supabase server-side via `getSupabaseServerClient()`
+  (`apps/website/src/lib/supabase/server.ts`, service role) → archive route reads
+  `newsletter_drafts` directly in a server component, no RLS policy needed.
+- `/blog/[slug]` is the styling/structure precedent (ReactMarkdown body, server
+  component, `revalidate = 60`, `generateStaticParams`).
+
+## Files
+
+### New — scripts
+1. `scripts/lib/newsletter-drafter.mjs` — shared lib (avoid triplicating funder's
+   ~150 lines). Exports: `getSupabase()`, `loadCandidates(supabase,{audience,
+   recipientSlug,projectCodes})`, `ocapCheck(candidates,{allowedVisibility})`
+   (generalised — funder hard-gate visibility list becomes a parameter),
+   `voiceGrade(body)`, `draftBodyJSON(prompt,opName)`, `saveDraft(supabase,fields)`.
+   Funder script left untouched (protect the working Snow MVP); migrate later.
+2. `scripts/draft-partner-newsletter.mjs` — `<partner-ref> <edition-period>
+   [--dry-run]`. Resolve profile: `partners.json.partners[ref]` if present, else
+   treat ref as email (`@`) or ghl contact id → look up `ghl_contacts` for real
+   name/email/org, merge with `_default` generic voice. Candidates scoped to
+   `audience='partner'` (+ profile.project_codes filter if set). OCAP
+   allowedVisibility `['partner','public']`. Save audience='partner',
+   recipient_slug=slug, edition_slug=`partner-<slug>-<period>`.
+3. `scripts/draft-brand-newsletter.mjs` — `<edition-period> [--dry-run]`. No
+   recipient. Candidates `audience='brand'`. OCAP allowedVisibility `['public']`
+   (strictest — public archive). General ACT brand voice prompt (inline Curtis
+   rules, "Dear friends of ACT", multi-project). Save audience='brand',
+   recipient_slug=null, edition_slug=`brand-<period>`.
+
+### New — config
+4. `wiki/narrative/partners.json` — mirrors funders.json shape. `_default`
+   generic partner voice profile (honest, not impersonating a real partner) +
+   empty `partners: {}` for Ben to curate bespoke entries. Schema documented in
+   `description`.
+
+### New — website (apps/website)
+5. `src/lib/newsletters.ts` — `fetchSentBrandEditions(limit)` +
+   `fetchBrandEditionBySlug(slug)` via `getSupabaseServerClient()`; return
+   `[]`/`null` if client null. Filters audience='brand', status='sent'.
+6. `src/app/newsletters/page.tsx` — index of sent brand editions (blog-list style,
+   no images). `revalidate = 60`.
+7. `src/app/newsletters/[slug]/page.tsx` — single edition, ReactMarkdown body_md,
+   subject as title, `generateStaticParams` from sent editions, `notFound()` else.
+
+## Schema-first checks before coding
+- `information_schema.columns` for `ghl_contacts` (name/email/org column names)
+  before writing the partner resolver — do not assume.
+
+## Verification
+- `node scripts/draft-partner-newsletter.mjs <ref> 2026-06 --dry-run` → candidate
+  load + OCAP + resolver run, no LLM/DB write; graceful empty-candidate message.
+- `node scripts/draft-brand-newsletter.mjs 2026-06 --dry-run`.
+- `npx tsc --noEmit` in `apps/website` (or `pnpm --filter @act/website build`) for
+  the new routes.
+- Optional live draft: promote a couple of `proposed` brand/partner candidates to
+  `include` to generate one real draft (only if Ben wants an end-to-end demo).
+
+## Tiers / safety
+- All Tier 1: new local files, local scripts, `--dry-run`, local commit on
+  `wip/newsletter-drafters-2026-05-28`. No push / PR / send without explicit verb.
+- No GHL writes (partner resolver only READS `ghl_contacts`).
+
+## Decision log
+- Partner config = **hybrid** (Ben, 2026-05-28): bespoke `partners.json` override
+  + live ghl_contacts fallback. Rationale: 271 partners can't be hand-curated like
+  48 funders; hybrid is usable now + no fabricated framing.
+- Brand archive = **build now** (Ben, 2026-05-28): dedicated `/newsletters` route
+  reading sent brand editions (not folded into /blog).

--- a/thoughts/shared/plans/2026-05-28-unified-content-calendar.md
+++ b/thoughts/shared/plans/2026-05-28-unified-content-calendar.md
@@ -1,0 +1,97 @@
+---
+title: Unified content calendar — cadence engine + Notion view
+slug: 2026-05-28-unified-content-calendar
+status: proposed
+created: 2026-05-28
+plan_trailer: unified-content-calendar
+related:
+  - act-communication-pipeline-2026-05-23-locked   # Q5 cadence/threshold spec
+  - 2026-05-28-partner-brand-newsletter-drafters
+---
+
+# Unified content calendar — cadence engine + Notion view
+
+## Goal
+
+Backlog item 3 of the comms operating system. Sit a scheduling **engine** + a
+Notion **view** on top of the four newsletter drafters, implementing the locked
+plan's **Q5**: per-audience cadence + candidate threshold, skip if under.
+
+Decisions (Ben, 2026-05-28): **engine + view** · **newsletters only** (4
+audiences, no social) · **Notion home**.
+
+Stop criteria: engine prints a correct per-audience schedule from live data; the
+Notion "Comms Content Calendar" DB exists + holds the 4 audience rows; daily cron
+entry added; plan committed. **Out of scope:** social posts, auto-firing
+per-recipient editions, storyteller drafter (not built).
+
+## Context (verified 2026-05-28)
+
+- Q5 cadence/thresholds: **funder** quarterly/min-3 · **partner** monthly/min-2 ·
+  **brand** fortnightly/min-3 · **storyteller** event/min-1. Skip under threshold,
+  manual override.
+- Notion DB-id registry: `config/notion-database-ids.json` (keys `newsletterCandidates`,
+  `newsletterDrafts`, `planningCalendar`). Sync scripts use `@notionhq/client` +
+  `NOTION_MIRROR_TOKEN`, DB id from the registry.
+- `planningCalendar` is a general life/work events calendar (Meeting/Deadline/
+  Travel) — wrong grain, NOT reused.
+- The Comms hub page already names "comms calendar" as Notion's job but no calendar
+  DB exists yet → this is additive (complements Candidates DB + Drafts DB).
+- PM2 crons in `ecosystem.config.cjs` (newsletter chain at 7:30/7:35 + 30-min/10-min
+  loops). New entry slots after them.
+- `newsletter_drafts` has `sent_at`, `audience`, `status`; candidate audience
+  tagging via `audiences` / `auto_audiences` (proven in the drafter build).
+
+## Files
+
+### New — config
+1. `config/comms-cadence.json` — per-audience `{label, cadence, intervalDays,
+   minCandidates, mode (per-recipient|per-audience|event), drafter, private}`.
+
+### New — engine
+2. `scripts/comms-calendar.mjs`:
+   - For each audience: `lastSent` = max(sent_at) sent edition; `nextDue` =
+     lastSent + intervalDays (or due-now if never sent; null for event-triggered);
+     `candidatesReady` = count `status='include'` candidates for the audience since
+     lastSent; `status` = Ready / Under threshold / Not due yet / Event-triggered;
+     `recommendedAction` = the drafter command (brand: per-audience period slug;
+     per-recipient: command template) or "Skip — N/min".
+   - Default run: print a table report (read-only).
+   - `--sync-notion`: upsert the 4 audience rows into the Comms Content Calendar DB
+     (match by Audience title).
+   - `--run-brand` (off by default): if brand is due AND ready, exec the brand
+     drafter for the current fortnight slug. Per-recipient stays manual (no
+     auto-fire of N editions).
+   - Reuses the shared lib where useful; otherwise small direct count queries.
+
+### Modified — config
+3. `config/notion-database-ids.json` — add `commsContentCalendar: "<new-db-id>"`.
+4. `ecosystem.config.cjs` — add `comms-content-calendar` cron
+   (`scripts/comms-calendar.mjs --sync-notion`, `40 7 * * *`, after candidates-to-notion).
+
+### Notion (Tier 2 — additive, flagged for go-ahead)
+5. Create DB **"Comms Content Calendar"** under the Comms & CRM Operating System
+   hub (`36debcf9-81cf-81c4-8f67-fbe0484c2986`). Props: Audience (title), Next due
+   (date — calendar key), Cadence (select), Mode (select), Last sent (date),
+   Candidates ready (number), Threshold (number), Status (select), Recommended
+   action (text), Drafter (text). Calendar view on Next due + table view.
+6. (Optional) tick backlog item 3 done on the "Newsletter + social audience system"
+   page.
+
+## Verification
+- `node scripts/comms-calendar.mjs` → report matches live data (e.g. brand never
+  sent → due now, 0/3 ready → Under threshold; funder → due, etc.).
+- After DB create: `node scripts/comms-calendar.mjs --sync-notion` → 4 rows; verify
+  via notion-fetch.
+- `node -e` cron-config sanity (ecosystem.config.cjs parses).
+
+## Tiers / safety
+- Tier 1: config + script + ecosystem edit + local commit on
+  `wip/newsletter-drafters-2026-05-28` (same branch, continues the comms work).
+- Tier 2 (flag first): create Notion DB, sync rows, Notion backlog tick, PM2 reload.
+- No auto-send, no per-recipient auto-fire, no LLM spend in the default path.
+
+## Decision log
+- engine + view + newsletters-only + Notion home (Ben, 2026-05-28).
+- Calendar = one row per audience (next due, recomputed), not speculative
+  forward-projected editions — honest + low-churn.

--- a/wiki/narrative/partners.json
+++ b/wiki/narrative/partners.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "updated": "2026-05-28",
+  "description": "Per-partner config for scripts/draft-partner-newsletter.mjs. Partner editions are per-recipient (monthly, private). Bespoke entries in `partners` (keyed by slug) override everything; partners NOT listed here fall back to `_default` + a live ghl_contacts lookup for the recipient's real name/email/org. Mirrors the shape of funders.json. Add a bespoke entry only when a partner is worth a hand-tuned voice; the long tail runs on _default. See Notion: Comms & CRM Operating System > Newsletter + social audience system.",
+  "_schema": {
+    "name": "Partner / organisation display name (string)",
+    "stage": "relationship stage e.g. active | warm | dormant (string)",
+    "primary_contact": "person we write to (string)",
+    "primary_email": "send address — used by prepare-newsletter-for-send.mjs (string)",
+    "ghl_id": "optional GHL contact id to scope candidates / resolve email (string)",
+    "tone": "voice instruction shaping every paragraph (string)",
+    "framing_notes": "what this partner cares about; shapes content selection (string)",
+    "claims_to_lead_with": "array of claim slugs (project:claim-slug) to feature",
+    "claims_to_avoid": "array of claim slugs to keep out",
+    "project_codes": "optional array — when set, candidates are filtered to these projects so a delivery partner only sees their own work"
+  },
+  "_default": {
+    "stage": "active",
+    "tone": "warm, plain, peer-to-peer. We write to a partner as a fellow worker, not a sponsor or an audience. Name the concrete thing we built together, name who did it, say what's next. No pitch tone, no thanking-the-funder register.",
+    "framing_notes": "Lead with the shared work — what moved since last month on the projects this partner touches. Be specific about place, people and dates. Close with the one thing we need from them or are bringing them next.",
+    "claims_to_lead_with": [],
+    "claims_to_avoid": []
+  },
+  "partners": {}
+}


### PR DESCRIPTION
Extends the ACT communication pipeline beyond the live funder drafter (Snow MVP) with the next two backlog items from the Comms & CRM Operating System. Two commits.

## 1. Partner + brand newsletter drafters + public brand archive (`d295c15`)

- **`scripts/lib/newsletter-drafter.mjs`** — shared lib (candidate load, parameterised OCAP gate, voice grade, LLM draft, save) so the new drafters don't re-duplicate the funder script. Funder drafter left untouched.
- **`scripts/draft-partner-newsletter.mjs`** — per-recipient, monthly, private. **Hybrid config**: bespoke `wiki/narrative/partners.json` entry overrides, else live `ghl_contacts` lookup (by email or ghl_id) + `_default` voice. OCAP `['partner','public']`.
- **`scripts/draft-brand-newsletter.mjs`** — per-audience, fortnightly, **public**. Strictest OCAP (`['public']` only). General ACT brand voice, no named recipient.
- **`wiki/narrative/partners.json`** — `_default` profile + empty `partners{}` to curate.
- **`apps/website` `/newsletters` + `/newsletters/[slug]`** — public archive of sent brand editions, read from `newsletter_drafts` via the server service-role client. Mirrors `/blog/[slug]`.

## 2. Unified content calendar — cadence engine + Notion view (`a567cb1`)

Implements locked-plan **Q5** (per-audience cadence + candidate threshold).

- **`config/comms-cadence.json`** — funder quarterly/min-3, partner monthly/min-2, brand fortnightly/min-3, storyteller event/min-1.
- **`scripts/comms-calendar.mjs`** — engine: per audience computes last sent → next due → candidates ready vs threshold → status + recommended action, from live `newsletter_drafts` + `newsletter_candidates`. Default = read-only report; `--sync-notion` upserts one row per audience (idempotent); `--run-brand` (off by default) fires only a due+ready brand edition.
- **Notion "Comms Content Calendar" DB** created under the Comms & CRM hub (`commsContentCalendar` in `config/notion-database-ids.json`).
- **`ecosystem.config.cjs`** — `comms-content-calendar` cron (`40 7 * * *`), live in PM2.

## Verification

- Scripts syntax-clean; partner resolver resolves a real `ghl_contact` (Red Dust); `loadCandidates` returns the 5 funder include rows with `.overlaps`/`.is(null)`/`.contains` + dedupe all executing; OCAP runs on real data.
- Website `tsc --noEmit` clean (0 errors).
- Calendar report matches live data (Funder 5/3 Ready→Q4-FY26; Partner/Brand under threshold; Storyteller event-triggered); 4 Notion rows created then idempotently updated; ecosystem config parses.

## Notes

- Drafters produce real output once brand/partner candidates are promoted `proposed`→`include` (same curation gate as funder). 0 promoted today.
- Storyteller drafter and the delivery-feedback loop are **not** in scope — both blocked on prerequisites (EL-v2 data model; GHL email-events wiring + first sends). See `thoughts/shared/handoffs/2026-05-28-*-blocker.md`.

Plans: `thoughts/shared/plans/2026-05-28-partner-brand-newsletter-drafters.md`, `thoughts/shared/plans/2026-05-28-unified-content-calendar.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)