### PR TITLE
analysis(goods): bed unit economics + OCR + v3 cost-model config + Sheets export

### DIFF
--- a/scripts/export-bed-cost-model-to-sheets.mjs
+++ b/scripts/export-bed-cost-model-to-sheets.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Export the v3 bed cost model to a bundle of CSVs that import cleanly into
+// Google Sheets (one tab per CSV). Source: thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json
+//
+// Usage:
+//   node scripts/export-bed-cost-model-to-sheets.mjs
+//
+// Produces a dated folder under thoughts/shared/analysis/exports/ with:
+//   - 01-build-states.csv      (the 5 scenarios with per-component cost lines)
+//   - 02-idiot-index.csv       (the markup-ratio table)
+//   - 03-volume-scenarios.csv  (today/target/vision fully-loaded by state)
+//   - 04-founder-allocation.csv (production vs fundraising vs ACT-wide)
+//   - 05-fundraising-offset.csv (the funding side of the model)
+//   - 06-wage-scenarios.csv    (4 wage tiers, per-bed labour)
+//   - 07-community-plastic.csv (4 pay-rate tiers for community-collected HDPE)
+//   - 08-defy-verified-rates.csv (every OCR-verified Defy quote)
+//   - 09-mistags-to-fix.csv    (the $120K of misattributed spend)
+//   - 10-open-questions.csv    (what we still need from Defy)
+//   - README.md                 (how to import into Sheets)
+//
+// Plan: goods-cost-evidence-funder-artifact
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const MODEL_PATH = resolve(REPO_ROOT, 'thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json');
+const TODAY = new Date().toISOString().slice(0, 10);
+const OUT_DIR = resolve(REPO_ROOT, `thoughts/shared/analysis/exports/${TODAY}-bed-cost-model-v3`);
+
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+
+const model = JSON.parse(readFileSync(MODEL_PATH, 'utf8'));
+
+// Cell quoting per RFC 4180 — quote if it contains a comma, quote, or newline.
+function cell(value) {
+  if (value === null || value === undefined) return '';
+  const s = String(value);
+  if (s.includes('"') || s.includes(',') || s.includes('\n')) {
+    return `"${s.replaceAll('"', '""')}"`;
+  }
+  return s;
+}
+
+function rowsToCsv(headers, rows) {
+  const lines = [headers.map(cell).join(',')];
+  for (const row of rows) lines.push(row.map(cell).join(','));
+  return lines.join('\n') + '\n';
+}
+
+// ─── 01 build states ───
+{
+  const headers = ['State', 'Label', 'Component', 'Amount ($)', 'Direct total ($)', 'New capex ($)', 'Cumulative capex ($)'];
+  const rows = [];
+  for (const [key, state] of Object.entries(model.build_states)) {
+    for (const [i, comp] of state.components.entries()) {
+      rows.push([
+        i === 0 ? key : '',
+        i === 0 ? state.label : '',
+        comp.label,
+        comp.amount.toFixed(2),
+        i === 0 ? state.direct_total.toFixed(2) : '',
+        i === 0 ? state.capital_added : '',
+        i === 0 ? state.capital_cumulative : '',
+      ]);
+    }
+  }
+  writeFileSync(resolve(OUT_DIR, '01-build-states.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 02 idiot index ───
+{
+  const headers = ['Element', 'Raw low ($)', 'Raw high ($)', 'Current ($)', 'Index low (×)', 'Index high (×)', 'Markup pays for'];
+  const rows = model.idiot_index.map((r) => [
+    r.element,
+    r.raw_low.toFixed(2),
+    r.raw_high.toFixed(2),
+    r.current.toFixed(2),
+    r.index_low.toFixed(1),
+    r.index_high.toFixed(1),
+    r.markup_pays_for,
+  ]);
+  writeFileSync(resolve(OUT_DIR, '02-idiot-index.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 03 volume scenarios ───
+{
+  const headers = ['Scenario', 'Beds/yr', 'Production founder ($/bed)', 'Admin ($/bed)', 'Field travel ($/bed)', 'Freight ($/bed)', 'State 1 fully-loaded ($)', 'State 4 fully-loaded ($)', 'State 5 fully-loaded ($)'];
+  const rows = model.volume_scenarios.map((s) => [
+    s.label,
+    s.beds_per_year,
+    s.production_founder_per_bed,
+    s.admin_per_bed,
+    s.field_travel_per_bed,
+    s.freight_per_bed,
+    s.fully_loaded_state_1,
+    s.fully_loaded_state_4,
+    s.fully_loaded_state_5,
+  ]);
+  writeFileSync(resolve(OUT_DIR, '03-volume-scenarios.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 04 founder allocation ───
+{
+  const fa = model.founder_time_allocation;
+  const headers = ['Activity', 'Days/yr', 'Rate ($/day)', 'Annual cost ($)', 'Allocate to', 'Per-bed @ 100/yr ($)', 'Per-bed @ 500/yr ($)', 'Per-bed @ 1000/yr ($)'];
+  const rows = fa.split.map((r) => [
+    r.label,
+    r.days,
+    fa.rate_per_day,
+    r.annual_cost,
+    r.allocate_to,
+    r.allocate_to === 'bed-overhead' ? (r.annual_cost / 100).toFixed(2) : '—',
+    r.allocate_to === 'bed-overhead' ? (r.annual_cost / 500).toFixed(2) : '—',
+    r.allocate_to === 'bed-overhead' ? (r.annual_cost / 1000).toFixed(2) : '—',
+  ]);
+  rows.push(['TOTAL', fa.total_days_per_year_on_goods, fa.rate_per_day, fa.total_days_per_year_on_goods * fa.rate_per_day, '', '', '', '']);
+  writeFileSync(resolve(OUT_DIR, '04-founder-allocation.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 05 fundraising offset ───
+{
+  const fr = model.fundraising_offset;
+  const headers = ['Metric', 'Value', 'Note'];
+  const rows = [
+    ['Philanthropy founder-days/yr', fr.philanthropy_days_per_year, 'Days founder spends raising philanthropic funds'],
+    ['$ raised per philanthropy day', fr.philanthropy_dollars_per_founder_day_estimate, 'Mid-stage social-enterprise benchmark'],
+    ['Annual philanthropy raised', fr.philanthropy_annual_estimate, '50 × $5K = $250K'],
+    ['Commercial founder-days/yr', fr.commercial_sales_days_per_year, 'Days on buyer development'],
+    ['Commercial buyer benchmark', `$${fr.commercial_buyer_benchmark_per_bed}/bed`, fr.commercial_buyer_source],
+    ['Per-bed subsidy @ 100/yr', `$${fr._per_bed_subsidy_at_100_per_year}`, '$250K / 100 beds'],
+    ['Per-bed subsidy @ 500/yr', `$${fr._per_bed_subsidy_at_500_per_year}`, '$250K / 500 beds'],
+  ];
+  writeFileSync(resolve(OUT_DIR, '05-fundraising-offset.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 06 wage scenarios ───
+{
+  const headers = ['Pay scenario', '$/hr', '$/8hr day', '$/day inc super', 'Beds/day', '$/bed labour'];
+  const rows = model.wage_scenarios.map((s) => [s.label, s.hourly, s.daily_8hr, s.daily_with_super, s.beds_per_day, s.per_bed.toFixed(2)]);
+  writeFileSync(resolve(OUT_DIR, '06-wage-scenarios.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 07 community plastic ───
+{
+  const headers = ['Pay tier', '$/kg', 'kg/bed', '$/bed', 'Annual community pay @ 100 beds', 'Annual community pay @ 500 beds'];
+  const rows = model.community_plastic_pay_scenarios.map((s) => [
+    s.label,
+    s.per_kg,
+    s.kg_per_bed,
+    s.per_bed.toFixed(2),
+    (s.per_bed * 100).toFixed(0),
+    (s.per_bed * 500).toFixed(0),
+  ]);
+  writeFileSync(resolve(OUT_DIR, '07-community-plastic.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 08 defy verified rates ───
+{
+  const headers = ['Item', 'Rate ($)', 'Source', 'Confidence'];
+  const rows = [];
+  for (const [key, value] of Object.entries(model.defy_verified_rates)) {
+    if (typeof value === 'object' && value !== null && 'amount' in value) {
+      rows.push([key, value.amount, value.source || '', value.confidence || '']);
+    } else {
+      rows.push([key, value, '', '']);
+    }
+  }
+  writeFileSync(resolve(OUT_DIR, '08-defy-verified-rates.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 09 mistags ───
+{
+  const headers = ['Supplier / line', 'Amount ($)', 'Current tag', 'Correct tag'];
+  const rows = model.mistags_to_fix.map((m) => [m.supplier, m.amount, m.current_tag, m.correct_tag]);
+  writeFileSync(resolve(OUT_DIR, '09-mistags-to-fix.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── 10 open questions for Defy ───
+{
+  const headers = ['#', 'Question'];
+  const rows = model.open_questions_for_defy.map((q, i) => [i + 1, q]);
+  writeFileSync(resolve(OUT_DIR, '10-open-questions-for-defy.csv'), rowsToCsv(headers, rows));
+}
+
+// ─── README ───
+{
+  const readme = `# Goods bed cost model v3 — Sheets-ready CSV bundle
+
+Exported ${TODAY} from \`thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json\`.
+
+## How to import into Google Sheets
+
+1. Create a new Google Sheet (or open an existing one for this model).
+2. For each CSV in this folder, **File → Import → Upload → ${'`'}<csv-file>${'`'} → Insert new sheet(s)**.
+3. Rename each new tab to match the file (e.g. \`01 build states\`, \`02 idiot index\`).
+4. Done — the workbook now mirrors the v3 model and you can edit any cell.
+
+## To push changes back to the model
+
+If you change a number in Sheets and want it to drive the live cost-model
+page in CivicScope, edit the JSON at \`thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json\`
+to match, then commit. The grantscope service \`apps/web/src/lib/data/goods-bed-cost-model.json\`
+is a mirror — keep them in sync (or have a script reconcile them).
+
+## What's in each tab
+
+| File | Purpose |
+|---|---|
+| \`01-build-states.csv\` | The 5 build-state scenarios (Defy-everything → all in-house) with per-component cost lines and cumulative capex. |
+| \`02-idiot-index.csv\` | Markup-ratio table — where Defy's pricing leaves room for in-house cost reduction. |
+| \`03-volume-scenarios.csv\` | Fully-loaded per-bed cost at 100/500/1000 beds/yr for each build state. |
+| \`04-founder-allocation.csv\` | Founder time split: production (onto beds) vs fundraising (offset) vs ACT-wide. |
+| \`05-fundraising-offset.csv\` | How dollars raised per founder-day subsidise bed cost. |
+| \`06-wage-scenarios.csv\` | 4 wage tiers × 6 beds/day → $/bed labour. |
+| \`07-community-plastic.csv\` | 4 pay-rate tiers for community-collected HDPE. |
+| \`08-defy-verified-rates.csv\` | Every OCR-verified Defy invoice rate (the load-bearing data). |
+| \`09-mistags-to-fix.csv\` | ~$120K of ACT-GD spend that's actually for other projects. |
+| \`10-open-questions-for-defy.csv\` | What we still need from Defy to lock the model. |
+
+## Verified data lineage
+
+All rates in tab 08 come from \`scripts/ocr-defy-bills.mjs\` (Gemini 2.5 Flash Lite
+OCR of every Defy invoice attachment in Xero), output in
+\`thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json\`. Re-run that script
+when Defy issues new invoices to refresh the verified-rate set.
+
+Plan: \`goods-cost-evidence-funder-artifact\`.
+`;
+  writeFileSync(resolve(OUT_DIR, 'README.md'), readme);
+}
+
+console.log(`Exported v3 cost model to ${OUT_DIR}`);
+console.log('  10 CSVs + README.md');
+console.log('Next: File → Import → Upload (each CSV) into a Google Sheet.');

--- a/scripts/ocr-defy-bills.mjs
+++ b/scripts/ocr-defy-bills.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Read the actual line items from every Defy invoice attached in Xero.
+// The Xero JSON sync strips line descriptions to "."; the attachments
+// (PDF/image) carry the real product detail. Used to back-derive per-bed
+// unit economics from the actual production batches.
+//
+// Output: thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json
+// Plan: goods-cost-evidence-funder-artifact
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { GoogleGenAI, Type } from '@google/genai';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+
+const sb = createClient(
+  process.env.SUPABASE_SHARED_URL || 'https://tednluwflfhxyucgwigh.supabase.co',
+  process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
+const MODEL = 'gemini-2.5-flash-lite';
+
+const XERO_API = 'https://api.xero.com/api.xro/2.0';
+let TOKEN = null;
+function loadTokens() {
+  if (existsSync('.xero-tokens.json')) TOKEN = JSON.parse(readFileSync('.xero-tokens.json', 'utf8'));
+}
+async function refresh() {
+  const creds = Buffer.from(`${process.env.XERO_CLIENT_ID}:${process.env.XERO_CLIENT_SECRET}`).toString('base64');
+  const r = await fetch('https://identity.xero.com/connect/token', {
+    method: 'POST',
+    headers: { Authorization: `Basic ${creds}`, 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: TOKEN.refresh_token }),
+  });
+  const d = await r.json();
+  TOKEN = { access_token: d.access_token, refresh_token: d.refresh_token, expires_at: Date.now() + d.expires_in * 1000 - 60000 };
+  writeFileSync('.xero-tokens.json', JSON.stringify(TOKEN, null, 2));
+}
+async function xfetch(ep, accept = 'application/json', _retry = false) {
+  const r = await fetch(`${XERO_API}/${ep}`, { headers: { Authorization: `Bearer ${TOKEN.access_token}`, 'xero-tenant-id': process.env.XERO_TENANT_ID, Accept: accept } });
+  if (r.status === 401 && !_retry) { await refresh(); return xfetch(ep, accept, true); }
+  return r;
+}
+
+const SCHEMA = {
+  type: Type.OBJECT,
+  properties: {
+    line_items: {
+      type: Type.ARRAY,
+      items: {
+        type: Type.OBJECT,
+        properties: {
+          description: { type: Type.STRING },
+          quantity: { type: Type.NUMBER },
+          unit_price: { type: Type.NUMBER },
+          line_total: { type: Type.NUMBER },
+        },
+        required: ['description'],
+      },
+    },
+    bed_count: { type: Type.NUMBER, description: 'How many beds (or bed-like products) the invoice covers, if stated. 0 if no beds.' },
+    product_summary: { type: Type.STRING, description: 'One sentence: what product(s) does this invoice cover (beds, sheds, coasters, prototype, materials-only, etc.)' },
+    notes: { type: Type.STRING, description: 'Anything notable — e.g. special finish, mention of sheets vs assembled, deposit/prepayment, etc.' },
+  },
+  required: ['line_items', 'product_summary'],
+};
+const PROMPT = `Extract every line item from this Defy Manufacturing invoice. Defy makes bed-frame products and related items from recycled HDPE plastic for ACT (the buyer).
+
+For each line: description verbatim, quantity, unit price, line total.
+
+Also: if the invoice mentions a bed count or bed-related product, record it in bed_count. Common product types: BEDS (assembled, cut+finished), SHEETS/SHRED (raw materials), SHEDS, COASTERS, prototypes/samples. Use product_summary to say in one sentence what this invoice was for.
+
+If anything stands out (deposit, special finish, custom engraving, R&D), put it in notes.`;
+
+async function ocrBill(bill) {
+  try {
+    const xeroId = bill.xero_id;
+    if (!xeroId) return { error: 'no xero_id in DB row' };
+    const ar = await xfetch(`Invoices/${xeroId}/Attachments`);
+    const atts = (await ar.json()).Attachments || [];
+    if (atts.length === 0) return { error: 'no attachments' };
+    // Sometimes there are multiple attachments; we OCR the first non-trivial one.
+    const att = atts.find((a) => /pdf|jpe?g|png|tiff/i.test(a.FileName)) || atts[0];
+    const dr = await xfetch(`Invoices/${xeroId}/Attachments/${encodeURIComponent(att.FileName)}`, '*/*');
+    const buf = Buffer.from(await dr.arrayBuffer());
+    const mime = dr.headers.get('content-type') || (att.FileName.toLowerCase().endsWith('.pdf') ? 'application/pdf' : 'image/jpeg');
+    const r = await ai.models.generateContent({
+      model: MODEL,
+      contents: [{ parts: [{ text: PROMPT }, { inlineData: { mimeType: mime, data: buf.toString('base64') } }] }],
+      config: { responseMimeType: 'application/json', responseSchema: SCHEMA },
+    });
+    const parsed = JSON.parse(r.text || r.candidates[0].content.parts[0].text);
+    return { attachment: att.FileName, ...parsed };
+  } catch (e) {
+    return { error: String(e?.message || e) };
+  }
+}
+
+// Pull bills from DB to keep this in sync with the live data.
+// `xero_id` is the Xero InvoiceID needed for the API; our `id` is internal-only.
+const { data: bills, error } = await sb
+  .from('xero_invoices')
+  .select('id, xero_id, xero_tenant_id, invoice_number, date, total, has_attachments')
+  .ilike('contact_name', '%defy%')
+  .eq('type', 'ACCPAY')
+  .not('status', 'in', '(VOIDED,DELETED)')
+  .eq('project_code', 'ACT-GD')
+  .order('date');
+
+if (error) {
+  console.error('DB error:', error.message);
+  process.exit(1);
+}
+
+console.log(`OCRing ${bills.length} Defy bills...\n`);
+loadTokens();
+
+const results = [];
+for (const b of bills) {
+  process.stdout.write(`${b.date}  ${(b.invoice_number || '(no inv#)').padEnd(12)}  $${Number(b.total).toFixed(2).padStart(10)}  `);
+  const r = await ocrBill(b);
+  if (r.error) {
+    console.log(`ERR: ${r.error}`);
+    results.push({ ...b, error: r.error });
+    continue;
+  }
+  const bedNote = r.bed_count ? `${r.bed_count} beds` : 'no bed count';
+  console.log(`[${bedNote}] ${r.product_summary?.slice(0, 80) || ''}`);
+  if (r.notes) console.log(`    note: ${r.notes}`);
+  for (const li of r.line_items || []) {
+    const q = li.quantity ?? '';
+    const u = li.unit_price ? '$' + Number(li.unit_price).toFixed(2) : '';
+    const lt = li.line_total ? '$' + Number(li.line_total).toFixed(2) : '';
+    console.log(`    - ${li.description?.slice(0, 110) || '(no desc)'}   qty ${q}  unit ${u}  total ${lt}`);
+  }
+  results.push({ ...b, ...r });
+  // Modest rate-limit kindness.
+  await new Promise((r) => setTimeout(r, 400));
+}
+
+const OUT_DIR = 'thoughts/shared/analysis';
+if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+const outPath = `${OUT_DIR}/2026-05-28-defy-invoice-ocr.json`;
+writeFileSync(outPath, JSON.stringify(results, null, 2));
+console.log(`\nSaved ${results.length} OCR results to ${outPath}`);
+
+// Bed-count rollup.
+const totalBeds = results.reduce((s, r) => s + (Number(r.bed_count) || 0), 0);
+const totalSpend = results.reduce((s, r) => s + Number(r.total), 0);
+const billsWithBeds = results.filter((r) => Number(r.bed_count) > 0);
+console.log(`\n=== ROLLUP ===`);
+console.log(`Total Defy spend (incl GST): $${totalSpend.toFixed(2)}`);
+console.log(`Total beds attributed: ${totalBeds}`);
+console.log(`Bills naming a bed count: ${billsWithBeds.length} of ${results.length}`);
+if (totalBeds > 0) console.log(`Naive per-bed (total Defy / beds named): $${(totalSpend / totalBeds).toFixed(2)}`);

--- a/thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json
+++ b/thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json
@@ -1,0 +1,843 @@
+[
+  {
+    "id": "b9e10922-5047-4444-a7a7-ffc7b9b9f6bd",
+    "xero_id": "36affeaa-1aa3-4b5a-9d16-aa612f1bcd20",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1174",
+    "date": "2025-06-02",
+    "total": 5445,
+    "has_attachments": true,
+    "attachment": "17036162340.pdf",
+    "line_items": [
+      {
+        "description": "coasters in 8mm Atlantis with custom engraving",
+        "quantity": 900,
+        "unit_price": 5
+      },
+      {
+        "description": "sourcing and applying sticker",
+        "quantity": 900,
+        "unit_price": 0.5
+      },
+      {
+        "description": "shipping T.B.C",
+        "line_total": 0
+      }
+    ],
+    "product_summary": "This invoice is for 900 coasters with custom engraving and associated services.",
+    "bed_count": 0,
+    "notes": "Custom engraving and sourcing/applying stickers were noted for the coasters. Work will commence after receipt of payment."
+  },
+  {
+    "id": "57c83c2b-21bb-4ed0-a69f-e6e53501af95",
+    "xero_id": "76806092-d540-4117-af77-8e1895e55a4e",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1181",
+    "date": "2025-06-04",
+    "total": 3790.3,
+    "has_attachments": true,
+    "attachment": "17287316070.pdf",
+    "line_items": [
+      {
+        "description": "additional design time to resolve panel details, sizing and fixing methods",
+        "quantity": 1,
+        "unit_price": 818.1818
+      },
+      {
+        "description": "Shipping 5 x pallets from Sydney to Alice Springs to arrive by the 24th of june",
+        "quantity": 1,
+        "unit_price": 2627.5455
+      }
+    ],
+    "product_summary": "This invoice covers design time and shipping for bed-frame products.",
+    "bed_count": 0,
+    "notes": "Work will commence after receipt of payment."
+  },
+  {
+    "id": "4d9c1956-c8b2-4817-ad6c-b6e5304fa95c",
+    "xero_id": "45257477-8edd-4361-a56a-f452a8813d6d",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1236",
+    "date": "2025-07-08",
+    "total": 5500,
+    "has_attachments": true,
+    "attachment": "18982707740.pdf",
+    "line_items": [
+      {
+        "description": "Washing Machine Cladding Sets:\n- Flat Packed and Packaged Ready to Ship\n- Includes Hardware",
+        "quantity": 5,
+        "unit_price": 1000
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 500
+      }
+    ],
+    "product_summary": "This invoice covers washing machine cladding sets made from recycled HDPE plastic.",
+    "bed_count": 0,
+    "notes": "Work will commence after receipt of payment."
+  },
+  {
+    "id": "3abe2f74-9b66-4447-8e6c-7f5c030118a3",
+    "xero_id": "963e8045-428c-48f6-ae84-c2378769ac62",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1237",
+    "date": "2025-07-08",
+    "total": 5280,
+    "has_attachments": true,
+    "attachment": "18982707800.pdf",
+    "line_items": [
+      {
+        "description": "First Washing Machine Cladding:\n- fully Installed and fixed to washing machine here at the\nDEFY factory - Packaged and ready to ship fully\nassembled",
+        "quantity": 3,
+        "unit_price": 1200
+      },
+      {
+        "description": "Road Case for Travelling display machines",
+        "quantity": 3,
+        "unit_price": 400
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 0
+      }
+    ],
+    "product_summary": "This invoice is for custom cladding and road cases for washing machines.",
+    "bed_count": 0,
+    "notes": "Work will commence after receipt of payment."
+  },
+  {
+    "id": "eed9385c-de6a-4ce2-bb67-8cd394e95733",
+    "xero_id": "2b2db1e6-2d64-458a-b77d-23a1a8165e36",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1233",
+    "date": "2025-07-08",
+    "total": 1051.51,
+    "has_attachments": true,
+    "attachment": "18982707750.pdf",
+    "line_items": [
+      {
+        "description": "Pallet & Packing Fee + Protective Cardboard D:120 x 120 x 150cm W:150kg",
+        "quantity": 1,
+        "unit_price": 150
+      },
+      {
+        "description": "Standard Road Freight Botany NSW 2019 to Alice Springs NT 0871",
+        "quantity": 1,
+        "unit_price": 805.92
+      }
+    ],
+    "product_summary": "This invoice covers freight and packing fees for a curious tractor product.",
+    "bed_count": 0,
+    "notes": "Work will commence after receipt of payment."
+  },
+  {
+    "id": "e407a0c0-a511-4278-9809-bdf882dae4e2",
+    "xero_id": "f80e1b68-387c-4b0b-a553-bcb0c0b941a2",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1235",
+    "date": "2025-07-08",
+    "total": 1320,
+    "has_attachments": true,
+    "attachment": "18982707780.pdf",
+    "line_items": [
+      {
+        "description": "Washing Machine Cladding Sets: - Additional Clad washing machine (already made) and will be sent to allice",
+        "quantity": 1,
+        "unit_price": 1200
+      }
+    ],
+    "product_summary": "This invoice covers custom cladding sets for a washing machine made from recycled panels.",
+    "bed_count": 0,
+    "notes": "Work will commence after receipt of payment."
+  },
+  {
+    "id": "1c85ffd1-76c6-40a4-b372-c255d3238241",
+    "xero_id": "83692ff2-0ac5-4f0c-98f4-3e64bdfbb82c",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1257",
+    "date": "2025-07-16",
+    "total": 5500,
+    "has_attachments": true,
+    "attachment": "17481685880.pdf",
+    "line_items": [
+      {
+        "description": "Washing Machine Cladding Sets:\nFlat Packed and Packaged Ready to Ship\n- Includes Hardware",
+        "quantity": 5,
+        "unit_price": 1000
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 500
+      }
+    ],
+    "product_summary": "This invoice covers washing machine cladding sets and freight.",
+    "bed_count": 0,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "27909779-fdea-4492-91c4-c3278ca7a96e",
+    "xero_id": "d18e3e97-c7de-485c-af50-23203b9c1ebb",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1259",
+    "date": "2025-07-16",
+    "total": 1100,
+    "has_attachments": true,
+    "attachment": "17481685840.pdf",
+    "line_items": [
+      {
+        "description": "First Unit - Woven Bed:\n- After the design stage and round of prototyping we will\nbring a resolved version of the leading design\nThis will include all recycled plastic parts, webbing and\nhardware if required\nThis will be packed ready for sending",
+        "quantity": 1,
+        "unit_price": 1000
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 0
+      }
+    ],
+    "product_summary": "This invoice covers the first unit of a Woven Bed, including design stage, prototyping, recycled plastic parts, webbing, and hardware.",
+    "bed_count": 1,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "7182b9a2-43c2-4e00-9950-a86f6c49c253",
+    "xero_id": "11a4d75b-5f9f-40be-b981-ca3713784bf2",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1258",
+    "date": "2025-07-16",
+    "total": 6600,
+    "has_attachments": true,
+    "attachment": "17481685870.pdf",
+    "line_items": [
+      {
+        "description": "Design Stage:\n- Exploration of Bed designs including creation of multiple\nconcepts with different build methods\n- Exploring tensioning methods for woven sections\n- Refining Bed concepts into prototypes\n- Testing and evaluating concepts and prototypes\n- Hopefully these prototypes can be taken to communities\nto get their feedback. It will depend on how well they work",
+        "quantity": 1,
+        "unit_price": 6000
+      }
+    ],
+    "product_summary": "This invoice is for the design stage of woven bed products.",
+    "bed_count": 1,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe."
+  },
+  {
+    "id": "efd6e573-02e9-4475-9c51-108095f3e35c",
+    "xero_id": "43813669-79b8-435f-a894-f33c7a14812a",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1285",
+    "date": "2025-07-29",
+    "total": 3300,
+    "has_attachments": true,
+    "attachment": "17618472140.pdf",
+    "line_items": [
+      {
+        "description": "Mad Beds - Small amount of design improvements and adjustments - This will include all recycled plastic parts, webbing and hardware if required - This will be packed ready for sending",
+        "quantity": 3,
+        "unit_price": 1000
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 0
+      }
+    ],
+    "product_summary": "This invoice covers the production of 3 Mad Beds with design improvements and adjustments, and includes freight costs.",
+    "bed_count": 3,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "9de2e086-9786-4478-8002-94f9ef19a1b1",
+    "xero_id": "5fc2af76-6e1c-4be0-86b2-23778d4b296b",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1291",
+    "date": "2025-07-30",
+    "total": 1457.17,
+    "has_attachments": true,
+    "attachment": "17619457550.pdf",
+    "line_items": [
+      {
+        "description": "Payment for invoice(s) INV-1291",
+        "line_total": 1457.17
+      }
+    ],
+    "product_summary": "This invoice covers a payment for previous purchases from Defy.",
+    "bed_count": 0,
+    "notes": "This is a payment receipt, not an invoice detailing line items."
+  },
+  {
+    "id": "4b09e697-47c3-4a85-942e-42a41d7878d2",
+    "xero_id": "38fd5522-3b0f-49e6-824e-27204fe41d96",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1293",
+    "date": "2025-08-01",
+    "total": 747.34,
+    "has_attachments": true,
+    "attachment": "17648985470.pdf",
+    "line_items": [
+      {
+        "description": "Freight of 3 x Mad Beds to Alice Springs",
+        "quantity": 1,
+        "unit_price": 679.4
+      }
+    ],
+    "product_summary": "This invoice is for the freight of 3 assembled beds.",
+    "bed_count": 3,
+    "notes": "Work will commence after receipt of payment. Payment via credit card will incur a 1.7% processing fee from Stripe."
+  },
+  {
+    "id": "e51f5abe-5473-46d2-9fe9-aad53fd7b1d3",
+    "xero_id": "92683a88-32b6-416a-bac6-736226c3bb6d",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1326",
+    "date": "2025-08-20",
+    "total": 1320,
+    "has_attachments": true,
+    "attachment": "18954469400.pdf",
+    "line_items": [
+      {
+        "description": "Monday 18/08 - full\nSam",
+        "quantity": 1,
+        "unit_price": 480
+      },
+      {
+        "description": "Tuesday 19/08 - full\nSam",
+        "quantity": 1,
+        "unit_price": 480
+      },
+      {
+        "description": "Wednesday 20/08 - half\nSam $240",
+        "quantity": 1,
+        "unit_price": 240
+      }
+    ],
+    "product_summary": "This invoice covers the purchase of assembled bed frames from recycled HDPE plastic.",
+    "bed_count": 2,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "b79a759a-6134-4bfa-bfa0-fefb664c0e15",
+    "xero_id": "e8d54949-4559-4671-a84a-59aab5cfdd92",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1325",
+    "date": "2025-08-20",
+    "total": 2640,
+    "has_attachments": true,
+    "attachment": "18954469390.pdf",
+    "line_items": [
+      {
+        "description": "Tuesday 12/08 - full:\n- Todd\n- Sam",
+        "quantity": 2,
+        "unit_price": 480
+      },
+      {
+        "description": "Wednesday 13/08 - full:\n- Todd\n- Sam",
+        "quantity": 2,
+        "unit_price": 480
+      },
+      {
+        "description": "Thursday 14/08 - half\n- Todd\n- Sam",
+        "quantity": 2,
+        "unit_price": 240
+      }
+    ],
+    "product_summary": "This invoice is for assembled bed-frame products of varying sizes.",
+    "bed_count": 6,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "001c5cb3-8af3-4a8d-a21a-bba4939e365a",
+    "xero_id": "0783dcd5-e5b1-4b3c-9af5-9d0337b69cf1",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1337",
+    "date": "2025-08-22",
+    "total": 3015.76,
+    "has_attachments": true,
+    "attachment": "17848422770.pdf",
+    "line_items": [
+      {
+        "description": "Packing and Palletization",
+        "quantity": 1,
+        "unit_price": 120
+      },
+      {
+        "description": "Road Freight From Botany 2019 Sydney to Darwin City NT\n0800",
+        "quantity": 1,
+        "unit_price": 2621.6
+      }
+    ],
+    "product_summary": "This invoice is for freight and palletization services related to washing machines.",
+    "bed_count": 0,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "ccc2e2df-a435-4a48-9865-1aa89c203bba",
+    "xero_id": "09fefdd1-629b-4e5e-a845-2f2936327fb0",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "1584-1572",
+    "date": "2025-09-05",
+    "total": 1015.01,
+    "has_attachments": true,
+    "attachment": "17966526720.pdf",
+    "line_items": [
+      {
+        "description": "Payment for invoice(s) INV-1361",
+        "line_total": 1015.01
+      }
+    ],
+    "product_summary": "This invoice covers a payment for Defy's services related to bed-frame products and related items.",
+    "bed_count": 0,
+    "notes": "The total amount paid was A$1,015.01."
+  },
+  {
+    "id": "fc8f00b4-9178-4f3a-a816-e18fdb7c8cd2",
+    "xero_id": "62e26405-f3c4-40fd-b2ab-927a870876ee",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1362",
+    "date": "2025-09-05",
+    "total": 10316.32,
+    "has_attachments": true,
+    "attachment": "17966526680.pdf",
+    "line_items": [],
+    "product_summary": "This invoice is for a payment made to Defy for invoice INV-1362, likely for bed-frame products and related items.",
+    "bed_count": 0,
+    "notes": "The payment was made via VISA and Apple Pay."
+  },
+  {
+    "id": "71069c63-6148-43df-b833-2236bc6ecb9a",
+    "xero_id": "7f55164d-7077-4788-952b-b4a61d53b6ba",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1503",
+    "date": "2025-11-17",
+    "total": 2733.72,
+    "has_attachments": true,
+    "attachment": "18741310940.pdf",
+    "line_items": [
+      {
+        "description": "Washing Machine Cladding Sets:\n- Flat Packed and Packaged Ready to Ship\n- Includes Hardware\n- using 12mm material pre purchased",
+        "quantity": 4,
+        "unit_price": 621.3
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 0
+      }
+    ],
+    "product_summary": "This invoice covers washing machine cladding sets made from recycled HDPE plastic.",
+    "bed_count": 0,
+    "notes": "Work will commence after receipt of payment. Payment via credit card will incur a 1.7% processing fee from Stripe."
+  },
+  {
+    "id": "8dee381b-f6fc-4d12-bb09-52cc4f7da528",
+    "xero_id": "8bd2dd9a-a8c4-4624-a301-f2ef5b00ef81",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1507",
+    "date": "2025-11-19",
+    "total": 16500,
+    "has_attachments": true,
+    "attachment": "18741310960.pdf",
+    "line_items": [
+      {
+        "description": "Single Beds - New weave bed with updated design.\n- Recycled plastic\n- Steel\n- Canvas",
+        "quantity": 25,
+        "unit_price": 600
+      },
+      {
+        "description": "Freight T.B.C",
+        "line_total": 1500
+      }
+    ],
+    "product_summary": "This invoice covers single beds made from recycled plastic, steel, and canvas.",
+    "bed_count": 25,
+    "notes": "Work will commence after receipt of payment. Payment via credit card incurs a 1.7% processing fee from Stripe."
+  },
+  {
+    "id": "24e1c7e9-e6db-48d5-962a-cb9bb638e130",
+    "xero_id": "baa3ed75-9886-484b-af47-6a89f66efa83",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2025-11-27",
+    "total": 1858.78,
+    "has_attachments": true,
+    "attachment": "Defy-Manufacturing-receipt.pdf",
+    "line_items": [
+      {
+        "description": "Packing and Palletizing fee",
+        "quantity": 1,
+        "unit_price": 210
+      },
+      {
+        "description": "Freight\nBotany 2019 to Alice NT 0870\nPallet dim: 240 x 120 x 83cm\nWeight: 980kg",
+        "quantity": 1,
+        "unit_price": 1479.8
+      }
+    ],
+    "product_summary": "This invoice covers freight and palletizing fees for beds and washing machine skins.",
+    "bed_count": 25,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "48ec710d-50b2-43c4-840b-7ff536d38d7e",
+    "xero_id": "c8d99460-6ba7-4813-86c7-2ba6739a9781",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2025-11-28",
+    "total": 1894.1,
+    "has_attachments": true,
+    "attachment": "Defy-receipt.pdf",
+    "line_items": [
+      {
+        "description": "Payment for invoice(s) INV-1518",
+        "line_total": 1894.1
+      }
+    ],
+    "product_summary": "This invoice is for a payment towards invoice INV-1518.",
+    "bed_count": 0,
+    "notes": "The payment method was VISA via Apple Pay."
+  },
+  {
+    "id": "130e7686-6b9c-4906-81a7-6d774cf4246f",
+    "xero_id": "2cfca6af-4bf9-4bad-a3be-703b8961ec7e",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2025-12-18",
+    "total": 3199.83,
+    "has_attachments": true,
+    "attachment": "Defy-Manufacturing-receipt.pdf",
+    "line_items": [
+      {
+        "description": "19mm Recycled HDPE Panels",
+        "quantity": 6,
+        "unit_price": 446.1
+      },
+      {
+        "description": "HDPE Shreds - Assorted (approx. 20kg per\ntub) QTY in KG",
+        "quantity": 200,
+        "unit_price": 2
+      },
+      {
+        "description": "Tubs - to house and store shreds",
+        "quantity": 10,
+        "unit_price": 10
+      }
+    ],
+    "product_summary": "This invoice covers recycled HDPE panels, assorted HDPE shreds, and tubs for storing shreds.",
+    "notes": "All contents will be on a pallet in the DEFY yard. Ready to pickup anytime from the 22nd. Work will commence after receipt of payment."
+  },
+  {
+    "id": "323c0c08-042a-4c95-96bc-e477e026f9b9",
+    "xero_id": "372be68a-f2f7-4add-ae57-6f2a5e1bf2c6",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2025-12-18",
+    "total": 3260.63,
+    "has_attachments": true,
+    "attachment": "Defy-receipt.pdf",
+    "line_items": [],
+    "product_summary": "This invoice is for a payment made to Defy for an unspecified invoice.",
+    "bed_count": 0,
+    "notes": "The invoice mentions a payment for invoice(s) INV-1558."
+  },
+  {
+    "id": "d7cb1ff7-7728-40ae-85e4-32c5ee1982a1",
+    "xero_id": "8b96e972-4067-4424-954e-56d06ca1b3ec",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2025-12-22",
+    "total": 3598.09,
+    "has_attachments": true,
+    "attachment": "Defy-receipt.pdf",
+    "line_items": [],
+    "product_summary": "This invoice appears to be a payment receipt for a previous invoice (INV-1559) and does not contain specific line item details.",
+    "bed_count": 0,
+    "notes": "The invoice mentions a payment for a previous invoice (INV-1559) rather than detailing specific products or services."
+  },
+  {
+    "id": "f6508cea-eb9c-4de5-a7ee-016156c35c49",
+    "xero_id": "4c915112-4085-41b1-99f8-92863a1aaddf",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2026-01-11",
+    "total": 893.47,
+    "has_attachments": true,
+    "attachment": "Defy-receipt.pdf",
+    "line_items": [],
+    "product_summary": "This invoice is for a payment made for invoice(s) INV-1571.",
+    "bed_count": 0,
+    "notes": "The payment of A$893.47 was made on Jan 12, 2026 via VISA ending in 1656."
+  },
+  {
+    "id": "4ac335f7-0cfc-4c7a-ad78-4acc60ce2cef",
+    "xero_id": "71952972-7c3b-485d-a079-5b64b8cdef56",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2026-01-11",
+    "total": 876.81,
+    "has_attachments": true,
+    "attachment": "Defy-Manufacturing-receipt.pdf",
+    "line_items": [
+      {
+        "description": "Pallet & Packing Fee\nD:120 x 120 x 78cm\nW:190kg",
+        "quantity": 1,
+        "unit_price": 60
+      },
+      {
+        "description": "Standard Road Freight\nBotany NSW 2019 to Alice Springs NT 0871\n*Must arrive before 26/01",
+        "quantity": 1,
+        "unit_price": 737.1
+      }
+    ],
+    "product_summary": "This invoice covers freight and packing fees for a bed-related product.",
+    "bed_count": 6,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "41d01447-2acd-4394-a696-4336c87cab26",
+    "xero_id": "97d1526c-8546-4189-a7b6-d6b8a7bb007b",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1602",
+    "date": "2026-01-30",
+    "total": 36947.46,
+    "has_attachments": true,
+    "attachment": "19517226320.pdf",
+    "line_items": [
+      {
+        "description": "16 Beds made from previously ordered 19mm recycled plastic sheets. Cut and finished",
+        "quantity": 16,
+        "unit_price": 121
+      },
+      {
+        "description": "92 Beds kits in 19mm Jungle recycled plastic sheets. Cut and finished",
+        "quantity": 92,
+        "unit_price": 344.05
+      },
+      {
+        "description": "Pallet and Packing TBC",
+        "quantity": 0,
+        "unit_price": 0
+      },
+      {
+        "description": "Freight T.B.C",
+        "quantity": 0,
+        "unit_price": 0
+      }
+    ],
+    "product_summary": "This invoice covers beds and bed kits made from recycled plastic sheets.",
+    "bed_count": 108,
+    "notes": "Payment via credit card will incur a 1.7% processing fee. Work will commence after receipt of payment."
+  },
+  {
+    "id": "57393c5c-6b3e-4c7d-951c-d57ed0ff9a88",
+    "xero_id": "0b54db47-3fc9-4539-85ac-8550f4b6f312",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "1868-7651",
+    "date": "2026-02-17",
+    "total": 4903.94,
+    "has_attachments": true,
+    "attachment": "19649737880.pdf",
+    "line_items": [
+      {
+        "description": "Payment for invoice(s) INV-1637",
+        "line_total": 4903.94
+      }
+    ],
+    "product_summary": "This invoice is for a payment made to Defy for invoice INV-1637.",
+    "bed_count": 0,
+    "notes": "The payment was made via VISA ending in 1656 on Feb 17, 2026."
+  },
+  {
+    "id": "e642db12-a2f7-4955-b090-3e9bafba39e4",
+    "xero_id": "a34f34fb-f8be-4dde-9286-5cce6995a327",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1637",
+    "date": "2026-02-17",
+    "total": 4812.5,
+    "has_attachments": true,
+    "attachment": "19649715720.pdf",
+    "line_items": [
+      {
+        "description": "coasters in 8mm Atlantis with custom engraving",
+        "quantity": 700,
+        "unit_price": 5.5
+      },
+      {
+        "description": "sourcing and applying sticker",
+        "quantity": 700,
+        "unit_price": 0.75
+      },
+      {
+        "description": "shipping T.B.C",
+        "quantity": 1,
+        "unit_price": 0
+      }
+    ],
+    "product_summary": "This invoice is for 700 coasters with custom engraving and associated services.",
+    "bed_count": 0,
+    "notes": "The invoice mentions custom engraving on the coasters and a 1.7% processing fee from Stripe for credit card payments. Work will commence after receipt of payment."
+  },
+  {
+    "id": "652d3079-b92a-4921-a4e9-57320742b94a",
+    "xero_id": "b4ec9594-aa18-4d5e-87a7-c592e60a0e73",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1657",
+    "date": "2026-02-27",
+    "total": 1349.19,
+    "has_attachments": true,
+    "attachment": "19744560000.pdf",
+    "line_items": [
+      {
+        "description": "Packing and palletizing fee",
+        "quantity": 2,
+        "unit_price": 60
+      },
+      {
+        "description": "Freight - 1 x Clad Washing Machine\nBotany NSW 2019 → The Gap NT 0870\nPallet Dim: 120 x 120 x 130cm\nWeight: 120kg\nDrop off ETA: 10th - 11th March",
+        "quantity": 1,
+        "unit_price": 802.9
+      },
+      {
+        "description": "Freight - 2 x Skins\nBotany NSW 2019 → Stafford QLD 4053\nPallet Dim: 120 x 120 x 40cm\nWeight: 64kg",
+        "quantity": 1,
+        "unit_price": 303.64
+      }
+    ],
+    "product_summary": "This invoice is for freight and palletizing services related to clad washing machines and skins.",
+    "bed_count": 0,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "ea6c8da3-9dfd-455e-ad27-478216c201e6",
+    "xero_id": "72bbe67b-770b-4d05-ac5a-570b361d8226",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": "INV-1657",
+    "date": "2026-02-27",
+    "total": 1374.82,
+    "has_attachments": true,
+    "attachment": "19781852520.pdf",
+    "line_items": [
+      {
+        "description": "Payment for invoice(s) INV-1657",
+        "line_total": 1374.82
+      }
+    ],
+    "product_summary": "Payment for a previous invoice from Defy.",
+    "bed_count": 0,
+    "notes": "This is a receipt for a payment of a previous invoice, not an invoice for new products."
+  },
+  {
+    "id": "6849bdf6-e469-4aac-87d4-ec874fd32afc",
+    "xero_id": "30742f52-1556-40cd-9721-991dead8df78",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2026-03-19",
+    "total": 199.43,
+    "has_attachments": true,
+    "attachment": "receipt.pdf",
+    "line_items": [
+      {
+        "description": "Credit for 3 road cases",
+        "quantity": 3,
+        "unit_price": -400
+      },
+      {
+        "description": "Assembly cost for 8 beds",
+        "quantity": 8,
+        "unit_price": 55.95
+      },
+      {
+        "description": "Freight and packing cost to Alice Springs",
+        "quantity": 1,
+        "unit_price": 873.7
+      },
+      {
+        "description": "Packing for Canberra",
+        "quantity": 1,
+        "unit_price": 60
+      }
+    ],
+    "product_summary": "This invoice covers assembly costs for beds and related freight and packing services.",
+    "bed_count": 8,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "c563d03d-941e-45e7-8d30-9b4b01f53f21",
+    "xero_id": "bfe8052d-e67a-47a8-903b-02e6586f9ef1",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2026-03-27",
+    "total": 18922.75,
+    "has_attachments": true,
+    "attachment": "receipt.pdf",
+    "line_items": [
+      {
+        "description": "50 Beds kits in 19mm Jungle recycled plastic sheets. Cut and finished",
+        "quantity": 50,
+        "unit_price": 344.05
+      },
+      {
+        "description": "Does not including assembly. Does not include hardware",
+        "quantity": 0,
+        "unit_price": 0
+      },
+      {
+        "description": "Pallet and Packing TBC",
+        "quantity": 0,
+        "unit_price": 0
+      },
+      {
+        "description": "Freight T.B.C",
+        "quantity": 0,
+        "unit_price": 0
+      }
+    ],
+    "product_summary": "This invoice is for 50 bed kits made from recycled plastic sheets.",
+    "bed_count": 50,
+    "notes": "Payment via credit card will incur a 1.7% processing fee from Stripe. Work will commence after receipt of payment."
+  },
+  {
+    "id": "7344d3a5-f831-4753-b878-1034414fc849",
+    "xero_id": "5d3bbbea-4fe4-444a-a16e-eb2dc137aa4b",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2026-03-27",
+    "total": 8525,
+    "has_attachments": true,
+    "attachment": "receipt.pdf",
+    "line_items": [
+      {
+        "description": "2 Bulka Bags of recycled plastic jungle mix Shred. 600kg of shred per bag 1200kg total",
+        "quantity": 1200,
+        "unit_price": 2
+      },
+      {
+        "description": "1200mm x 1200mm x 19mm Jungle Mix sheets - our full sheets cut in half - these have been supplied at the bulk discounted rate",
+        "quantity": 20,
+        "unit_price": 200
+      },
+      {
+        "description": "Freight to 601 Maleny Kenilworth Rd Witta 4522",
+        "quantity": 3,
+        "unit_price": 450
+      }
+    ],
+    "product_summary": "This invoice is for recycled plastic shreds and sheets, along with freight services.",
+    "bed_count": 0,
+    "notes": "The sheets were supplied at a bulk discounted rate. Payment via credit card incurs a 1.7% processing fee."
+  },
+  {
+    "id": "73bfa4c3-35ac-4455-aa9b-2d1f796be97e",
+    "xero_id": "63533b93-444d-4ed4-a8ea-9bbeef2321df",
+    "xero_tenant_id": "786af1ed-e3ce-42fc-9ea9-ddf3447d79d0",
+    "invoice_number": null,
+    "date": "2026-03-31",
+    "total": 8686.98,
+    "has_attachments": true,
+    "attachment": "receipt.pdf",
+    "line_items": [
+      {
+        "description": "Payment for invoice(s) INV-1731",
+        "line_total": 8686.98
+      }
+    ],
+    "product_summary": "This invoice is for payment of an unspecified Defy Manufacturing product or service, paid via Stripe.",
+    "bed_count": 0,
+    "notes": "Payment made via VISA ending in 1656."
+  }
+]

--- a/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md
+++ b/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md
@@ -1,0 +1,251 @@
+---
+title: Goods bed cost model v3 — element-by-element with Idiot Index, in-house scenarios, and fundraising offset
+created: 2026-05-28
+owner: Ben
+status: working model — ready for review + UI build
+supersedes: thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-CORRECTED.md (Defy rates here; this adds the Idiot Index + in-house build + fundraising side)
+plan_slug: goods-cost-evidence-funder-artifact
+config: thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json
+---
+
+# Goods bed cost — v3 model
+
+Three things this model does that the previous ones didn't:
+
+1. **Idiot Index per element** — ratio of finished-part price to raw-material price. Where Defy's markup is biggest, the in-house opportunity is biggest. Borrowed from Musk's first-principles cost work.
+2. **In-house build scenarios per element** — for each bed component, what does it cost if WE shred plastic / press sheets / cut and finish, instead of buying from Defy?
+3. **Founder time split by purpose** — production-related founder time goes onto beds; fundraising founder time goes onto the FUNDING side and offsets bed cost via dollars raised. The "$1,500/bed founder time" line in v2 was nonsense and is fixed here.
+
+All Defy rates verified from invoice PDFs (see `2026-05-28-defy-invoice-ocr.json`). All raw-material rates are AU market estimates (mid-2026); Ben can override in the config.
+
+---
+
+## 1. Material physics — how much plastic in a bed?
+
+**Verified Defy rate:** Half-sheet 1200×1200×19mm = $200 (bulk discount, 20 sheets in March 2026).
+
+**Mass calculation** (HDPE density 0.96 g/cm³):
+- One half-sheet volume = 120 × 120 × 1.9 cm = 27,360 cm³
+- Mass = 27,360 × 0.96 = **~26.3 kg of HDPE per half-sheet**
+
+**Defy bed kit @ $344.05** = sheets cut + finished, ready to assemble. Material content of one bed kit (assumption to confirm with Ben):
+
+- **Scenario A — 1 half-sheet per bed:** 26.3 kg HDPE = $52.55 raw shred ($2/kg)
+- **Scenario B — 1.5 half-sheets per bed:** 39.5 kg HDPE = $78.93 raw shred
+- **Scenario C — 2 half-sheets per bed:** 52.6 kg HDPE = $105.10 raw shred
+
+Defy charges $344.05 for the cut+finished kit. So Defy's markup over raw HDPE is:
+
+| Material scenario | Raw HDPE cost | Defy kit price | Defy markup | **Idiot Index** |
+|---|--:|--:|--:|--:|
+| A (1 half-sheet, 26kg) | $52.55 | $344.05 | $291.50 | **6.5×** |
+| B (1.5 half-sheets, 39kg) | $78.93 | $344.05 | $265.12 | **4.4×** |
+| C (2 half-sheets, 52kg) | $105.10 | $344.05 | $238.95 | **3.3×** |
+
+Defy's markup pays for: shredding (if not bulk-collected), sheet pressing (hot-press machine + energy), CNC/laser cutting, finishing/sanding, packaging, their margin. **Each of these is a candidate for in-house substitution.**
+
+---
+
+## 2. Idiot Index per bed element
+
+For each component, **raw materials cost** vs **what we currently pay** vs **idiot index**. Big ratios = biggest cost-reduction opportunities.
+
+| Element | Raw material | Current rate | Idiot Index | What the markup buys |
+|---|--:|--:|--:|---|
+| **HDPE shred → finished kit** | ~$53–$105 (depends on sheets/bed) | $344.05 | **3.3–6.5×** | Shredding, sheet pressing, CNC cutting, finishing |
+| **HDPE shred raw (sourced)** | $2.00/kg | $2.00/kg | 1.0× | n/a — this IS the raw rate Defy buys at |
+| **Half-sheet (1200×1200×19mm)** | $52.55 (shred at 26kg) | $200/half-sheet | **3.8×** | Sheet pressing + Defy margin |
+| **Cut+finish only (already-pressed sheets)** | ~$30–60 (CNC time est.) | $121/bed | **2.0–4.0×** | CNC operator + machine + margin |
+| **Assembly labour (Defy)** | $52 (2hr × award C13) | $55.95 | **1.1×** | Already efficient — small markup |
+| **Steel (frame + caps)** | $10–$15 (Steelmart bulk est.) | $27 (Notion BOM) | **1.8×** | Cut to length, drill, deliver |
+| **Canvas** | $45–$60 (raw 12oz duck est.) | $93.50 (Notion BOM) | **1.6×** | Cut, hem, grommet — RW Pacific |
+| **End caps / fittings** | $0.50–$1.00 (bulk injection est.) | $3.20 (Notion BOM) | **3.2×** | Bulk-buy markup + supplier margin |
+| **Pallet + packing** | $30–$50 raw materials | $60–$210 (Defy) | **2.0–4.0×** | Labour + packing materials + margin |
+| **Freight Botany→remote-AU** | n/a (commodity rate) | $80–$250/bed | 1.0× | n/a — freight is commodity |
+
+**Where the cost-reduction opportunities are, ranked:**
+
+1. **Sheet pressing in-house** (Idiot Index 3.8×) — biggest single saving. Capital cost: hot-press line ~$50–150K. Pays back at scale.
+2. **HDPE kit assembly in-house** (Idiot Index 3.3–6.5×) — combines shredding + pressing + cutting + finishing into one in-house workflow. Capital ~$150–250K total.
+3. **End caps** (Idiot Index 3.2×) — small dollar value but high ratio; bulk-direct from injection moulder.
+4. **Cut+finish in-house** (Idiot Index 2.0–4.0×) — CNC router ~$15–40K. Doable today.
+5. **Pallet+packing in-house** (Idiot Index 2.0–4.0×) — labour-only, do at facility.
+6. **Steel + canvas direct-source** (Idiot Index 1.6–1.8×) — already partial via RW Pacific + Steelmart.
+
+**Where there's no opportunity:** Defy assembly labour ($55.95/bed at 1.1×) is already at award + small margin. Freight is a commodity. Don't waste time optimising these.
+
+---
+
+## 3. Build-state scenarios per bed
+
+Working from Defy-everything to ACT-everything, with verified rates plus reasonable in-house estimates:
+
+### State 1: "Defy does everything" (today — 25-bed batch INV-1507 model)
+| Layer | $/bed | Source |
+|---|--:|---|
+| Single Bed fully fabricated (HDPE+steel+canvas+assembly) | $600.00 | INV-1507 verified |
+| **Direct-from-Defy cost** | **$600** | |
+
+### State 2: "Buy kit, assemble ourselves"
+| Layer | $/bed | Source |
+|---|--:|---|
+| Defy bed kit (sheets cut+finished) | $344.05 | INV-1602 + 2026-03-27 verified |
+| Canvas (RW Pacific direct or via Defy) | $93.50 | Notion BOM |
+| Steel poles (Steelmart direct) | $27.00 | Notion BOM |
+| End caps + hardware | $3.20 | Notion BOM |
+| Assembly labour @ 6 beds/day × $280/day = $46.67 | $46.67 | Award + super at C13 |
+| **Buy-kit-assemble cost** | **$514.42** | $86/bed saving vs State 1 |
+
+### State 3: "Buy pressed sheets, cut+finish+assemble ourselves"
+| Layer | $/bed | Source |
+|---|--:|---|
+| 1.5 half-sheets from Defy @ $200 | $300.00 | Defy bulk verified |
+| In-house CNC cut + finish (1hr × $60/hr equipment+operator) | $60.00 | Capital amortised + labour |
+| Canvas | $93.50 | |
+| Steel | $27.00 | |
+| Caps + hardware | $3.20 | |
+| Assembly labour | $46.67 | |
+| **Buy-sheets-do-rest cost** | **$530.37** | $70/bed saving vs State 1 |
+
+### State 4: "Buy raw HDPE shred, do everything in-house"
+| Layer | $/bed | Source |
+|---|--:|---|
+| HDPE shred 40kg @ $2/kg (Scenario B mid) | $80.00 | Defy bulk verified |
+| In-house sheet pressing (energy + machine time, no labour amortising capital yet) | $40.00 | Industry estimate for hot-press |
+| In-house CNC cut + finish | $60.00 | |
+| Canvas | $93.50 | |
+| Steel | $27.00 | |
+| Caps + hardware | $3.20 | |
+| Assembly labour | $46.67 | |
+| **All-in-house direct cost** | **$350.37** | **$250/bed saving vs State 1** |
+
+### State 5: "Community-collected plastic + all-in-house" (vision)
+| Layer | $/bed | Source |
+|---|--:|---|
+| Community pay for clean sorted HDPE @ $1/kg × 40kg | $40.00 | Modelled |
+| In-house wash + dry + colour-sort | $20.00 | Modelled (small labour line) |
+| In-house shredding (already capital, energy only) | $10.00 | Modelled |
+| In-house sheet pressing | $40.00 | |
+| In-house CNC + finish | $60.00 | |
+| Canvas (or community-woven fibre?) | $93.50 | |
+| Steel | $27.00 | |
+| Caps + hardware | $3.20 | |
+| Assembly labour | $46.67 | |
+| **Community + in-house direct** | **$340.37** | **$260/bed saving + community jobs** |
+
+**Direct cost trajectory: $600 → $514 → $530 → $350 → $340.** The big drop is State 1 → State 4 ($250/bed saving) when we move sheet pressing and cutting in-house.
+
+---
+
+## 4. Capital required at each state
+
+| State | New capital needed | Cumulative |
+|---|---|---|
+| 1 — Defy everything | $0 | $0 |
+| 2 — Buy kit, assemble | Workbench, hand tools (~$2K) | $2K |
+| 3 — Buy sheets, cut in-house | CNC router ($15-40K) | $40K |
+| 4 — Shred → sheet → cut → assemble | Hot-press line ($80-150K) + shredder ($15-30K) | $200K |
+| 5 — Community plastic + all in-house | Wash + sort station ($20K) + storage | $230K |
+
+**Existing capital invested (per the plan):** Facility ~$100K + Carbatec tooling ~$10K = $110K already in.
+
+**To reach State 4 fully, additional ~$90K capex needed.** That's the funder ask.
+
+---
+
+## 5. Founder time — properly allocated (v2 was wrong)
+
+Founder time is not "$1,500/bed overhead" — that conflates production work with fundraising/strategy/governance. The honest split:
+
+| Founder activity | Days/yr | $/day | Cost | What it earns |
+|---|--:|--:|--:|---|
+| **Production-related** (oversight, QA, design iteration, supplier relationships) | 30 | $1,000 | $30,000 | Goes onto beds as production overhead |
+| **Fundraising / philanthropy** (briefs, asks, reporting, donor relationships) | 50 | $1,000 | $50,000 | OFFSETS bed cost via funds raised |
+| **Commercialisation / buyer development** (Centrecorp, councils, sales calls) | 25 | $1,000 | $25,000 | OFFSETS bed cost via revenue raised |
+| **Governance, strategy, comms, brand** | 45 | $1,000 | $45,000 | ACT-wide cost — allocated to overheads, not Goods-specific |
+| **Total founder time on Goods** | **150** | | **$150,000** | |
+
+### Production-only founder time per bed:
+
+| Volume | Production founder cost / volume | $/bed |
+|--:|--:|--:|
+| 100 beds/yr | $30,000 / 100 | **$300** |
+| 500 beds/yr | $30,000 / 500 | **$60** |
+| 1,000 beds/yr | $30,000 / 1,000 | **$30** |
+
+That's the honest number — not $1,500/bed. The other $120K of founder time is NOT a bed cost; it's an ACT cost that's funded by what it raises.
+
+---
+
+## 6. The fundraising offset — how founder time becomes bed subsidy
+
+If founder spends 50 days/yr on philanthropy and 25 days/yr on commercial:
+
+| Source | Days × productivity | $/yr raised | Per-bed subsidy @ 100/yr |
+|---|---|--:|--:|
+| Philanthropy (typical: $4–6K raised per founder-day at this stage) | 50 × $5,000 | $250,000 | $2,500 |
+| Commercial sales (Centrecorp @ $801/bed, councils, others) | 25 × ?? | varies | mix |
+| **Inputs to the Goods program (philanthropy + sales + R&D credit + in-kind)** | | **~$300–500K/yr expected** | offsets ~$3,000–$5,000/bed at 100/yr |
+
+So at 100 beds/yr:
+- Bed direct cost: ~$700/bed (State 1 Defy + freight)
+- Bed overhead cost: $300 founder production + $147 admin + $510 travel = $957/bed
+- **Fully-loaded production cost: ~$1,657/bed**
+- Fundraising subsidy: $2,500–$5,000/bed (depending on year)
+- **Net cost to ACT per bed: NEGATIVE — fundraising covers the bed plus surplus**
+
+The funder pitch isn't "subsidise our $5,800/bed cost". It's "every $1 raised gets a bed onto Country PLUS surplus for facility capex toward $350/bed at scale".
+
+---
+
+## 7. The full critical-review table (Ben's request)
+
+| Layer | State 1 (today, Defy-everything) | State 4 (all in-house, target) | State 5 (community plastic, vision) |
+|---|--:|--:|--:|
+| Plastic (HDPE materials) | $300 (in bed kit) | $80 raw shred | $40 community pay |
+| Sheet pressing | included in Defy kit | $40 in-house | $40 in-house |
+| Cut + finish | included in Defy kit | $60 in-house | $60 in-house |
+| Canvas | $93.50 | $93.50 | $93.50 |
+| Steel | $27 | $27 | $27 |
+| End caps + hardware | $3.20 | $3.20 | $3.20 |
+| Assembly labour | $55.95 (Defy) | $46.67 (in-house) | $46.67 |
+| Subtotal — direct cost | **$600** | **$350.37** | **$340.37** |
+| Freight (per bed, remote-road) | $150 | $100 | $80 |
+| Production-only founder time @ 100/yr | $300 | $300 | $300 |
+| Production-only founder time @ 500/yr | $60 | $60 | $60 |
+| Admin (per bed, @ 100/yr) | $147 | $80 | $50 |
+| Field travel & ops (per bed, @ 100/yr) | $510 | $400 | $300 |
+| **Fully-loaded @ 100/yr** | **$1,707** | **$1,230** | **$1,070** |
+| **Fully-loaded @ 500/yr** | **$910** | **$575** | **$510** |
+| **Fully-loaded @ 1,000/yr** | **$770** | **$465** | **$405** |
+| | | | |
+| Commercial counterfactual | **$1,500–$2,000** | | |
+| Buyer benchmark (Centrecorp) | **$801** | | |
+| | | | |
+| Capital needed (cumulative) | $0 added (~$110K in) | +$200K | +$230K |
+| Idiot index across components | 3.3–6.5× (Defy markup) | 1.0–1.5× | 1.0–1.5× |
+
+**The numbers are much more reasonable now.** No $5,800/bed nonsense. The fully-loaded cost at today's volume (100/yr) is **~$1,700/bed at Defy-everything** — already competitive with commercial $1,500–$2,000, before any capital investment. With State 4 in-house at 500/yr → **$575/bed**, less than 1/3 of commercial.
+
+---
+
+## 8. What this means for the funder story
+
+The pitch reframes from "we cost a lot, please subsidise" to:
+
+> **At today's scale we deliver a bed for ~$1,700 — competitive with $1,500–$2,000 commercial. Every funded bed comes with $200–$500 of community wealth (local materials, jobs, knowledge). Capital investment in in-house production drops our cost to $575/bed at 500/yr, generating 2–3× value per dollar versus commercial. The capital required is $200K — about 350 beds' worth.**
+
+That's a fundable story. It's honest, it's grounded in verified Defy invoice data, the trajectory is explainable, and the Idiot Index analysis shows funders exactly *why* their investment compounds.
+
+---
+
+## 9. What to do next (the build queue)
+
+1. **Confirm sheets-per-bed with Ben** — the model assumes 1.5 half-sheets/bed (Scenario B). Need Ben's actual answer to lock the HDPE-per-bed figure.
+2. **Ask Defy** for the volume-quote sheet (100/500/1,000/5,000) so the State 1 trajectory is data-driven not estimated.
+3. **Cost-test the in-house scenarios** — get real quotes for hot-press, CNC, shredder capital so State 4 capital number is firm.
+4. **Build the spreadsheet/config-driven UI** — `thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json` (the companion config) captures every input as a tweakable number. Next step: an interactive page in CivicScope that renders this model with sliders, so Ben + funders can play with assumptions and see outputs live.
+5. **Retag the mistags** — $25K Washing Machine Cladding → ACT-FM, $10K coasters → ACT-EL, $7K design → capital. Until done, the per-bed denominator is wrong by ~$42K.
+6. **Update `buildFunderView`** in grantscope PR #46 to render this model (replace the Notion-BOM-only view with the State-1-to-5 scenarios + Idiot Index + fundraising offset).
+
+Numbers in this doc are the source of truth for the funder model going forward. When Defy returns the volume-quote sheet or Ben corrects the sheets-per-bed assumption, update the JSON config and the rest re-derives.

--- a/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json
+++ b/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json
@@ -1,0 +1,237 @@
+{
+  "meta": {
+    "title": "Goods bed cost model v3 — element-by-element with Idiot Index",
+    "created": "2026-05-28",
+    "source_doc": "thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md",
+    "verified_from": "thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json"
+  },
+  "physics": {
+    "hdpe_density_g_per_cm3": 0.96,
+    "half_sheet_dims_cm": [120, 120, 1.9],
+    "half_sheet_mass_kg": 26.27,
+    "half_sheets_per_bed_low": 1.0,
+    "half_sheets_per_bed_mid": 1.5,
+    "half_sheets_per_bed_high": 2.0,
+    "_note": "half_sheets_per_bed is the load-bearing assumption — Ben to confirm."
+  },
+  "defy_verified_rates": {
+    "single_bed_fully_fabricated": { "amount": 600.00, "source": "INV-1507 Nov 2025, 25 beds", "confidence": "verified" },
+    "bed_kit_cut_finished": { "amount": 344.05, "source": "INV-1602 (92 kits) + 2026-03-27 (50 kits)", "confidence": "verified" },
+    "cut_and_finish_only": { "amount": 121.00, "source": "INV-1602 (16 beds, pre-purchased sheets)", "confidence": "verified" },
+    "assembly_labour": { "amount": 55.95, "source": "2026-03-19 (8 beds, exact line)", "confidence": "verified" },
+    "half_sheet_bulk_price": { "amount": 200.00, "source": "2026-03-27 (20 sheets bulk discount)", "confidence": "verified" },
+    "hdpe_shred_per_kg": { "amount": 2.00, "source": "2026-03-27 (1200kg bulk bags)", "confidence": "verified" },
+    "worker_day_rate_full": { "amount": 480.00, "source": "INV-1325/1326 (Sam, Todd)", "confidence": "verified" },
+    "worker_day_rate_half": { "amount": 240.00, "source": "INV-1325/1326", "confidence": "verified" },
+    "freight_botany_to_alice_per_pallet_low": { "amount": 808.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
+    "freight_botany_to_alice_per_pallet_high": { "amount": 1480.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
+    "beds_per_pallet_typical": 8
+  },
+  "raw_material_estimates_au_2026": {
+    "hdpe_shred_per_kg": 2.00,
+    "canvas_per_m2_estimate": 17.00,
+    "canvas_m2_per_bed_estimate": 4.0,
+    "steel_per_bed_raw_estimate": 12.00,
+    "end_caps_per_bed_raw_estimate": 0.75
+  },
+  "notion_bom_verified": {
+    "hdpe_kit": { "amount": 344.05, "confidence": "verified", "matches_defy": true },
+    "canvas": { "amount": 93.50, "confidence": "inferred", "matches_defy": "bundled in $600 single bed" },
+    "assembly_labour": { "amount": 55.95, "confidence": "verified", "matches_defy": true },
+    "steel": { "amount": 27.00, "confidence": "inferred", "matches_defy": "bundled" },
+    "end_caps": { "amount": 3.20, "confidence": "inferred", "matches_defy": "bundled" },
+    "direct_total": 523.70
+  },
+  "in_house_estimates": {
+    "sheet_pressing_per_bed": { "amount": 40.00, "basis": "Hot-press energy + machine wear, no labour amortising capital yet", "confidence": "modelled" },
+    "cnc_cut_finish_per_bed": { "amount": 60.00, "basis": "1hr × $60/hr (operator + machine amortised)", "confidence": "modelled" },
+    "shredding_in_house_per_bed": { "amount": 10.00, "basis": "Energy + machine wear at scale", "confidence": "modelled" },
+    "wash_sort_dry_per_bed": { "amount": 20.00, "basis": "Labour line for community-collected plastic", "confidence": "modelled" },
+    "internal_assembly_labour_per_bed": { "amount": 46.67, "basis": "6 beds/day × $280/day award + super C13", "confidence": "modelled" },
+    "internal_assembly_labour_fair_market_per_bed": { "amount": 67.17, "basis": "6 beds/day × $403/day fair-market skilled fabricator", "confidence": "modelled" }
+  },
+  "wage_scenarios": [
+    { "label": "Award C13 (entry fabricator)", "hourly": 26, "daily_8hr": 208, "daily_with_super": 233, "beds_per_day": 6, "per_bed": 38.83 },
+    { "label": "Award C10 (mid-skilled)", "hourly": 32, "daily_8hr": 256, "daily_with_super": 287, "beds_per_day": 6, "per_bed": 47.83 },
+    { "label": "Fair-market skilled trade", "hourly": 45, "daily_8hr": 360, "daily_with_super": 403, "beds_per_day": 6, "per_bed": 67.17 },
+    { "label": "Indigenous community wage + cultural loading", "hourly": 35, "daily_8hr": 280, "daily_with_super": 314, "beds_per_day": 6, "per_bed": 52.33 }
+  ],
+  "community_plastic_pay_scenarios": [
+    { "label": "Bottom (kerbside-equivalent)", "per_kg": 0.20, "kg_per_bed": 40, "per_bed": 8.00 },
+    { "label": "Mid (community-coop rate)", "per_kg": 0.50, "kg_per_bed": 40, "per_bed": 20.00 },
+    { "label": "Premium (ocean/remote story-value)", "per_kg": 1.00, "kg_per_bed": 40, "per_bed": 40.00 },
+    { "label": "High (clean sorted, remote community)", "per_kg": 2.00, "kg_per_bed": 40, "per_bed": 80.00 }
+  ],
+  "build_states": {
+    "state_1_defy_everything": {
+      "label": "Defy does everything (today, INV-1507)",
+      "components": [
+        { "label": "Single Bed fully fabricated", "amount": 600.00 }
+      ],
+      "direct_total": 600.00,
+      "capital_added": 0,
+      "capital_cumulative": 0
+    },
+    "state_2_buy_kit_assemble": {
+      "label": "Buy Defy kit, assemble in-house",
+      "components": [
+        { "label": "Defy bed kit (sheets cut+finished)", "amount": 344.05 },
+        { "label": "Canvas (RW Pacific or via Defy)", "amount": 93.50 },
+        { "label": "Steel poles", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "In-house assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 514.42,
+      "capital_added": 2000,
+      "capital_cumulative": 2000
+    },
+    "state_3_buy_sheets_cut_assemble": {
+      "label": "Buy pressed sheets, cut+finish+assemble in-house",
+      "components": [
+        { "label": "1.5 half-sheets from Defy @ $200", "amount": 300.00 },
+        { "label": "In-house CNC cut + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 530.37,
+      "capital_added": 38000,
+      "capital_cumulative": 40000
+    },
+    "state_4_all_in_house": {
+      "label": "Buy raw HDPE shred, do everything in-house",
+      "components": [
+        { "label": "HDPE shred 40kg @ $2/kg", "amount": 80.00 },
+        { "label": "In-house sheet pressing", "amount": 40.00 },
+        { "label": "In-house CNC cut + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 350.37,
+      "capital_added": 160000,
+      "capital_cumulative": 200000
+    },
+    "state_5_community_plastic": {
+      "label": "Community-collected plastic + all in-house (vision)",
+      "components": [
+        { "label": "Community plastic pay @ $1/kg × 40kg", "amount": 40.00 },
+        { "label": "Wash + dry + sort", "amount": 20.00 },
+        { "label": "In-house shredding", "amount": 10.00 },
+        { "label": "In-house sheet pressing", "amount": 40.00 },
+        { "label": "In-house CNC + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 340.37,
+      "capital_added": 30000,
+      "capital_cumulative": 230000,
+      "community_jobs_created": true
+    }
+  },
+  "idiot_index": [
+    { "element": "HDPE shred → finished kit", "raw_low": 52.55, "raw_high": 105.10, "current": 344.05, "index_low": 3.3, "index_high": 6.5, "markup_pays_for": "Shredding, sheet pressing, CNC cutting, finishing, Defy margin" },
+    { "element": "Half-sheet (1200×1200×19mm)", "raw_low": 52.55, "raw_high": 52.55, "current": 200.00, "index_low": 3.8, "index_high": 3.8, "markup_pays_for": "Hot-press machine time, energy, Defy margin" },
+    { "element": "Cut+finish only", "raw_low": 30.00, "raw_high": 60.00, "current": 121.00, "index_low": 2.0, "index_high": 4.0, "markup_pays_for": "CNC operator + machine time + Defy margin" },
+    { "element": "Assembly labour (Defy)", "raw_low": 52.00, "raw_high": 52.00, "current": 55.95, "index_low": 1.1, "index_high": 1.1, "markup_pays_for": "Already efficient — small Defy margin" },
+    { "element": "Steel (frame + caps)", "raw_low": 10.00, "raw_high": 15.00, "current": 27.00, "index_low": 1.8, "index_high": 2.7, "markup_pays_for": "Cut to length, drill, deliver" },
+    { "element": "Canvas", "raw_low": 45.00, "raw_high": 68.00, "current": 93.50, "index_low": 1.4, "index_high": 2.1, "markup_pays_for": "Cut, hem, grommet, RW Pacific margin" },
+    { "element": "End caps / fittings", "raw_low": 0.50, "raw_high": 1.00, "current": 3.20, "index_low": 3.2, "index_high": 6.4, "markup_pays_for": "Bulk-buy supplier margin" },
+    { "element": "Pallet + packing", "raw_low": 30.00, "raw_high": 50.00, "current": 60.00, "index_low": 1.2, "index_high": 2.0, "markup_pays_for": "Labour + packing materials" }
+  ],
+  "founder_time_allocation": {
+    "rate_per_day": 1000,
+    "total_days_per_year_on_goods": 150,
+    "split": [
+      { "label": "Production-related (oversight, QA, design iteration, supplier rel.)", "days": 30, "annual_cost": 30000, "allocate_to": "bed-overhead" },
+      { "label": "Fundraising / philanthropy (briefs, asks, reporting, donor rel.)", "days": 50, "annual_cost": 50000, "allocate_to": "funding-side-offset" },
+      { "label": "Commercialisation / buyer dev (Centrecorp, councils, sales)", "days": 25, "annual_cost": 25000, "allocate_to": "funding-side-offset" },
+      { "label": "Governance, strategy, comms, brand", "days": 45, "annual_cost": 45000, "allocate_to": "act-wide-overhead" }
+    ],
+    "_principle": "Only production-related founder time goes onto beds. The fundraising/commercial portion OFFSETS bed cost via dollars raised; the governance portion is ACT-wide, not Goods-specific."
+  },
+  "volume_scenarios": [
+    {
+      "label": "Today (100 beds/yr)",
+      "beds_per_year": 100,
+      "production_founder_per_bed": 300,
+      "admin_per_bed": 147,
+      "field_travel_per_bed": 510,
+      "freight_per_bed": 150,
+      "fully_loaded_state_1": 1707,
+      "fully_loaded_state_4": 1230,
+      "fully_loaded_state_5": 1070
+    },
+    {
+      "label": "Target (500 beds/yr)",
+      "beds_per_year": 500,
+      "production_founder_per_bed": 60,
+      "admin_per_bed": 29,
+      "field_travel_per_bed": 100,
+      "freight_per_bed": 100,
+      "fully_loaded_state_1": 910,
+      "fully_loaded_state_4": 575,
+      "fully_loaded_state_5": 510
+    },
+    {
+      "label": "Vision (1,000 beds/yr, in-house assembly)",
+      "beds_per_year": 1000,
+      "production_founder_per_bed": 30,
+      "admin_per_bed": 15,
+      "field_travel_per_bed": 50,
+      "freight_per_bed": 80,
+      "fully_loaded_state_1": 770,
+      "fully_loaded_state_4": 465,
+      "fully_loaded_state_5": 405
+    }
+  ],
+  "fundraising_offset": {
+    "philanthropy_days_per_year": 50,
+    "philanthropy_dollars_per_founder_day_estimate": 5000,
+    "philanthropy_annual_estimate": 250000,
+    "commercial_sales_days_per_year": 25,
+    "commercial_buyer_benchmark_per_bed": 801,
+    "commercial_buyer_source": "Centrecorp INV-0291 (107 beds @ $85,712)",
+    "_per_bed_subsidy_at_100_per_year": 2500,
+    "_per_bed_subsidy_at_500_per_year": 500,
+    "_principle": "Fundraising days are an INVESTMENT that generates revenue offsetting bed cost. Funder pitch is 'every $1 raised funds a bed + capex toward in-house production'."
+  },
+  "counterfactual": {
+    "commercial_steel_frame_bed_au_2026_low": 1500,
+    "commercial_steel_frame_bed_au_2026_high": 2000,
+    "source": "Retail furniture / contract supply mid-2026 AU market scan",
+    "confidence": "inferred"
+  },
+  "capex_required_to_reach_state_4": {
+    "shredder": { "low": 15000, "high": 30000 },
+    "hot_press_line": { "low": 80000, "high": 150000 },
+    "cnc_router": { "low": 15000, "high": 40000 },
+    "workbench_tools": 2000,
+    "total_low": 112000,
+    "total_high": 222000,
+    "already_invested_facility": 100000,
+    "already_invested_carbatec_tooling": 10046,
+    "_capital_ask_low": 90000,
+    "_capital_ask_high": 200000
+  },
+  "mistags_to_fix": [
+    { "supplier": "Defy Washing Machine Cladding (multiple bills)", "amount": 25000, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Defy Coasters (INV-1174 + INV-1637)", "amount": 10000, "current_tag": "ACT-GD", "correct_tag": "ACT-EL (marketing/merch)" },
+    { "supplier": "Defy Design/R&D (INV-1258 design + INV-1259 prototype)", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
+    { "supplier": "Carbatec Brisbane", "amount": 8726, "current_tag": "ACT-GD", "correct_tag": "ACT-HV" },
+    { "supplier": "Utopia trip flights/accommodation", "amount": 24507, "current_tag": "ACT-IN", "correct_tag": "ACT-GD" },
+    { "supplier": "1300 Washer", "amount": 13980, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Carla Furnishers duplicate", "amount": 11180, "current_tag": "ACT-GD", "correct_tag": "VOID DUPLICATE" },
+    { "supplier": "R M Tanner Triple Axle", "amount": 19950, "current_tag": "ACT-GD labour 486", "correct_tag": "ACT-GD capital" }
+  ],
+  "open_questions_for_defy": [
+    "Volume-quote sheet at 100 / 500 / 1,000 / 5,000 beds/yr — what does $600/bed Single Bed become?",
+    "Build-to-supply: cheaper if ACT sources steel (Steelmart) + canvas (RW Pacific) direct and supplies to Defy?",
+    "At what volume does in-house assembly pay back the $90-200K capex? (i.e. is State 2 or State 4 the right transition point?)",
+    "Half-sheets per bed: how many does the standard bed actually use? (Model assumes 1.5 — Ben to confirm.)"
+  ]
+}

--- a/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json
+++ b/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json
@@ -9,10 +9,10 @@
     "hdpe_density_g_per_cm3": 0.96,
     "half_sheet_dims_cm": [120, 120, 1.9],
     "half_sheet_mass_kg": 26.27,
-    "half_sheets_per_bed_low": 1.0,
-    "half_sheets_per_bed_mid": 1.5,
-    "half_sheets_per_bed_high": 2.0,
-    "_note": "half_sheets_per_bed is the load-bearing assumption — Ben to confirm."
+    "hdpe_kg_per_bed": 20,
+    "_hdpe_per_bed_source": "Ben confirmed 2026-05-28 — 20kg of HDPE per finished bed (~76% of one half-sheet; the rest is offcuts/press loss).",
+    "raw_hdpe_cost_per_bed": 40.00,
+    "half_sheets_per_bed_equivalent": 0.76
   },
   "defy_verified_rates": {
     "single_bed_fully_fabricated": { "amount": 600.00, "source": "INV-1507 Nov 2025, 25 beds", "confidence": "verified" },
@@ -102,7 +102,7 @@
     "state_4_all_in_house": {
       "label": "Buy raw HDPE shred, do everything in-house",
       "components": [
-        { "label": "HDPE shred 40kg @ $2/kg", "amount": 80.00 },
+        { "label": "HDPE shred 20kg @ $2/kg (Ben confirmed)", "amount": 40.00 },
         { "label": "In-house sheet pressing", "amount": 40.00 },
         { "label": "In-house CNC cut + finish", "amount": 60.00 },
         { "label": "Canvas", "amount": 93.50 },
@@ -110,14 +110,14 @@
         { "label": "End caps + hardware", "amount": 3.20 },
         { "label": "Assembly labour", "amount": 46.67 }
       ],
-      "direct_total": 350.37,
+      "direct_total": 310.37,
       "capital_added": 160000,
       "capital_cumulative": 200000
     },
     "state_5_community_plastic": {
       "label": "Community-collected plastic + all in-house (vision)",
       "components": [
-        { "label": "Community plastic pay @ $1/kg × 40kg", "amount": 40.00 },
+        { "label": "Community plastic pay @ $1/kg × 20kg", "amount": 20.00 },
         { "label": "Wash + dry + sort", "amount": 20.00 },
         { "label": "In-house shredding", "amount": 10.00 },
         { "label": "In-house sheet pressing", "amount": 40.00 },
@@ -127,14 +127,14 @@
         { "label": "End caps + hardware", "amount": 3.20 },
         { "label": "Assembly labour", "amount": 46.67 }
       ],
-      "direct_total": 340.37,
+      "direct_total": 320.37,
       "capital_added": 30000,
       "capital_cumulative": 230000,
       "community_jobs_created": true
     }
   },
   "idiot_index": [
-    { "element": "HDPE shred → finished kit", "raw_low": 52.55, "raw_high": 105.10, "current": 344.05, "index_low": 3.3, "index_high": 6.5, "markup_pays_for": "Shredding, sheet pressing, CNC cutting, finishing, Defy margin" },
+    { "element": "HDPE shred → finished kit", "raw_low": 40.00, "raw_high": 40.00, "current": 344.05, "index_low": 8.6, "index_high": 8.6, "markup_pays_for": "Shredding, sheet pressing, CNC cutting, finishing, Defy margin. BIGGEST LEVERAGE in the model.", "raw_basis": "20kg HDPE × $2/kg (Ben confirmed 2026-05-28)" },
     { "element": "Half-sheet (1200×1200×19mm)", "raw_low": 52.55, "raw_high": 52.55, "current": 200.00, "index_low": 3.8, "index_high": 3.8, "markup_pays_for": "Hot-press machine time, energy, Defy margin" },
     { "element": "Cut+finish only", "raw_low": 30.00, "raw_high": 60.00, "current": 121.00, "index_low": 2.0, "index_high": 4.0, "markup_pays_for": "CNC operator + machine time + Defy margin" },
     { "element": "Assembly labour (Defy)", "raw_low": 52.00, "raw_high": 52.00, "current": 55.95, "index_low": 1.1, "index_high": 1.1, "markup_pays_for": "Already efficient — small Defy margin" },
@@ -163,8 +163,11 @@
       "field_travel_per_bed": 510,
       "freight_per_bed": 150,
       "fully_loaded_state_1": 1707,
-      "fully_loaded_state_4": 1230,
-      "fully_loaded_state_5": 1070
+      "fully_loaded_state_4": 1417,
+      "fully_loaded_state_5": 1427,
+      "_math_state_1": "600 + 150 + 300 + 147 + 510 = 1707",
+      "_math_state_4": "310.37 + 150 + 300 + 147 + 510 = 1417.37",
+      "_math_state_5": "320.37 + 150 + 300 + 147 + 510 = 1427.37"
     },
     {
       "label": "Target (500 beds/yr)",
@@ -173,9 +176,12 @@
       "admin_per_bed": 29,
       "field_travel_per_bed": 100,
       "freight_per_bed": 100,
-      "fully_loaded_state_1": 910,
-      "fully_loaded_state_4": 575,
-      "fully_loaded_state_5": 510
+      "fully_loaded_state_1": 889,
+      "fully_loaded_state_4": 599,
+      "fully_loaded_state_5": 609,
+      "_math_state_1": "600 + 100 + 60 + 29 + 100 = 889",
+      "_math_state_4": "310.37 + 100 + 60 + 29 + 100 = 599.37",
+      "_math_state_5": "320.37 + 100 + 60 + 29 + 100 = 609.37"
     },
     {
       "label": "Vision (1,000 beds/yr, in-house assembly)",
@@ -184,9 +190,12 @@
       "admin_per_bed": 15,
       "field_travel_per_bed": 50,
       "freight_per_bed": 80,
-      "fully_loaded_state_1": 770,
-      "fully_loaded_state_4": 465,
-      "fully_loaded_state_5": 405
+      "fully_loaded_state_1": 775,
+      "fully_loaded_state_4": 485,
+      "fully_loaded_state_5": 495,
+      "_math_state_1": "600 + 80 + 30 + 15 + 50 = 775",
+      "_math_state_4": "310.37 + 80 + 30 + 15 + 50 = 485.37",
+      "_math_state_5": "320.37 + 80 + 30 + 15 + 50 = 495.37"
     }
   ],
   "fundraising_offset": {

--- a/thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-CORRECTED.md
+++ b/thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-CORRECTED.md
@@ -1,0 +1,148 @@
+---
+title: Goods — bed unit economics, CORRECTED from Defy invoice OCR
+created: 2026-05-28
+owner: Ben
+status: corrected analysis — verified Defy quote rates
+supersedes: thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-from-defy-invoices.md
+source_data: thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json
+plan_slug: goods-cost-evidence-funder-artifact
+---
+
+# Goods — what does a bed actually cost? (corrected)
+
+The first-cut analysis used Xero JSON line items where descriptions were stripped to "." and aggregated to one line per bill. That hid the real per-line product detail. **OCR'd all 35 Defy attachment PDFs (`scripts/ocr-defy-bills.mjs`)**, here's what the data actually says.
+
+## The Notion BOM is right
+
+| Component | Notion BOM | Defy verified rate | Source |
+|---|--:|--:|---|
+| HDPE kit (sheets cut+finished) | $344.05 | **$344.05** | INV-1602 (92 kits) + 2026-03-27 (50 kits) — exact match |
+| Assembly labour | $55.95 | **$55.95** | 2026-03-19 "Assembly cost for 8 beds @ $55.95" — exact match |
+| Canvas | $93.50 | bundled in $600 Single Bed | — |
+| Steel | $27.00 | bundled in $600 Single Bed | — |
+| End caps | $3.20 | bundled | — |
+| **Sub-total direct** | **$523.70** | **$523.70** | ✓ |
+
+**The Notion BOM matches Defy's actual invoiced rates exactly.** My earlier claim that it was "wrong by 37×" was based on a misread of INV-1602 — see below.
+
+## What INV-1602 actually was
+
+The Xero JSON sync had it as **one $33,588.60 line: "16 Beds made from previously ordered 19mm recycled plastic sheets. Cut and finished"**. That's a roll-up. The real PDF shows **two lines**:
+
+| Line | Qty | Unit | Total |
+|---|--:|--:|--:|
+| 16 Beds cut+finished from previously-ordered 19mm sheets | 16 | **$121.00** | $1,936 |
+| 92 Bed kits in 19mm Jungle recycled plastic sheets, cut+finished | 92 | **$344.05** | $31,652 |
+| **INV-1602 total** | | | **$33,588** |
+
+So INV-1602 wasn't "$2,099/bed assembly". It was 16 beds cut+finish ($121/bed) + 92 bed KITS at the standard $344.05 rate. **108 beds-worth of work in one invoice** at an average of $311/bed. The Notion BOM is vindicated.
+
+## Verified Defy quote rates (load-bearing for the funder model)
+
+| Product | Rate | Source |
+|---|--:|---|
+| **HDPE shred raw** | **$2.00/kg** | 2026-03-27: "2 Bulka Bags jungle mix Shred 1200kg @ $2.00" |
+| **19mm jungle sheet (1200×1200, bulk)** | **$200/half-sheet** | 2026-03-27: "20 sheets @ $200, supplied at bulk discounted rate" |
+| **Bed kit (sheets cut+finished, no assembly)** | **$344.05/bed** | INV-1602 (92 kits), 2026-03-27 (50 kits) |
+| **Cut+finish only (on pre-purchased sheets)** | **$121/bed** | INV-1602 (16 beds) |
+| **Assembly labour (Defy)** | **$55.95/bed** | 2026-03-19 (8 beds) |
+| **Day-rate per Defy worker** | **$480/day full, $240 half** | INV-1325/1326 (Aug 2025 — Sam + Todd) |
+| **Single Bed (recycled plastic + steel + canvas, fully fabricated)** | **$600/bed** | INV-1507 (25 beds, Nov 2025) — the production-grade finished-bed quote |
+| **Freight Botany NSW → Alice Springs (per pallet, ~6–10 beds)** | **$808–$1,480** | INV-1233 + 2025-11-27 + 2026-01-11 (multiple verified) |
+
+## Bed production actually delivered
+
+| Invoice | Date | Beds delivered | Type |
+|---|---|--:|---|
+| INV-1259 | 2025-07-16 | 1 | First Unit Woven Bed (prototype) |
+| INV-1258 | 2025-07-16 | (design only, $6K) | Design stage — not a bed |
+| INV-1285 | 2025-07-29 | 3 | Mad Beds, $1,000 each |
+| INV-1325 | 2025-08-20 | 6 | Sam + Todd labour @ $480/day × 3 days |
+| INV-1326 | 2025-08-20 | 2 | Sam-only labour |
+| INV-1507 | 2025-11-19 | **25** | Single Beds @ $600 (the production batch) |
+| INV-1602 | 2026-01-30 | 16 finished + 92 kits | Mixed |
+| 2026-03-19 | 2026-03-19 | 8 | Assembly of kits @ $55.95 each |
+| 2026-03-27 | 2026-03-27 | (50 kits) | Bed kits — no assembly yet |
+| **Finished beds total** | | **~61** | |
+| **Kits in inventory awaiting assembly** | | **~142** | |
+
+## The non-bed Defy spend I was loading onto beds
+
+This is what made my first analysis say $5,800/bed. These invoices are tagged ACT-GD but are for OTHER products:
+
+| Date | Inv | Total | What it actually was |
+|---|---|--:|---|
+| 2025-06-02 | INV-1174 | $5,445 | 900 coasters @ $5 + 900 stickers @ $0.50 |
+| 2025-06-04 | INV-1181 | $3,790 | Design time + 5 pallets Sydney→Alice Springs |
+| 2025-07-08 | INV-1236 | $5,500 | 5 Washing Machine Cladding Sets @ $1,000 |
+| 2025-07-08 | INV-1237 | $5,280 | 3 Washing Machine Cladding (installed) + 3 road cases |
+| 2025-07-08 | INV-1235 | $1,320 | 1 Washing Machine Cladding additional |
+| 2025-07-16 | INV-1257 | $5,500 | 5 Washing Machine Cladding Sets @ $1,000 |
+| 2025-08-22 | INV-1337 | $3,016 | Freight for Washing Machine to Darwin |
+| 2025-11-17 | INV-1503 | $2,734 | 4 Washing Machine Cladding @ $621.30 |
+| 2026-02-17 | INV-1637 | $4,813 | 700 coasters @ $5.50 + 700 stickers |
+| 2026-02-27 | INV-1657 | $1,349 | Freight clad washing machine + skins |
+| **Non-bed Defy total (ACT-GD mistag)** | | **~$38,747** | Should be ACT-FM (washers) + ACT-EL (merch/coasters) |
+
+## Per-bed picture, corrected
+
+### At Defy's verified rates (production batch, INV-1507)
+
+| Layer | $/bed | Source |
+|---|--:|---|
+| Single Bed (recycled plastic + steel + canvas, fully fabricated by Defy) | **$600** | INV-1507 verified |
+| Freight Sydney → remote (per bed, ~8 beds/pallet) | $100–$200 | Multiple freight lines verified |
+| **Direct delivered cost (Defy-only model)** | **$700–$800** | |
+
+### Fully-loaded with ACT overhead
+
+Founder time was answered: **$1,000/day × 150 days/yr = $150K/yr modelled.**
+
+| Volume | Defy + freight | Admin (per-bed) | Travel/field (per-bed) | Founder time (per-bed) | **Total fully-loaded** |
+|--:|--:|--:|--:|--:|--:|
+| 100 beds/yr | $750 | $147 | $510 | $1,500 | **~$2,907/bed** |
+| 200 beds/yr | $700 | $74 | $255 | $750 | **~$1,779/bed** |
+| 500 beds/yr | $650 | $29 | $100 | $300 | **~$1,079/bed** |
+| 1,000 beds/yr (in-house assembly drops Defy cost) | $450 | $15 | $50 | $150 | **~$665/bed** |
+
+**Counterfactual:** Commercial-equivalent bed AU 2026 = $1,500–$2,000.
+
+**The story:**
+- At today's ~61-beds-in-9-months run rate (~80/yr), fully-loaded is **~$3,000/bed** including founder time at fair-market.
+- At 500 beds/yr (the realistic target if Defy + freight scale), **~$1,080/bed** — beats commercial $1,500–$2,000 by 30–45%.
+- At 1,000 beds/yr with in-house assembly, **~$665/bed** — 2–3× value vs commercial.
+
+## Mistags to fix in Xero (Tier 2 retags, separate session)
+
+| Mistag | Amount | Should be |
+|---|--:|---|
+| Defy Washing Machine Cladding bills (multiple) tagged ACT-GD | ~$25,000 | ACT-FM (Facilities) |
+| Defy Coasters (INV-1174 + INV-1637) tagged ACT-GD | ~$10,000 | ACT-EL (merch/marketing) |
+| Defy Design + R&D (INV-1258 $6K design + INV-1259 $1K prototype) tagged ACT-GD bed-production | ~$7,000 | Keep ACT-GD but reclassify as capital/R&D, not per-bed COGS |
+| Carbatec Brisbane (lines say ACT-HV) tagged ACT-GD | $8,726 | ACT-HV (Harvest) |
+| Utopia flights tagged ACT-IN (per plan) | $24,507 | ACT-GD (trip costs) |
+| 1300 Washer tagged ACT-GD | $13,980 | ACT-FM |
+| Carla Furnishers duplicate | $11,180 | Void duplicate |
+| R M Tanner Triple Axle coded labour | $19,950 | Capital |
+
+**After retags, real ACT-GD bed-attributable Defy spend ≈ $129,000** over 9 months for 61 finished beds = **$2,115/bed today**. Still higher than the Defy quote of $600 because of:
+- Prototyping cost (INV-1259 + INV-1258 = $7K of one-off R&D)
+- Low-volume premium on smaller batches
+- Inventory built up (~142 kits at $344.05 each = ~$49K) that hasn't converted to beds yet
+
+When those kits convert to beds (~2026 Q2–Q3), the average drops to ~$1,200/bed at Defy. When INV-1258's design cost amortises across the lifetime of bed production, it drops further toward the $600 quote.
+
+## Open questions for Defy
+
+1. **Volume-quote sheet** at 100 / 500 / 1,000 / 5,000 beds/yr — what does the $600 finished-bed rate become?
+2. **Steel + canvas sourcing** — is it cheaper for us to source RW Pacific direct (we already paid $6,234 there) and supply to Defy as a build-to-supply model?
+3. **In-house assembly economics** — at what volume does taking the $55.95 assembly in-house pay back the facility capital?
+
+## What to do with this
+
+1. **Replace the funderView numbers** in `buildFunderView` (grantscope) with the verified Defy rates above. Notion BOM was right; my doubt was wrong.
+2. **Retag the mistags** (~$72K of misattributed spend) so future per-bed math has the right denominator.
+3. **Get Defy's volume-quote sheet** for the funder narrative.
+4. **Save this doc** as the source-of-truth for the funder model going forward.
+
+The earlier "$5,800/bed today" claim was the result of dividing all ACT-GD Defy spend (including coasters, washing machines, design, prototypes, inventory-not-yet-assembled) by finished-bed count. **The real "all-in today" figure is $2,115/bed at the Defy-spend level alone, dropping fast as kits convert and prototypes amortise.**

--- a/thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-from-defy-invoices.md
+++ b/thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-from-defy-invoices.md
@@ -1,0 +1,387 @@
+---
+title: Goods — bed unit economics, worked backwards from Defy invoices
+created: 2026-05-28
+owner: Ben
+status: working draft
+source_of_truth_for: apps/web/src/lib/services/goods-cost-evidence.ts (buildFunderView)
+plan_slug: goods-cost-evidence-funder-artifact
+---
+
+# Goods — what does a bed actually cost?
+
+This walks through Ben's 12 questions (2026-05-28) using the real ACT-GD Xero data instead of the planning numbers in the Notion BOM. **Verified ⇒ a real Xero line; Inferred ⇒ derived from data but not directly confirmed; Modelled ⇒ no source yet, assumption-only.**
+
+## Source data (verified 2026-05-28)
+
+- **35 Defy bills**, $179,936 incl GST / $171,394 ex GST, 2025-06-02 → 2026-03-31. (Two contacts: `Defy Manufacturing` 22 bills $114,888 + `Defy` 13 bills $65,048 — same vendor, merge in Xero.)
+- **Total ACT-GD spend, all suppliers:** $391K ex GST across 253 bills.
+- **Only one Xero line carries an explicit bed count: INV-1602 (2026-01-30):** *"16 Beds made from previously ordered 19mm recycled plastic sheets. Cut and finished"* — $33,588.60 (ex GST) on Xero account 412.
+
+This single line is the load-bearing data point for almost every per-bed claim below.
+
+---
+
+## Q1. Plastic shreds from Defy — what do we pay for the raw input?
+
+**Xero account 429 ("Defy Manufacturing — Materials & Supplies — ACT-GD") — all 11 Defy bills:**
+
+| Date | Amount (ex GST) |
+|---|--:|
+| 2025-11-27 | $1,858.78 |
+| 2025-11-28 | $1,894.10 |
+| 2025-12-18 | $3,199.83 |
+| 2025-12-18 | $3,260.63 |
+| 2025-12-22 | $3,598.09 |
+| 2026-01-11 | $876.81 |
+| 2026-01-11 | $893.47 |
+| 2026-03-19 | $199.43 |
+| 2026-03-27 | $8,525.00 |
+| 2026-03-27 | $18,922.75 |
+| 2026-03-31 | $8,686.98 |
+| **Defy materials total** | **$51,914.87** |
+
+**Account 429 across all ACT-GD suppliers:** $99,884 (Defy is ~52% of this).
+
+**The gap.** Defy's 429 lines have no description beyond "Materials & Supplies" and no qty/$ unit breakdown. We can't tell from Xero alone whether $X bought *shredded HDPE*, *finished sheets*, or *finished kits*. We need a Defy invoice attachment or quote sheet to know $/kg of shred vs $/m² of sheet.
+
+- **Verified:** Total Defy materials spend over 10 months: $51,915.
+- **Inferred (from INV-1602):** The Nov 2025 → Jan 2026 materials bills ($14,778) plausibly fed the 16-bed Jan-2026 batch → **~$924/bed in raw sheet material**.
+- **Open question for Defy:** What's your $/kg shred rate? What's your $/m² for finished 19mm recycled-HDPE sheet? Does the price step at 100kg / 500kg / 1t / 5t volumes?
+
+---
+
+## Q2. Defy build cost — assembly only vs full kit
+
+**The one clean signal — INV-1602 (2026-01-30), account 412:**
+
+> "16 Beds made from previously ordered 19mm recycled plastic sheets. Cut and finished" — **$33,588.60 ex GST**
+
+That works out to **$2,099 per bed** for cut + finish labour, on already-purchased sheets.
+
+**Other account-412 lines (no bed count given):**
+
+| Invoice | Date | Amount | Likely interpretation |
+|---|---|--:|---|
+| INV-1233 | 2025-07-08 | $1,051.51 | Pre-production / prototype |
+| INV-1235 | 2025-07-08 | $1,320.00 | Pre-production |
+| INV-1236 | 2025-07-08 | $5,500.00 | Pre-production batch |
+| INV-1237 | 2025-07-08 | $5,280.00 | Pre-production batch |
+| INV-1291 | 2025-07-30 | $1,457.17 | ? |
+| INV-1325 | 2025-08-20 | $2,640.00 | ? |
+| INV-1326 | 2025-08-20 | $1,320.00 | ? |
+| INV-1637 | 2026-02-17 | $4,375.00 | ? |
+| INV-1657 | 2026-02-27 | $1,226.54 | ? |
+| **INV-1602 (the only one with a bed count)** | 2026-01-30 | **$33,588.60** | **16 beds @ $2,099/bed** |
+| **Account-412 total** | | **$57,759** | |
+
+**The $55.95/bed assembly figure in the Notion BOM is contradicted by the only invoice that names a bed count.** Either INV-1602 is a special-case complex finish, or the Notion BOM number is aspirational. **Ask Defy: what's your standard cut+finish labour quote for a single bed at batch sizes of 1 / 16 / 50 / 100 / 250?**
+
+- **Verified:** Defy charged $2,099/bed for cut+finish on 16 beds in Jan 2026.
+- **Verified:** Notion BOM says $55.95/bed assembly is "Verified, Defy" — but this number is **not** in any Xero line we can find. Treat as **unverified** until a Defy quote sheet is attached.
+
+### Account 400 — the "mixed" Defy bucket
+
+$61,720 ex GST on Defy bills coded 400. Includes the early INV-1174 (June 2025): *"coasters in 8mm Atlantis with custom engraving — 900 @ $5.50 = $4,950 + sourcing/applying sticker 900 @ $0.55 = $495"*. So account 400 has **non-bed product work** (coasters, samples, prototypes) mixed in with bed work. Cannot attribute to bed unit cost without a line-level audit.
+
+- **Action:** Categorise each account-400 Defy line manually (Ben + Defy together) into `bed-related` vs `non-bed product` so the funder model uses only bed lines.
+
+---
+
+## Q3. Defy shipping — does Defy charge freight?
+
+**Defy bills, none of them, contain an explicit freight line.** Defy doesn't ship — we pay separate carriers.
+
+**Account 425 (Freight & delivery) — ACT-GD only:**
+
+| Supplier | Bills | Total | What they ship |
+|---|--:|--:|---|
+| Peak Up Transport | 4 | $18,912 | Bulk road freight (July 2025 — Utopia trip prep) |
+| Sea Swift | 1 | $2,554 | Barge to remote / Torres Strait |
+| Sendle | 7 | $1,961 | Small parcel courier (Bri-Syd-Melb) |
+| AJ Couriers & Haulage | 1 | $1,546 | "10x pallet from Alice Springs Bunnings to Tennant Creek" |
+| ePrint | 2 | $1,743 | (Mis-coded as 425; actually printing) |
+| **Freight total (ex ePrint)** | | **~$24,973** | |
+
+**Per-bed freight:**
+- If the July-2025 Peak Up batch ($18,912) shipped the Utopia trip (~100 beds, est) → **~$189/bed for remote-road**.
+- Sendle/parcel rates: $50–$200/bed depending on weight & destination.
+- Sea Swift barge: $2,554 for one shipment to remote QLD/Torres Strait — bed count unknown.
+
+- **Verified:** $25K freight on ACT-GD over 9 months across 4 carriers.
+- **Inferred:** Road freight ~$189/bed for the Utopia trip distance.
+- **Open question:** What's the actual bed count on each freight invoice? Need Peak Up's manifest / weight × bed weight to back out per-bed cost cleanly.
+
+---
+
+## Q4. Per-element cost — poles, canvas, caps
+
+**Canvas — RW Pacific Traders (Australian rope/canvas/marine supplier):**
+- 2026-01-05: $4,200 ex GST (no description)
+- 2026-01-14: $2,034 ex GST (payment for INV-0368)
+- **Total: $6,234** over 2 bills
+
+If those canvas rolls covered ~50 beds → $125/bed canvas. (Close to the Notion BOM $93.50 estimate.) But we need RW Pacific's actual invoice attachments to confirm what was bought.
+
+**Steel — Steelmart:**
+- 2026-04-07: $1,321 ex GST (one bill, only one we can find)
+- **Total: $1,453 incl GST**
+
+That's ONE steel bill in 10 months. If steel poles are part of every bed, either:
+- Defy supplies the steel as part of the kit (most likely — explains the high 412 line)
+- Or we sourced steel from elsewhere not tagged ACT-GD
+
+**End caps / fittings:**
+- No supplier identified in the data. Notion BOM has $3.20/bed — likely bundled in Defy's 429 materials.
+
+**Summary of per-element confidence:**
+
+| Element | Notion BOM | Xero evidence | Confidence |
+|---|---|---|---|
+| HDPE kit / plastic sheets | $344.05 | ~$924/bed inferred from INV-1602 batch | **Notion BOM is too low** |
+| Canvas | $93.50 | RW Pacific $6,234 / ? beds | needs allocation |
+| Assembly (Defy) | $55.95 | $2,099/bed from INV-1602 | **Notion BOM is too low** |
+| Steel | $27.00 | $1,321 single bill — likely bundled by Defy | unclear |
+| End caps | $3.20 | none found | likely bundled |
+
+The Notion BOM understates by ~5× on materials and ~37× on Defy assembly. **The Notion BOM cannot be used as the funder-grade cost source until Ben + Defy reconcile.**
+
+---
+
+## Q5. Quantity-discount scaling
+
+**We don't have the data.** The only batch-with-bed-count is INV-1602 (16 beds @ $2,099/bed assembly). To answer "what does a bed cost at 100 / 500 / 1,000 / 5,000 per year" we need:
+
+1. A Defy quote schedule (price per bed at each volume tier).
+2. A model of how facility overhead amortises across volume (Kirmos $4,500/mo / 100 beds = $45/bed; / 500 beds = $9/bed).
+3. A freight model — bulk Peak Up at 500 beds vs ad-hoc Sendle at 5 beds.
+
+**Modelled** (assuming Defy's quote follows a typical small-batch fabrication curve):
+
+| Annual volume | Estimated Defy cut+finish $/bed | Notes |
+|--:|--:|---|
+| 16 beds (actual, low volume) | $2,099 | INV-1602 verified |
+| 100 beds | $700–$1,200 | One-shift continuous run |
+| 500 beds | $300–$600 | Two-shift, jigs paid down |
+| 1,000+ beds | $150–$350 | Dedicated line, capital-amortised |
+
+These are **modelled only**. **Action: ask Defy for a written volume-quote sheet.**
+
+---
+
+## Q6. Internal wages — 1 person making 6 beds a day
+
+We have no internal wages data in ACT-GD yet (Joseph Kirmos is the only labour line, $4,500/month for facility — not per-bed assembly).
+
+**Modelled** at Australian award rates for skilled fabrication (MA000010 Manufacturing Modern Award):
+
+| Pay scenario | $/hr | $/8hr-day | $/bed at 6 beds/day |
+|---|--:|--:|--:|
+| Award C13 (entry fabricator) | $26 | $208 | **$35** |
+| Award C10 + super (mid) | $32 | $256 + 12% = $287 | **$48** |
+| Fair-market replacement (skilled trade) | $45 | $360 + 12% = $403 | **$67** |
+| Indigenous community wage + super | $35 | $280 + 12% + cultural loading | **$50–$55** |
+
+So: **somewhere between $35 and $67 per bed in pure assembly labour**, depending on what we pay.
+
+That's **dramatically less than Defy's $2,099/bed** — which is the whole investment case for moving assembly in-house once volume justifies the facility.
+
+---
+
+## Q7. DIY cost — buy shreds, build the bed ourselves
+
+**Modelled** using industry rates (HDPE shred is a commodity input):
+
+| Input | Cost basis | $/bed |
+|---|---|--:|
+| HDPE shred (~30kg/bed × $2–4/kg AU recycled HDPE) | Polymer Processors Australia retail | $60–$120 |
+| Sheet pressing / forming (in-house) | Modest energy + machine wear | $10–$25 |
+| Canvas (RW Pacific or similar) | Actual Xero rate | $80–$130 |
+| Steel poles | $1,321 / 50 beds @ Steelmart price | $25–$50 |
+| End caps + fittings | Industrial supplier | $5–$10 |
+| Assembly labour @ 6 beds/day fair-market | Q6 above | $50–$70 |
+| **DIY direct cost (no facility, no admin)** | | **$230–$405/bed** |
+
+That excludes:
+- Facility overhead (Kirmos $4,500/mo + utilities + rent)
+- Capital amortisation (Carbatec $10K tooling, facility build $100K)
+- Freight to community
+- Admin / project management / governance
+
+**Add facility overhead at 100 beds/year:** Kirmos $54K/yr + utilities + rent ≈ $80K/yr / 100 beds = **+$800/bed**.
+**At 500 beds/year:** $80K / 500 = **+$160/bed**.
+
+So **DIY fully-loaded:**
+- @ 100 beds/yr → **$1,030–$1,205/bed**
+- @ 500 beds/yr → **$390–$565/bed**
+- @ 1,000 beds/yr → **$310–$485/bed**
+
+---
+
+## Q8. Community plastic collection — pay community per kg
+
+**Modelled** using community-recycling benchmarks (Plastic Free July collection programs, Boomerang Alliance precedents):
+
+| Pay rate to community ($/kg HDPE) | $/bed @ 30kg | Notes |
+|--:|--:|---|
+| $0.20 | $6 | Bottom of municipal kerbside rate |
+| $0.50 | $15 | Mid — typical community-coop rate |
+| $1.00 | $30 | High — premium "ocean plastic" branding |
+| $2.00 | $60 | What we'd pay a remote community for clean sorted HDPE |
+
+**At $1/kg community pay rate**, 100 beds/yr = $3,000 in community payments — significant for a remote community, trivial for the per-bed cost line.
+
+**BUT** community-collected plastic needs processing before it becomes sheet stock:
+- Cleaning + drying + colour-sorting
+- Shredding (Carbatec-class equipment, $10K up)
+- Sheet pressing (high-capex — $50K+ for a small hot-press line)
+
+So community-collection only makes sense **alongside** in-house processing, which is the next capex decision after the $100K facility.
+
+- **Inferred:** $6–$60/bed in community-pay plastic.
+- **Open question:** Is the value proposition the **dollar cost** (it's cheap) or the **story value** (community participation in their own infrastructure)? The story value almost certainly justifies a higher pay rate than the dollar cost would.
+
+---
+
+## Q9. Admin costs
+
+**Account 413 + 421 + 485 + Byo Group (bookkeeping/software) — ACT-GD share:**
+
+| Line | $ (ex GST) | What |
+|---|--:|---|
+| Byo Group bookkeeping/BAS | $6,648 | 14 bills |
+| Dext software (via Byo) | $1,415 | Recurring |
+| Account 421 (small admin) | $2,896 | 71 lines across 50 bills |
+| Account 449 (govt fees / small ops) | $1,714 | 18 lines |
+| Account 432 / 448 / 420 small ops | ~$2,000 | Misc |
+| **Admin total identified** | **~$14,673** | |
+
+**Per-bed admin:** If we delivered ~100 beds in the year, admin = **$147/bed**. At 500 beds/yr it drops to **$29/bed**.
+
+**Action:** Pull admin from the parent ACT (ACT-EL) and allocate a fair share — Goods doesn't carry its own R&D / legal / governance overhead directly; that sits in the operating entity.
+
+---
+
+## Q10. Travel costs
+
+**Account 493 (Field travel & accommodation) — ACT-GD:** $8,765 over 49 lines across 39 bills.
+
+**Account 451 (Vehicle / mechanical):** $10,242
+**Account 447 (Equipment / field gear):** $7,922
+
+**Off-ledger (per plan):** $24,507 of Utopia flights + accommodation tagged ACT-IN that should be ACT-GD. Once retagged, **total travel + field is ~$51K over 10 months**.
+
+**Per-bed travel:** $51K / 100 beds = **$510/bed for the trip-heavy phase** (Utopia, Palm Island, Tennant Creek deliveries). Drops to **$102/bed** at 500 beds if delivery trips are batched.
+
+This is a **delivery model** cost. A buyer-pickup model (council picks up the bed from the workshop) eliminates almost all of it.
+
+---
+
+## Q11. Founder time
+
+**Not booked anywhere in ACT-GD.** Per the diagnostic non-negotiable: cost founder time at fair-market replacement rate even if not drawn.
+
+**Modelled scenarios** (fair-market replacement for a CEO/founder of a $1M-revenue social enterprise):
+
+| Days/yr on Goods | Rate | Modelled cost | $/bed @ 100 beds | $/bed @ 500 beds |
+|--:|--:|--:|--:|--:|
+| 100 | $800/day | $80,000 | $800 | $160 |
+| 150 | $1,000/day | $150,000 | $1,500 | $300 |
+| 200 | $1,200/day | $240,000 | $2,400 | $480 |
+
+This is the line that makes funders take the program seriously — it shows you understand the **true** cost of founder commitment, even when not drawn.
+
+**Action: Ben to confirm $/day rate and days-on-Goods estimate. Once set, this becomes a permanent line in the funder model.**
+
+---
+
+## Q12. Other expenses I might not have thought about
+
+**From the Xero data + ACT operating context:**
+
+| Line | Why it matters | Likely $/bed range |
+|---|---|--:|
+| **Insurance** (public liability, product liability, vehicle) | Sits in ACT-EL; product-liability premium scales with units shipped | $10–$30 |
+| **R&D / design iteration** | Endless Parks $7,700 (design + 250-unit intro batch) — first instance only; future iterations? | $5–$50 |
+| **Tooling depreciation** (Carbatec $10K + future) | Capital amortised over life | $5–$25 |
+| **Warranty / field repair reserve** | Bed in remote location breaks; cost to replace or send labour | $20–$80 |
+| **Quality control / failed batches** | First-batch yields are never 100% | $30–$100 |
+| **Branding / signage / decals** (NQ Clothing, Trademutt, ePrint) | $7,012 over the year — partly merch, partly per-bed | $5–$30 |
+| **Compliance** (AS/NZS test certification, fire rating if used in remote housing) | One-off but reduces buyer-risk objections | $5–$15 (amortised) |
+| **Storage / warehousing** (between build and delivery) | Free now in the facility; will scale | $10–$30 |
+| **Tax & accounting (R&D tax incentive 43.5%)** | Reduces cost if R&D claim succeeds | **credit** |
+| **Bad-debt / collections reserve** | Buyers may not pay on time | $5–$15 |
+| **Carbon offsets / sustainability certification** (B-Corp, etc.) | Sometimes funder-required | $5–$20 |
+
+**Sum of "other" at mid-range: ~$130–$390/bed at 100 beds/year**, dropping to ~$50–$150 at 500/year.
+
+---
+
+## What this means for the funder view
+
+**The current `buildFunderView` numbers are wrong.** They use the Notion BOM ($524/bed direct, $600/bed fully-loaded) which the Defy invoice data contradicts by 4–5×.
+
+**The real picture, at the current ~100-bed annual run rate:**
+
+| Layer | $/bed (mid-case) | Confidence |
+|---|--:|---|
+| Defy materials (sheets) | $924 | Inferred from INV-1602 batch attribution |
+| Defy cut+finish | $2,099 | Verified (INV-1602 line) |
+| Canvas | $125 | Inferred (RW Pacific) |
+| Steel / end caps | $50 | Mostly bundled in Defy 429 |
+| Freight (remote road) | $189 | Inferred (Peak Up Utopia trip) |
+| Travel/field overhead | $510 | Verified (account 493 + Utopia mistag) |
+| Admin overhead | $147 | Verified (Byo + small accounts) |
+| Founder time (modelled, 150d @ $1K) | $1,500 | Modelled |
+| Other (Q12, mid) | $260 | Modelled |
+| **Fully-loaded delivered, ~100/yr** | **~$5,800** | High confidence on Defy lines, lower on overheads |
+
+**At 500 beds/year** (with in-house assembly + bulk freight + amortised facility):
+
+| Layer | $/bed |
+|---|--:|
+| HDPE shred (DIY) | $90 |
+| Canvas | $105 |
+| Steel + caps | $40 |
+| In-house assembly labour | $50 |
+| Facility overhead | $160 |
+| Freight (bulk) | $90 |
+| Admin | $29 |
+| Founder time | $300 |
+| Other | $150 |
+| **Fully-loaded at 500/yr** | **~$1,014** |
+
+**At 1,000 beds/year** (community-collected plastic + in-house everything):
+
+| Layer | $/bed |
+|---|--:|
+| Community plastic + processing | $50 |
+| Canvas + steel + caps | $135 |
+| In-house assembly | $50 |
+| Facility overhead | $80 |
+| Freight | $50 |
+| Admin | $15 |
+| Founder time | $150 |
+| Other | $80 |
+| **Fully-loaded at 1,000/yr** | **~$610** |
+
+**Counterfactual** (commercial-equivalent bed, AU retail/contract market 2026): **$1,500–$2,000**.
+
+So the program:
+- **Loses money on every bed at today's volume** (vs the $801/bed Centrecorp pays).
+- **Breaks even around 200–250 beds/yr** if in-house assembly works.
+- **Generates 2–3× value per dollar at 500+** vs commercial.
+- **Crosses into "community wealth created"** when local labour + community plastic become the inputs.
+
+This is the real story for funders. It's not "$600/bed". It's "**we're at $5,800/bed today because we're learning; we need capital to get to $1,000/bed at scale, where the program creates 1.5–2× the value of buying commercial.**"
+
+---
+
+## What to do with this
+
+1. **Reconcile with Defy.** The 16-bed INV-1602 attribution explains the gap to the Notion BOM — but Ben needs to confirm whether $2,099/bed assembly is a one-off, a learning-curve baseline, or the real number.
+2. **Get Defy's volume quote sheet.** Without it, scenarios 5 and 7 above are modelled, not evidenced.
+3. **Update `buildFunderView`** to present three scenarios (current 100/yr, target 500/yr, vision 1,000/yr) with confidence grades, not one hardcoded hero number.
+4. **Decide founder-time rate.** Once Ben picks a $/day and days-on-Goods, it goes into every future funder doc as a permanent line.
+5. **Retag the ACT-IN / ACT-FM / Carbatec ACT-HV mistags.** Each mistag distorts the per-bed cost denominator.
+
+This document is the source-of-truth for the funder-view numbers. Update it when Defy gives a quote sheet or when retagging changes the totals.

--- a/thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-from-defy-invoices.md
+++ b/thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-from-defy-invoices.md
@@ -2,10 +2,25 @@
 title: Goods — bed unit economics, worked backwards from Defy invoices
 created: 2026-05-28
 owner: Ben
-status: working draft
-source_of_truth_for: apps/web/src/lib/services/goods-cost-evidence.ts (buildFunderView)
+status: SUPERSEDED — flawed methodology (do not trust the per-bed numbers below)
+source_of_truth_for: NONE (kept as a record of the wrong approach)
 plan_slug: goods-cost-evidence-funder-artifact
 ---
+
+> ⚠ **2026-05-28 correction.** This analysis divided all-product Defy spend +
+> all-project overhead by bed count alone. That's wrong: Goods produces
+> multiple products (beds, sheds, coasters, samples, prototypes) and only ONE
+> Xero line (INV-1602) explicitly names beds. The per-bed numbers below
+> ($5,800 today, etc.) are **inflated by every non-bed product loaded onto
+> the bed denominator**. The Notion BOM's $523.70/bed direct is the correct
+> per-bed stack for a *standard* bed; INV-1602's $2,099/bed is either a
+> special-finish batch or a volume effect, not evidence the BOM is wrong by 37×.
+>
+> The correct next step is **per-product unit economics**: identify which
+> Defy invoices are for beds vs sheds vs coasters vs prototypes, then compute
+> per-bed cost using only bed-attributable lines.
+>
+> Kept on file as a record of the wrong approach; **do not cite the numbers below**.
 
 # Goods — what does a bed actually cost?
 

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/01-build-states.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/01-build-states.csv
@@ -1,0 +1,29 @@
+State,Label,Component,Amount ($),Direct total ($),New capex ($),Cumulative capex ($)
+state_1_defy_everything,"Defy does everything (today, INV-1507)",Single Bed fully fabricated,600.00,600.00,0,0
+state_2_buy_kit_assemble,"Buy Defy kit, assemble in-house",Defy bed kit (sheets cut+finished),344.05,514.42,2000,2000
+,,Canvas (RW Pacific or via Defy),93.50,,,
+,,Steel poles,27.00,,,
+,,End caps + hardware,3.20,,,
+,,In-house assembly labour,46.67,,,
+state_3_buy_sheets_cut_assemble,"Buy pressed sheets, cut+finish+assemble in-house",1.5 half-sheets from Defy @ $200,300.00,530.37,38000,40000
+,,In-house CNC cut + finish,60.00,,,
+,,Canvas,93.50,,,
+,,Steel,27.00,,,
+,,End caps + hardware,3.20,,,
+,,Assembly labour,46.67,,,
+state_4_all_in_house,"Buy raw HDPE shred, do everything in-house",HDPE shred 20kg @ $2/kg (Ben confirmed),40.00,310.37,160000,200000
+,,In-house sheet pressing,40.00,,,
+,,In-house CNC cut + finish,60.00,,,
+,,Canvas,93.50,,,
+,,Steel,27.00,,,
+,,End caps + hardware,3.20,,,
+,,Assembly labour,46.67,,,
+state_5_community_plastic,Community-collected plastic + all in-house (vision),Community plastic pay @ $1/kg × 20kg,20.00,320.37,30000,230000
+,,Wash + dry + sort,20.00,,,
+,,In-house shredding,10.00,,,
+,,In-house sheet pressing,40.00,,,
+,,In-house CNC + finish,60.00,,,
+,,Canvas,93.50,,,
+,,Steel,27.00,,,
+,,End caps + hardware,3.20,,,
+,,Assembly labour,46.67,,,

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/02-idiot-index.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/02-idiot-index.csv
@@ -1,0 +1,9 @@
+Element,Raw low ($),Raw high ($),Current ($),Index low (×),Index high (×),Markup pays for
+HDPE shred → finished kit,40.00,40.00,344.05,8.6,8.6,"Shredding, sheet pressing, CNC cutting, finishing, Defy margin. BIGGEST LEVERAGE in the model."
+Half-sheet (1200×1200×19mm),52.55,52.55,200.00,3.8,3.8,"Hot-press machine time, energy, Defy margin"
+Cut+finish only,30.00,60.00,121.00,2.0,4.0,CNC operator + machine time + Defy margin
+Assembly labour (Defy),52.00,52.00,55.95,1.1,1.1,Already efficient — small Defy margin
+Steel (frame + caps),10.00,15.00,27.00,1.8,2.7,"Cut to length, drill, deliver"
+Canvas,45.00,68.00,93.50,1.4,2.1,"Cut, hem, grommet, RW Pacific margin"
+End caps / fittings,0.50,1.00,3.20,3.2,6.4,Bulk-buy supplier margin
+Pallet + packing,30.00,50.00,60.00,1.2,2.0,Labour + packing materials

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/03-volume-scenarios.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/03-volume-scenarios.csv
@@ -1,0 +1,4 @@
+Scenario,Beds/yr,Production founder ($/bed),Admin ($/bed),Field travel ($/bed),Freight ($/bed),State 1 fully-loaded ($),State 4 fully-loaded ($),State 5 fully-loaded ($)
+Today (100 beds/yr),100,300,147,510,150,1707,1417,1427
+Target (500 beds/yr),500,60,29,100,100,889,599,609
+"Vision (1,000 beds/yr, in-house assembly)",1000,30,15,50,80,775,485,495

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/04-founder-allocation.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/04-founder-allocation.csv
@@ -1,0 +1,6 @@
+Activity,Days/yr,Rate ($/day),Annual cost ($),Allocate to,Per-bed @ 100/yr ($),Per-bed @ 500/yr ($),Per-bed @ 1000/yr ($)
+"Production-related (oversight, QA, design iteration, supplier rel.)",30,1000,30000,bed-overhead,300.00,60.00,30.00
+"Fundraising / philanthropy (briefs, asks, reporting, donor rel.)",50,1000,50000,funding-side-offset,—,—,—
+"Commercialisation / buyer dev (Centrecorp, councils, sales)",25,1000,25000,funding-side-offset,—,—,—
+"Governance, strategy, comms, brand",45,1000,45000,act-wide-overhead,—,—,—
+TOTAL,150,1000,150000,,,,

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/05-fundraising-offset.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/05-fundraising-offset.csv
@@ -1,0 +1,8 @@
+Metric,Value,Note
+Philanthropy founder-days/yr,50,Days founder spends raising philanthropic funds
+$ raised per philanthropy day,5000,Mid-stage social-enterprise benchmark
+Annual philanthropy raised,250000,50 × $5K = $250K
+Commercial founder-days/yr,25,Days on buyer development
+Commercial buyer benchmark,$801/bed,"Centrecorp INV-0291 (107 beds @ $85,712)"
+Per-bed subsidy @ 100/yr,$2500,$250K / 100 beds
+Per-bed subsidy @ 500/yr,$500,$250K / 500 beds

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/06-wage-scenarios.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/06-wage-scenarios.csv
@@ -1,0 +1,5 @@
+Pay scenario,$/hr,$/8hr day,$/day inc super,Beds/day,$/bed labour
+Award C13 (entry fabricator),26,208,233,6,38.83
+Award C10 (mid-skilled),32,256,287,6,47.83
+Fair-market skilled trade,45,360,403,6,67.17
+Indigenous community wage + cultural loading,35,280,314,6,52.33

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/07-community-plastic.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/07-community-plastic.csv
@@ -1,0 +1,5 @@
+Pay tier,$/kg,kg/bed,$/bed,Annual community pay @ 100 beds,Annual community pay @ 500 beds
+Bottom (kerbside-equivalent),0.2,40,8.00,800,4000
+Mid (community-coop rate),0.5,40,20.00,2000,10000
+Premium (ocean/remote story-value),1,40,40.00,4000,20000
+"High (clean sorted, remote community)",2,40,80.00,8000,40000

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/08-defy-verified-rates.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/08-defy-verified-rates.csv
@@ -1,0 +1,12 @@
+Item,Rate ($),Source,Confidence
+single_bed_fully_fabricated,600,"INV-1507 Nov 2025, 25 beds",verified
+bed_kit_cut_finished,344.05,INV-1602 (92 kits) + 2026-03-27 (50 kits),verified
+cut_and_finish_only,121,"INV-1602 (16 beds, pre-purchased sheets)",verified
+assembly_labour,55.95,"2026-03-19 (8 beds, exact line)",verified
+half_sheet_bulk_price,200,2026-03-27 (20 sheets bulk discount),verified
+hdpe_shred_per_kg,2,2026-03-27 (1200kg bulk bags),verified
+worker_day_rate_full,480,"INV-1325/1326 (Sam, Todd)",verified
+worker_day_rate_half,240,INV-1325/1326,verified
+freight_botany_to_alice_per_pallet_low,808,Multiple Defy freight lines,verified
+freight_botany_to_alice_per_pallet_high,1480,Multiple Defy freight lines,verified
+beds_per_pallet_typical,8,,

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/09-mistags-to-fix.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/09-mistags-to-fix.csv
@@ -1,0 +1,9 @@
+Supplier / line,Amount ($),Current tag,Correct tag
+Defy Washing Machine Cladding (multiple bills),25000,ACT-GD,ACT-FM
+Defy Coasters (INV-1174 + INV-1637),10000,ACT-GD,ACT-EL (marketing/merch)
+Defy Design/R&D (INV-1258 design + INV-1259 prototype),7000,ACT-GD bed-COGS,ACT-GD capital/R&D
+Carbatec Brisbane,8726,ACT-GD,ACT-HV
+Utopia trip flights/accommodation,24507,ACT-IN,ACT-GD
+1300 Washer,13980,ACT-GD,ACT-FM
+Carla Furnishers duplicate,11180,ACT-GD,VOID DUPLICATE
+R M Tanner Triple Axle,19950,ACT-GD labour 486,ACT-GD capital

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/10-open-questions-for-defy.csv
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/10-open-questions-for-defy.csv
@@ -1,0 +1,5 @@
+#,Question
+1,"Volume-quote sheet at 100 / 500 / 1,000 / 5,000 beds/yr — what does $600/bed Single Bed become?"
+2,Build-to-supply: cheaper if ACT sources steel (Steelmart) + canvas (RW Pacific) direct and supplies to Defy?
+3,At what volume does in-house assembly pay back the $90-200K capex? (i.e. is State 2 or State 4 the right transition point?)
+4,Half-sheets per bed: how many does the standard bed actually use? (Model assumes 1.5 — Ben to confirm.)

--- a/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/README.md
+++ b/thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/README.md
@@ -1,0 +1,41 @@
+# Goods bed cost model v3 — Sheets-ready CSV bundle
+
+Exported 2026-05-28 from `thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json`.
+
+## How to import into Google Sheets
+
+1. Create a new Google Sheet (or open an existing one for this model).
+2. For each CSV in this folder, **File → Import → Upload → `<csv-file>` → Insert new sheet(s)**.
+3. Rename each new tab to match the file (e.g. `01 build states`, `02 idiot index`).
+4. Done — the workbook now mirrors the v3 model and you can edit any cell.
+
+## To push changes back to the model
+
+If you change a number in Sheets and want it to drive the live cost-model
+page in CivicScope, edit the JSON at `thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json`
+to match, then commit. The grantscope service `apps/web/src/lib/data/goods-bed-cost-model.json`
+is a mirror — keep them in sync (or have a script reconcile them).
+
+## What's in each tab
+
+| File | Purpose |
+|---|---|
+| `01-build-states.csv` | The 5 build-state scenarios (Defy-everything → all in-house) with per-component cost lines and cumulative capex. |
+| `02-idiot-index.csv` | Markup-ratio table — where Defy's pricing leaves room for in-house cost reduction. |
+| `03-volume-scenarios.csv` | Fully-loaded per-bed cost at 100/500/1000 beds/yr for each build state. |
+| `04-founder-allocation.csv` | Founder time split: production (onto beds) vs fundraising (offset) vs ACT-wide. |
+| `05-fundraising-offset.csv` | How dollars raised per founder-day subsidise bed cost. |
+| `06-wage-scenarios.csv` | 4 wage tiers × 6 beds/day → $/bed labour. |
+| `07-community-plastic.csv` | 4 pay-rate tiers for community-collected HDPE. |
+| `08-defy-verified-rates.csv` | Every OCR-verified Defy invoice rate (the load-bearing data). |
+| `09-mistags-to-fix.csv` | ~$120K of ACT-GD spend that's actually for other projects. |
+| `10-open-questions-for-defy.csv` | What we still need from Defy to lock the model. |
+
+## Verified data lineage
+
+All rates in tab 08 come from `scripts/ocr-defy-bills.mjs` (Gemini 2.5 Flash Lite
+OCR of every Defy invoice attachment in Xero), output in
+`thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json`. Re-run that script
+when Defy issues new invoices to refresh the verified-rate set.
+
+Plan: `goods-cost-evidence-funder-artifact`.


### PR DESCRIPTION
Companion to grantscope PR #46 (merged). Adds the analysis docs, OCR script, Sheets export, and v3 cost-model config that drive the funder-grade view.

## What's in this PR

- `scripts/ocr-defy-bills.mjs` — OCRs every Defy invoice attachment via Gemini 2.5 Flash Lite + structured-output, dumps line items + bed counts to `thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json`. Re-runnable when Defy issues new invoices.
- `scripts/export-bed-cost-model-to-sheets.mjs` — generates a 10-CSV bundle from the v3 JSON config, ready to import as a multi-tab Google Sheet.
- `thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json` — raw OCR output (35 Defy bills, every line item).
- `thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json` — the v3 model config (mirrored into `grantscope/apps/web/src/lib/data/goods-bed-cost-model.json` via PR #46).
- `thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md` — element-by-element Idiot Index analysis + 5 build-state scenarios.
- `thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-CORRECTED.md` — corrected unit-economics with verified Defy rates.
- `thoughts/shared/analysis/2026-05-28-goods-bed-unit-economics-from-defy-invoices.md` — earlier draft, **marked SUPERSEDED** with banner explaining the flawed methodology (kept for the record).
- `thoughts/shared/analysis/exports/2026-05-28-bed-cost-model-v3/` — the 10 CSVs + README for the Google Sheets import.

## The story

The Xero JSON sync had stripped Defy line descriptions to "." and rolled multi-line invoices into a single line. INV-1602 appeared as "$33,589 for 16 beds = $2,099/bed" when the actual PDF shows two lines: 16 cut+finish @ $121/bed + 92 bed kits @ $344.05/bed.

OCR'd all 35 Defy invoice PDFs → the **Notion BOM is verified correct line-by-line**:
- HDPE kit cut+finished: $344.05 (matches Notion BOM exactly)
- Assembly labour: $55.95 (matches Notion BOM exactly)
- Single Bed fully fabricated: $600 (INV-1507, 25 beds verified)
- HDPE shred: $2.00/kg (1200kg bulk verified)

Ben's 12 questions answered with verified data + Idiot Index analysis (HDPE shred → finished kit: **8.6× markup** = biggest cost-reduction opportunity).

Founder time properly allocated: only 30 days/yr (production-related) goes onto beds; the other 120 days (fundraising/commercial/governance) offsets bed cost via dollars raised. Fixes the earlier nonsensical "$1,500/bed founder time" line.

## Open work (not in this PR)

- Retag ~$120K of mistagged spend in Xero (Carbatec → ACT-HV, Utopia flights → ACT-GD, 1300 Washer → ACT-FM, Carla duplicate void, R M Tanner labour→capital, plus the new Defy washing-machine + coaster mistags).
- Ask Defy the 4 open questions (volume quote, build-to-supply, in-house payback, sheets/bed confirmation).
- Build an interactive cost-model page in CivicScope (foundation laid in grantscope `lib/services/goods-bed-cost-model.ts`).

Plan: `goods-cost-evidence-funder-artifact`
