### PR TITLE
feat(finance): Phase 3 — invoice sync derives project_code FROM Xero Project Tracking

### DIFF
--- a/scripts/sync-xero-to-supabase.mjs
+++ b/scripts/sync-xero-to-supabase.mjs
@@ -494,6 +494,39 @@ function detectProjectFromTracking(trackingCategories) {
 }
 
 /**
+ * Phase 3 (2026-05-30): Xero `Project Tracking` is the topmost source of truth.
+ * Returns the ACT-XX code ONLY when a line item carries a `Project Tracking`
+ * (or legacy `Project`) tag that resolves to a known code. Returns null
+ * otherwise — the caller must then PRESERVE the existing mirror `project_code`
+ * (hybrid rule: Xero-where-present, else keep existing). Deliberately excludes
+ * Business Divisions and text/contact heuristics: those are the drift-prone
+ * guesses Phase 3 moves away from. ~71% of income is in locked periods and
+ * cannot carry a Xero tag, so a hard flip would erase historical classification.
+ */
+function detectProjectFromXeroTracking(trackingCategories) {
+  if (!trackingCategories?.length) return null;
+  for (const tracking of trackingCategories) {
+    const catName = tracking.Name || '';
+    if (catName !== 'Project Tracking' && catName !== 'Project') continue;
+    const trackingValue = (tracking.Option || '').trim();
+    if (!trackingValue) continue;
+    // Direct ACT-XX prefix, e.g. "ACT-GD — Goods"
+    if (trackingValue.startsWith('ACT-')) {
+      const code = trackingValue.split(/\s*[—–-]\s*/)[0].trim();
+      if (PROJECT_CODES.projects?.[code]) return code;
+    }
+    // Resolve via xero_tracking field / aliases
+    const trackingLower = trackingValue.toLowerCase();
+    for (const [code, proj] of Object.entries(PROJECT_CODES.projects || {})) {
+      if ((proj.xero_tracking || '').toLowerCase() === trackingLower) return code;
+      const aliases = (proj.xero_tracking_aliases || []).map(a => a.toLowerCase());
+      if (aliases.includes(trackingLower)) return code;
+    }
+  }
+  return null;
+}
+
+/**
  * Detect project code from reference or description text
  */
 function detectProjectFromText(text) {
@@ -610,9 +643,28 @@ async function syncInvoices(options = {}) {
 
   for (const invoice of allInvoices) {
     try {
-      // Detect project code
+      // Detect project code (broad heuristic — kept for the match-rate stat only)
       const projectCode = detectProjectCode(invoice);
       if (projectCode) stats.invoices.matched_projects++;
+
+      // Phase 3: derive project_code FROM the authoritative Xero `Project Tracking`
+      // tag (hybrid — Xero-where-present, else preserve the mirror's existing code).
+      const allInvoiceTracking = invoice.LineItems?.flatMap(l => l.Tracking || []) || [];
+      const xeroTrackingCode = detectProjectFromXeroTracking(allInvoiceTracking);
+      // MANUAL-TAG GUARD: never overwrite a user's manual retag from our UI.
+      let preserveManualTag = false;
+      if (supabase && xeroTrackingCode && invoice.InvoiceID) {
+        try {
+          const { data: existingRow } = await supabase
+            .from('xero_invoices')
+            .select('project_code_source')
+            .eq('xero_id', invoice.InvoiceID)
+            .maybeSingle();
+          if (existingRow?.project_code_source && String(existingRow.project_code_source).startsWith('manual')) {
+            preserveManualTag = true;
+          }
+        } catch (_e) { /* best-effort; fall through */ }
+      }
 
       // Match contact to GHL
       const contactId = await matchContactToGHL(
@@ -643,6 +695,10 @@ async function syncInvoices(options = {}) {
         contact_xero_id: invoice.Contact?.ContactID,
         status: invoice.Status,
         type: invoice.Type, // ACCREC or ACCPAY
+        // Phase 3: write project_code ONLY when Xero carries a Project Tracking tag
+        // and the row isn't manually tagged. Otherwise omit it so the upsert
+        // preserves the mirror's existing project_code (taggers/manual/historical).
+        ...(xeroTrackingCode && !preserveManualTag ? { project_code: xeroTrackingCode, project_code_source: 'xero_tracking' } : {}),
         total: parseFloat(invoice.Total) || 0,
         subtotal: parseFloat(invoice.SubTotal) || 0,
         total_tax: parseFloat(invoice.TotalTax) || 0,

--- a/thoughts/shared/plans/2026-05-30-xero-source-of-truth-goods-ledger.md
+++ b/thoughts/shared/plans/2026-05-30-xero-source-of-truth-goods-ledger.md
@@ -110,7 +110,7 @@ Probe: `scripts/probe-goods-funder-truth.mjs` (read-only, DB `tednluwflfhxyucgwi
 - **Still TODO:** Locked 54 invoices · $1.08M → **Standard Ledger handoff doc** (Tier 1, not yet generated).
 - Mirror lags Xero until next sync (expected); Phase 3 derivation will pick up the new tags.
 
-### Phase 3 — Flip the mirror derivation · Tier 1–2 code
+### Phase 3 — Flip the mirror derivation · Tier 1–2 code — **DONE 2026-05-30**
 - `scripts/sync-xero-to-supabase.mjs`: derive `project_code` **from**
   `line_items[].tracking[]` where `Name === 'Project Tracking'` (parse `ACT-XX` prefix).
   **Xero-where-present, else keep existing `project_code`** — NOT a hard flip. This is
@@ -118,7 +118,29 @@ Probe: `scripts/probe-goods-funder-truth.mjs` (read-only, DB `tednluwflfhxyucgwi
   drop Goods from $649K to the ~15 tagged invoices. Xero is authoritative when set;
   Supabase `project_code` fills the locked/historical gap.
 - Keep the **manual-source guard** (never overwrite `project_code_source LIKE 'manual%'`).
-- **Verify:** re-sync → Goods ledger unchanged at $649,711 (no regression).
+- **✅ Implemented:** new helper `detectProjectFromXeroTracking()` (authoritative `Project
+  Tracking`/`Project` category ONLY — excludes Business Divisions + text/contact heuristics).
+  **KEY GAP FOUND:** the invoice write block *never wrote `project_code` at all* (line 614
+  computed it as a stat counter only, threw it away) — the invoice mirror's `project_code`
+  was maintained entirely by the standalone taggers, never by the sync. The bank-txn block
+  *did* write it (line 816). Added the same conditional-spread + DB manual-guard to the
+  invoice `record`. Derivation runs only when a live Xero tag exists; otherwise the upsert
+  omits `project_code` so PostgREST preserves the existing value.
+- **✅ Verify (re-synced `invoices --days=250`, 1248 invoices, 0 errors):**
+  - Goods ACCREC `ACT-GD` = **19 invoices · $650,910.79**. The +$1,200 vs the documented
+    $649,711 is **INV-0327 (John Villiers, PAID)** — live Xero `Project Tracking="ACT-GD —
+    Goods"` on all 4 lines (flights/accom/program mgmt) but the old heuristics had misfiled
+    it `ACT-CORE`. Xero asserting authority = correct, not a regression. Verified live
+    pre-write (`get Invoices?InvoiceNumbers=…`).
+  - INV-0298 Dusseldorp confirmed `ACT-JH` live (dry-run's "→ACT-MY" was **stale-mirror
+    line_items** noise; the mirror lagged Xero). No JH→MY drift.
+  - **583 invoices** (all types) now source=`xero_tracking` (was 0 for invoices). Manual
+    sources (`manual_retag_2026-05-12` ×4, `manual` ×1) preserved.
+  - **Window note:** `--days=N` filters by invoice **Date**, so it (a) catches all unlocked
+    tagged invoices (earliest Goods tag = INV-0282 `2025-10-21`) and (b) **excludes VOIDED**
+    invoices — which is why the dry-run's voided "flips" (INV-0324/0317/0296/0297) never
+    materialized. Incremental (`modifiedSince`) would be needed to relabel retro-modified
+    invoices dated before the window, but the cron's next incremental pass handles those.
 
 ### Phase 4 — Goods funder ledger as a derived view · Tier 1 (+ Tier 3 if DB view migration)
 - Build `v_goods_funder_ledger` (or script-materialised): ACCREC where derived


### PR DESCRIPTION
## Phase 3 — make the Supabase mirror derive project classification FROM Xero

Part of the **Xero-as-source-of-truth** plan (`thoughts/shared/plans/2026-05-30-xero-source-of-truth-goods-ledger.md`). Phases 1–2 shipped in #127/#128.

### The gap this closes
The invoice sync **never wrote `project_code`** — line 614 computed it as a stat counter and discarded it. The invoice mirror's classification was maintained entirely by the standalone taggers, never by the sync. (The bank-transaction block at line 816 *did* write it; invoices were the orphan.) That's why "Xero is the source" never stuck for income.

### Change
- New `detectProjectFromXeroTracking()` — reads the authoritative `Project Tracking` / `Project` category **only** (excludes Business Divisions + text/contact heuristics, which are the drift-prone guesses).
- **Hybrid write** in the invoice `record`: set `project_code` FROM the Xero tag where present; otherwise omit it so the PostgREST upsert **preserves** the existing value. 71% of income is in locked periods and can't carry a Xero tag — a hard flip would erase historical classification.
- **Manual-source guard**: never overwrite `project_code_source LIKE 'manual%'` (DB-checked per invoice, matching the bank-txn block's pattern).

### Verification (re-sync `invoices --days=250`, 1248 invoices, 0 errors)
- Goods ACCREC `ACT-GD` = **19 invoices / $650,910.79**. The +$1,200 vs the prior $649,711 is **INV-0327 (John Villiers, PAID)** — live Xero tags it `ACT-GD — Goods` on all 4 lines (flights/accom/program mgmt), but the old heuristics had misfiled it `ACT-CORE`. Verified against live Xero pre-write. Xero asserting authority = correct, not a regression.
- **583 invoices** (all types) now `project_code_source = xero_tracking` (was 0 for invoices); manual tags preserved; voided rows untouched.
- INV-0298 Dusseldorp confirmed `ACT-JH` live (a dry-run "→ACT-MY" was stale-mirror line_items noise — the mirror lagged Xero).

### Notes
- `--days=N` filters by invoice **Date**, so it excludes VOIDED invoices (the dry-run's voided "flips" never materialized) but misses retro-modified invoices dated before the window; the cron's next incremental pass relabels those.
- Scripts-only change — no `apps/` touched, so Vercel preview is not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)