### PR TITLE
feat(finance): pre-SL cleanup — voided-receivable guard, 100% FY26 tagging, Project Money page

### DIFF
--- a/apps/command-center/src/app/api/finance/lifetime-ledger/route.ts
+++ b/apps/command-center/src/app/api/finance/lifetime-ledger/route.ts
@@ -41,6 +41,7 @@ export async function GET() {
     .from('xero_invoices')
     .select('contact_name, status, type, total, amount_due, date')
     .eq('type', 'ACCREC')
+    .not('status', 'in', '(DELETED,VOIDED)')
     .not('contact_name', 'is', null)
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 })

--- a/apps/command-center/src/app/api/finance/project-money/route.ts
+++ b/apps/command-center/src/app/api/finance/project-money/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+// Project Money — live per-project income / expense / net + tagging coverage,
+// derived straight from the Xero mirror (xero_invoices ACCREC+ACCPAY, xero_transactions
+// SPEND). Reads live so it reflects tagging immediately (unlike project_monthly_financials).
+// Income = ACCREC invoiced total (received = amount_paid). Expense = ACCPAY bills + SPEND.
+// FY26 = from 2025-07-01. Voided/deleted excluded.
+
+const FY_START = '2025-07-01'
+const VOID = '(VOIDED,DELETED)'
+const PAGE = 1000
+
+const num = (v: unknown) => Math.abs(Number(v) || 0)
+const tag = (c: unknown) => (c && String(c).trim() ? String(c).trim() : null)
+
+async function pageAll<T>(build: (from: number, to: number) => any): Promise<T[]> {
+  let out: T[] = []
+  let from = 0
+  for (;;) {
+    const { data, error } = await build(from, from + PAGE - 1)
+    if (error) throw error
+    out = out.concat(data || [])
+    if (!data || data.length < PAGE) break
+    from += PAGE
+  }
+  return out
+}
+
+interface Bucket {
+  income: number; received: number; billsOutstanding: number; spendExpense: number
+}
+const empty = (): Bucket => ({ income: 0, received: 0, billsOutstanding: 0, spendExpense: 0 })
+
+export async function GET() {
+  try {
+    const [income, bills, spend, projects] = await Promise.all([
+      pageAll<any>((f, t) => supabase.from('xero_invoices')
+        .select('project_code, project_code_source, total, amount_paid, status')
+        .eq('type', 'ACCREC').not('status', 'in', VOID).gte('date', FY_START).range(f, t)),
+      pageAll<any>((f, t) => supabase.from('xero_invoices')
+        .select('project_code, project_code_source, total, amount_due, status')
+        .eq('type', 'ACCPAY').not('status', 'in', VOID).gte('date', FY_START).range(f, t)),
+      pageAll<any>((f, t) => supabase.from('xero_transactions')
+        .select('project_code, project_code_source, total')
+        .in('type', ['SPEND', 'SPEND-OVERPAYMENT']).gte('date', FY_START).range(f, t)),
+      supabase.from('projects').select('code, name, tier, status').limit(500).then(r => r.data || []),
+    ])
+
+    const nameOf = new Map<string, { name: string; tier: string | null; status: string | null }>()
+    for (const p of projects) nameOf.set(p.code, { name: p.name, tier: p.tier, status: p.status })
+
+    const buckets = new Map<string, Bucket>()
+    const bucket = (code: string) => {
+      let b = buckets.get(code); if (!b) { b = empty(); buckets.set(code, b) } return b
+    }
+    // Coverage accumulators
+    const cov = {
+      income: { tagged: { n: 0, $: 0 }, untagged: { n: 0, $: 0 } },
+      expense: { tagged: { n: 0, $: 0 }, untagged: { n: 0, $: 0 } },
+    }
+    const addCov = (kind: 'income' | 'expense', code: string | null, amt: number) => {
+      const k = code ? 'tagged' : 'untagged'; cov[kind][k].n++; cov[kind][k].$ += amt
+    }
+
+    const UNTAGGED = '— untagged —'
+    for (const r of income) {
+      const code = tag(r.project_code); const amt = num(r.total)
+      addCov('income', code, amt)
+      const b = bucket(code || UNTAGGED); b.income += amt; b.received += num(r.amount_paid)
+    }
+    for (const r of bills) {
+      const code = tag(r.project_code); const amt = num(r.total)
+      // Coverage counts the bill record (every expense should be tagged); but for the
+      // money total we only add the UNPAID portion (amount_due) — the paid portion
+      // already shows up as a SPEND bank transaction, so adding the full bill double-counts.
+      addCov('expense', code, amt)
+      bucket(code || UNTAGGED).billsOutstanding += (r.status === 'AUTHORISED' ? num(r.amount_due) : 0)
+    }
+    for (const r of spend) {
+      const code = tag(r.project_code); const amt = num(r.total)
+      addCov('expense', code, amt)
+      bucket(code || UNTAGGED).spendExpense += amt
+    }
+
+    const rows = [...buckets.entries()].map(([code, b]) => {
+      // Cash-out (SPEND) + unpaid bill commitments (amount_due). Matches the cash basis
+      // of project_monthly_financials without double-counting paid bills.
+      const expense = b.spendExpense + b.billsOutstanding
+      const meta = nameOf.get(code)
+      return {
+        code,
+        name: code === UNTAGGED ? 'Untagged' : (meta?.name || code),
+        tier: meta?.tier || null,
+        status: meta?.status || null,
+        income: b.income,
+        received: b.received,
+        billsOutstanding: b.billsOutstanding,
+        spendExpense: b.spendExpense,
+        expense,
+        net: b.income - expense,
+        untagged: code === UNTAGGED,
+      }
+    }).sort((a, b) => {
+      if (a.untagged) return 1
+      if (b.untagged) return -1
+      return (b.income + b.expense) - (a.income + a.expense)
+    })
+
+    const totals = rows.reduce((acc, r) => ({
+      income: acc.income + r.income,
+      received: acc.received + r.received,
+      expense: acc.expense + r.expense,
+      net: acc.net + r.net,
+    }), { income: 0, received: 0, expense: 0, net: 0 })
+
+    const pct = (t: { n: number }, u: { n: number }) => {
+      const d = t.n + u.n; return d ? Math.round((t.n / d) * 100) : 100
+    }
+
+    return NextResponse.json({
+      fyStart: FY_START,
+      rows,
+      totals,
+      coverage: {
+        income: { ...cov.income, pct: pct(cov.income.tagged, cov.income.untagged) },
+        expense: { ...cov.expense, pct: pct(cov.expense.tagged, cov.expense.untagged) },
+      },
+    })
+  } catch (error: any) {
+    console.error('GET /api/finance/project-money error:', error.message)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/finance/project-money/page.tsx
+++ b/apps/command-center/src/app/finance/project-money/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { ArrowLeft, CheckCircle2, AlertTriangle, ArrowDownRight, ArrowUpRight, Wallet } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface Row {
+  code: string; name: string; tier: string | null; status: string | null
+  income: number; received: number; billsOutstanding: number; spendExpense: number
+  expense: number; net: number; untagged: boolean
+}
+interface CovSide { tagged: { n: number; $: number }; untagged: { n: number; $: number }; pct: number }
+interface Resp {
+  fyStart: string
+  rows: Row[]
+  totals: { income: number; received: number; expense: number; net: number }
+  coverage: { income: CovSide; expense: CovSide }
+}
+
+function fmt(n: number | null | undefined) {
+  if (n == null) return '—'
+  const a = Math.abs(n)
+  const s = a >= 1_000_000 ? `$${(a / 1_000_000).toFixed(2)}M` : a >= 1000 ? `$${Math.round(a).toLocaleString()}` : `$${Math.round(a)}`
+  return n < 0 ? `-${s}` : s
+}
+
+function CoverageCard({ label, side, href }: { label: string; side: CovSide; href: string }) {
+  const done = side.untagged.n === 0
+  return (
+    <div className={cn('rounded-xl border p-4', done ? 'border-emerald-500/30 bg-emerald-500/10' : 'border-amber-500/30 bg-amber-500/10')}>
+      <div className="flex items-center gap-2 text-sm font-medium text-foreground/80">
+        {done ? <CheckCircle2 className="h-4 w-4 text-emerald-400" /> : <AlertTriangle className="h-4 w-4 text-amber-400" />}
+        {label} tagging
+      </div>
+      <div className="mt-1 text-2xl font-bold">{side.pct}%</div>
+      <div className="mt-1 text-xs text-muted-foreground">
+        {done ? 'All tagged' : (
+          <Link href={href} className="hover:underline">
+            {side.untagged.n} untagged · {fmt(side.untagged.$)} →
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default function ProjectMoneyPage() {
+  const [hideEmpty, setHideEmpty] = useState(true)
+  const { data, isLoading, error } = useQuery<Resp>({
+    queryKey: ['project-money'],
+    queryFn: async () => {
+      const r = await fetch('/api/finance/project-money')
+      if (!r.ok) throw new Error((await r.json()).error || 'Failed')
+      return r.json()
+    },
+  })
+
+  const rows = (data?.rows || []).filter(r => !hideEmpty || r.income !== 0 || r.expense !== 0)
+
+  return (
+    <div className="mx-auto max-w-6xl p-6">
+      <Link href="/finance" className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+        <ArrowLeft className="h-4 w-4" /> Finance
+      </Link>
+
+      <div className="mb-1 flex items-center gap-2">
+        <Wallet className="h-6 w-6 text-emerald-400" />
+        <h1 className="text-2xl font-bold">Project Money</h1>
+      </div>
+      <p className="mb-6 text-sm text-muted-foreground">
+        Live income, expense &amp; net per project — straight from the Xero mirror. FY26 (from {data?.fyStart}), excl. voided. Income = invoiced ACCREC; expense = bank/card spend + unpaid bills (cash basis, no double-count).
+      </p>
+
+      {isLoading && <div className="text-muted-foreground">Loading…</div>}
+      {error && <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-red-300">{(error as Error).message}</div>}
+
+      {data && (
+        <>
+          {/* Coverage + totals */}
+          <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <CoverageCard label="Income" side={data.coverage.income} href="/finance/invoices" />
+            <CoverageCard label="Expense" side={data.coverage.expense} href="/finance/transactions" />
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground/80"><ArrowUpRight className="h-4 w-4 text-emerald-400" /> Income</div>
+              <div className="mt-1 text-2xl font-bold text-emerald-400">{fmt(data.totals.income)}</div>
+              <div className="mt-1 text-xs text-muted-foreground">{fmt(data.totals.received)} received</div>
+            </div>
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground/80"><ArrowDownRight className="h-4 w-4 text-red-400" /> Expense</div>
+              <div className="mt-1 text-2xl font-bold text-red-400">{fmt(data.totals.expense)}</div>
+              <div className={cn('mt-1 text-xs', data.totals.net >= 0 ? 'text-emerald-400' : 'text-red-400')}>net {fmt(data.totals.net)}</div>
+            </div>
+          </div>
+
+          <div className="mb-2 flex justify-end">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+              <input type="checkbox" checked={hideEmpty} onChange={e => setHideEmpty(e.target.checked)} />
+              Hide projects with no money
+            </label>
+          </div>
+
+          {/* Per-project table */}
+          <div className="overflow-x-auto rounded-xl border border-border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/40 text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2 text-left">Project</th>
+                  <th className="px-3 py-2 text-right">Income</th>
+                  <th className="px-3 py-2 text-right">Received</th>
+                  <th className="px-3 py-2 text-right">Expense</th>
+                  <th className="px-3 py-2 text-right">Net</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map(r => (
+                  <tr key={r.code} className={cn('border-t border-border/60', r.untagged && 'bg-amber-500/5')}>
+                    <td className="px-3 py-2">
+                      {r.untagged ? (
+                        <span className="inline-flex items-center gap-1 text-amber-400"><AlertTriangle className="h-3.5 w-3.5" /> Untagged</span>
+                      ) : (
+                        <Link href={`/finance/projects/${r.code}`} className="hover:underline">
+                          <span className="font-mono text-xs text-muted-foreground">{r.code}</span> {r.name}
+                        </Link>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-right tabular-nums text-emerald-400/90">{r.income ? fmt(r.income) : '—'}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{r.received ? fmt(r.received) : '—'}</td>
+                    <td className="px-3 py-2 text-right tabular-nums text-red-400/90">{r.expense ? fmt(r.expense) : '—'}</td>
+                    <td className={cn('px-3 py-2 text-right font-medium tabular-nums', r.net >= 0 ? 'text-emerald-400' : 'text-red-400')}>{fmt(r.net)}</td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot className="border-t-2 border-border bg-muted/30 font-semibold">
+                <tr>
+                  <td className="px-3 py-2">Total ({rows.filter(r => !r.untagged).length} projects)</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-emerald-400">{fmt(data.totals.income)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">{fmt(data.totals.received)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-red-400">{fmt(data.totals.expense)}</td>
+                  <td className={cn('px-3 py-2 text-right tabular-nums', data.totals.net >= 0 ? 'text-emerald-400' : 'text-red-400')}>{fmt(data.totals.net)}</td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/command-center/src/lib/nav-data.ts
+++ b/apps/command-center/src/lib/nav-data.ts
@@ -126,6 +126,7 @@ export const navStructure: SidebarNavGroup[] = [
           // STATE — where are we right now (trust meters + money state)
           { href: '#state', label: 'State', icon: BarChart3, divider: true },
           { href: '/finance/overview', label: 'State · Cockpit', icon: Layers, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
+          { href: '/finance/project-money', label: 'State · Project Money', icon: DollarSign, color: 'text-emerald-400', bg: 'bg-emerald-500/20' },
           { href: '/finance/close', label: 'State · Close pack', icon: ClipboardCheck, color: 'text-cyan-400', bg: 'bg-cyan-500/20' },
 
           // OPERATE — get to 100% (full toolset lives in the Operate tab-bar)

--- a/scripts/apply-expense-tags.mjs
+++ b/scripts/apply-expense-tags.mjs
@@ -1,0 +1,54 @@
+// Apply approved expense tags to the Supabase mirror.
+// Set: 106 HIGH items. Override: ACT-IN items at Alice Springs / Darwin → ACT-GD.
+// Hold: 35 REVIEW items (skipped). Source: manual-bulk-2026-05-30 (manual-guard protected).
+// Dry-run by default; pass --apply to write.
+import '../lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+
+const APPLY = process.argv.includes('--apply');
+const SOURCE = 'manual-bulk-2026-05-30';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const items = JSON.parse(readFileSync('scripts/output/untagged-expense-proposal.json', 'utf8'));
+
+// On-country reassign rule (Ben's call: ASP/DRW travel is Goods, not infra).
+const isOnCountry = (it) => /\bASP\b|\bDRW\b|\bMNG\b|alice springs|darwin/i.test(`${it.contact} ${it.desc}`);
+
+const toApply = [];
+for (const it of items) {
+  if (it.conf !== 'HIGH') continue;            // HOLD REVIEW items
+  let code = it.suggest;
+  let note = '';
+  // Ben's call: Alice Springs / Darwin on-country spend is Goods, regardless of the
+  // vendor-rule default (flights default to ACT-IN; the "Flight Bar Witta" contact
+  // mis-maps Alice Springs card spend to ACT-HV). Reassign all such items → ACT-GD.
+  if (isOnCountry(it) && code !== 'ACT-GD') { note = ` (reassigned ${code}→GD)`; code = 'ACT-GD'; }
+  toApply.push({ ...it, finalCode: code, note });
+}
+
+// Summary
+const by = {};
+for (const it of toApply) { by[it.finalCode] = by[it.finalCode] || { n: 0, $: 0 }; by[it.finalCode].n++; by[it.finalCode].$ += it.amount; }
+console.log(`${APPLY ? 'APPLYING' : 'DRY-RUN'} — ${toApply.length} items, source=${SOURCE}\n`);
+console.log('Final project split:');
+for (const [k, v] of Object.entries(by).sort((a, b) => b[1].$ - a[1].$)) console.log(`  ${k.padEnd(8)} ${String(v.n).padStart(3)}  $${Math.round(v.$).toLocaleString()}`);
+const reassigned = toApply.filter(it => it.note);
+console.log(`\nReassigned IN→GD (${reassigned.length}):`);
+for (const it of reassigned) console.log(`  ${it.date} ${(it.contact || '').slice(0, 26).padEnd(26)} ${(it.desc || '').slice(0, 30)}  $${Math.round(it.amount)}`);
+
+if (!APPLY) { console.log('\n(dry-run — pass --apply to write)'); process.exit(0); }
+
+// Apply grouped by (table, finalCode)
+const groups = {};
+for (const it of toApply) { const key = `${it.table}|${it.finalCode}`; (groups[key] = groups[key] || []).push(it.id); }
+let updated = 0;
+for (const [key, ids] of Object.entries(groups)) {
+  const [table, code] = key.split('|');
+  const { data, error } = await sb.from(table)
+    .update({ project_code: code, project_code_source: SOURCE })
+    .in('id', ids).select('id');
+  if (error) { console.error(`  ERROR ${table}/${code}: ${error.message}`); continue; }
+  updated += (data || []).length;
+  console.log(`  ${table} → ${code}: ${(data || []).length}/${ids.length}`);
+}
+console.log(`\nApplied ${updated}/${toApply.length}.`);

--- a/scripts/apply-incidental-tags.mjs
+++ b/scripts/apply-incidental-tags.mjs
@@ -1,0 +1,47 @@
+// Tag the 35 held REVIEW incidentals by location/type signal; default ACT-CORE.
+// Dry-run by default; --apply writes to the mirror. Source manual-bulk-2026-05-30.
+import '../lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+
+const APPLY = process.argv.includes('--apply');
+const SOURCE = 'manual-bulk-2026-05-30';
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const items = JSON.parse(readFileSync('scripts/output/untagged-expense-proposal.json', 'utf8')).filter(i => i.conf === 'REVIEW');
+
+// Keyword → project_code. First match wins; default ACT-CORE.
+const RULES = [
+  [/sealink|quarters tsv|lucinda|tully bakery|hermit park/i, 'ACT-PI'],   // North QLD / Palm Island trip
+  [/sydney|bridgeclimb|domestic airport|cheesecake shop|lotte duty free|denpasar|sunnymead|suzanne zemek|freedom fuels/i, 'ACT-IN'], // travel
+  [/3 legged thing|do film/i, 'ACT-EL'],                                  // photography / film
+];
+const codeFor = (it) => {
+  const hay = `${it.contact} ${it.desc}`;
+  for (const [re, code] of RULES) if (re.test(hay)) return code;
+  return 'ACT-CORE';
+};
+
+const assigned = items.map(it => ({ ...it, finalCode: codeFor(it) }));
+const by = {};
+for (const it of assigned) { by[it.finalCode] = by[it.finalCode] || { n: 0, $: 0 }; by[it.finalCode].n++; by[it.finalCode].$ += it.amount; }
+
+console.log(`${APPLY ? 'APPLYING' : 'DRY-RUN'} — ${assigned.length} incidentals → source ${SOURCE}\n`);
+for (const it of assigned.sort((a, b) => (a.finalCode > b.finalCode ? 1 : a.finalCode < b.finalCode ? -1 : b.amount - a.amount))) {
+  console.log(`  ${it.finalCode.padEnd(8)} ${it.date}  ${(it.contact || '').slice(0, 28).padEnd(28)} $${String(Math.round(it.amount)).padStart(4)}`);
+}
+console.log('\nSplit:');
+for (const [k, v] of Object.entries(by).sort((a, b) => b[1].$ - a[1].$)) console.log(`  ${k.padEnd(8)} ${String(v.n).padStart(2)}  $${Math.round(v.$).toLocaleString()}`);
+
+if (!APPLY) { console.log('\n(dry-run — pass --apply to write)'); process.exit(0); }
+
+const groups = {};
+for (const it of assigned) { const key = `${it.table}|${it.finalCode}`; (groups[key] = groups[key] || []).push(it.id); }
+let updated = 0;
+for (const [key, ids] of Object.entries(groups)) {
+  const [table, code] = key.split('|');
+  const { data, error } = await sb.from(table).update({ project_code: code, project_code_source: SOURCE }).in('id', ids).select('id');
+  if (error) { console.error(`  ERROR ${table}/${code}: ${error.message}`); continue; }
+  updated += (data || []).length;
+  console.log(`  ${table} → ${code}: ${(data || []).length}/${ids.length}`);
+}
+console.log(`\nApplied ${updated}/${assigned.length}.`);

--- a/scripts/propose-untagged-expense-tags.mjs
+++ b/scripts/propose-untagged-expense-tags.mjs
@@ -1,0 +1,110 @@
+// Propose project_code tags for the FY26 untagged expenses (ACCPAY bills + SPEND txns).
+// READ-ONLY: writes a review artifact + a JSON apply-list. No DB writes.
+// Confidence: vendor-rule match = HIGH; description/contact keyword = MED; neither = REVIEW.
+import '../lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { loadProjectsConfig } from './lib/project-loader.mjs';
+import { writeFileSync } from 'fs';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const FY = '2025-07-01';
+const PROJECTS = (await loadProjectsConfig()).projects || {};
+
+// Vendor rules (same source the auto-tagger uses)
+const { data: vrules } = await sb.from('vendor_project_rules').select('vendor_name, aliases, project_code');
+const vendorMap = (vrules || []).map(r => ({
+  code: r.project_code,
+  aliases: [r.vendor_name, ...(r.aliases || [])].filter(Boolean).map(a => a.toLowerCase()),
+}));
+
+// Description/contact keyword map from project names + xero_tracking aliases
+const kw = [];
+for (const [code, p] of Object.entries(PROJECTS)) {
+  const terms = new Set();
+  if (p.name) terms.add(p.name.toLowerCase());
+  if (p.xero_tracking) terms.add(String(p.xero_tracking).toLowerCase());
+  for (const a of p.xero_tracking_aliases || []) terms.add(String(a).toLowerCase());
+  for (const t of p.ghl_tags || []) terms.add(String(t).toLowerCase());
+  kw.push({ code, terms: [...terms].filter(t => t.length >= 4) });
+}
+
+function matchVendor(name) {
+  const n = (name || '').toLowerCase();
+  if (!n) return null;
+  for (const v of vendorMap) for (const a of v.aliases) if (a.length >= 3 && n.includes(a)) return v.code;
+  return null;
+}
+function matchKeyword(text) {
+  const t = (text || '').toLowerCase();
+  if (!t) return null;
+  for (const k of kw) for (const term of k.terms) if (t.includes(term)) return k.code;
+  return null;
+}
+
+async function pullUntagged() {
+  const out = [];
+  const { data: bills } = await sb.from('xero_invoices')
+    .select('id, invoice_number, contact_name, total, date, line_items')
+    .eq('type', 'ACCPAY').is('project_code', null)
+    .not('status', 'in', '(VOIDED,DELETED)').gte('date', FY);
+  for (const b of bills || []) out.push({
+    kind: 'bill', table: 'xero_invoices', id: b.id, ref: b.invoice_number,
+    contact: b.contact_name, amount: Math.abs(+b.total || 0), date: b.date,
+    desc: b.line_items?.[0]?.description || '',
+  });
+  let from = 0;
+  for (;;) {
+    const { data } = await sb.from('xero_transactions')
+      .select('id, contact_name, total, date, line_items')
+      .in('type', ['SPEND', 'SPEND-OVERPAYMENT']).is('project_code', null)
+      .gte('date', FY).range(from, from + 999);
+    for (const s of data || []) out.push({
+      kind: 'spend', table: 'xero_transactions', id: s.id, ref: s.contact_name,
+      contact: s.contact_name, amount: Math.abs(+s.total || 0), date: s.date,
+      desc: s.line_items?.[0]?.description || '',
+    });
+    if (!data || data.length < 1000) break;
+    from += 1000;
+  }
+  return out;
+}
+
+const items = await pullUntagged();
+for (const it of items) {
+  const v = matchVendor(it.contact);
+  if (v) { it.suggest = v; it.conf = 'HIGH'; it.via = 'vendor-rule'; continue; }
+  const k = matchKeyword(`${it.contact} ${it.desc}`);
+  if (k) { it.suggest = k; it.conf = 'MED'; it.via = 'keyword'; continue; }
+  it.suggest = ''; it.conf = 'REVIEW'; it.via = '';
+}
+
+items.sort((a, b) => (a.conf > b.conf ? 1 : a.conf < b.conf ? -1 : b.amount - a.amount));
+const byConf = c => items.filter(i => i.conf === c);
+const sum = arr => arr.reduce((s, i) => s + i.amount, 0);
+
+// Markdown artifact
+const codeName = c => (PROJECTS[c]?.name ? `${c} — ${PROJECTS[c].name}` : c);
+let md = `# Untagged expense tag proposal — ${items.length} items ($${Math.round(sum(items)).toLocaleString()})\n\n`;
+md += `_FY26 (from ${FY}), excl. voided. Apply target: Supabase mirror, source \`manual-bulk-2026-05-30\` (manual-guard protected)._\n\n`;
+md += `| Confidence | Items | $ |\n|---|---|---|\n`;
+for (const c of ['HIGH', 'MED', 'REVIEW']) md += `| ${c} | ${byConf(c).length} | $${Math.round(sum(byConf(c))).toLocaleString()} |\n`;
+md += `\n`;
+for (const c of ['HIGH', 'MED', 'REVIEW']) {
+  const rows = byConf(c);
+  if (!rows.length) continue;
+  md += `## ${c} (${rows.length})${c === 'HIGH' ? ' — vendor-rule matches' : c === 'MED' ? ' — keyword matches' : ' — no signal, need your call'}\n\n`;
+  md += `| # | kind | date | contact | desc | $ | → suggest | via |\n|---|---|---|---|---|---|---|---|\n`;
+  rows.forEach((it, i) => {
+    const idx = items.indexOf(it);
+    md += `| ${idx} | ${it.kind} | ${it.date} | ${(it.contact || '').slice(0, 28)} | ${(it.desc || '').slice(0, 32).replace(/\|/g, '/')} | $${Math.round(it.amount).toLocaleString()} | ${it.suggest ? codeName(it.suggest) : '—'} | ${it.via} |\n`;
+  });
+  md += `\n`;
+}
+
+const artifact = 'thoughts/shared/financials/2026-05-30-untagged-expense-tag-proposal.md';
+writeFileSync(artifact, md);
+writeFileSync('scripts/output/untagged-expense-proposal.json', JSON.stringify(items, null, 2));
+console.log(`${items.length} items: HIGH ${byConf('HIGH').length} · MED ${byConf('MED').length} · REVIEW ${byConf('REVIEW').length}`);
+console.log(`$ total $${Math.round(sum(items)).toLocaleString()}  (HIGH $${Math.round(sum(byConf('HIGH'))).toLocaleString()})`);
+console.log(`Artifact: ${artifact}`);
+console.log(`Apply-list: scripts/output/untagged-expense-proposal.json`);

--- a/scripts/sync-xero-to-supabase.mjs
+++ b/scripts/sync-xero-to-supabase.mjs
@@ -702,7 +702,12 @@ async function syncInvoices(options = {}) {
         total: parseFloat(invoice.Total) || 0,
         subtotal: parseFloat(invoice.SubTotal) || 0,
         total_tax: parseFloat(invoice.TotalTax) || 0,
-        amount_due: parseFloat(invoice.AmountDue) || 0,
+        // Phantom-receivable guard: a VOIDED/DELETED invoice owes nothing. Force
+        // amount_due to 0 so the mirror can never persist a stale "due" for a
+        // voided row (root cause of the 2026-05-30 $375,100 phantom receivables).
+        amount_due: (invoice.Status === 'VOIDED' || invoice.Status === 'DELETED')
+          ? 0
+          : (parseFloat(invoice.AmountDue) || 0),
         amount_paid: parseFloat(invoice.AmountPaid) || 0,
         currency_code: invoice.CurrencyCode || 'AUD',
         date: parseXeroDate(invoice.Date),

--- a/thoughts/shared/financials/2026-05-30-untagged-expense-tag-proposal.md
+++ b/thoughts/shared/financials/2026-05-30-untagged-expense-tag-proposal.md
@@ -1,0 +1,161 @@
+# Untagged expense tag proposal — 141 items ($65,214)
+
+_FY26 (from 2025-07-01), excl. voided. Apply target: Supabase mirror, source `manual-bulk-2026-05-30` (manual-guard protected)._
+
+| Confidence | Items | $ |
+|---|---|---|
+| HIGH | 106 | $63,870 |
+| MED | 0 | $0 |
+| REVIEW | 35 | $1,345 |
+
+## HIGH (106) — vendor-rule matches
+
+| # | kind | date | contact | desc | $ | → suggest | via |
+|---|---|---|---|---|---|---|---|
+| 0 | bill | 2025-12-07 | Kennards Hire | Kennards Hire — Materials & Supp | $6,616 | ACT-HV — The Harvest Witta | vendor-rule |
+| 1 | bill | 2026-01-04 | Total Tools East Brisbane | Total Tools — Materials & Equipm | $4,547 | ACT-HV — The Harvest Witta | vendor-rule |
+| 2 | bill | 2025-11-27 | Kennards Hire | Kennards Hire — Materials & Supp | $3,745 | ACT-HV — The Harvest Witta | vendor-rule |
+| 3 | bill | 2025-12-01 | Bunnings Warehouse | . | $2,886 | ACT-HV — The Harvest Witta | vendor-rule |
+| 4 | spend | 2025-11-15 | Qantas | Flight for Suzanne Zemek and Ste | $2,399 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 5 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - DXB   / DXB   - B | $2,229 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 6 | bill | 2025-11-30 | TNT Plastering & Maintenance | TNT Plastering & Maintenance | $2,000 | ACT-HV — The Harvest Witta | vendor-rule |
+| 7 | bill | 2026-03-16 | MALENY LANDSCAPING SUPPLIES | Maleny Landscaping — Materials & | $1,995 | ACT-HV — The Harvest Witta | vendor-rule |
+| 8 | bill | 2025-12-08 | Kennards Hire | Kennards Hire — Materials & Supp | $1,714 | ACT-HV — The Harvest Witta | vendor-rule |
+| 9 | bill | 2025-12-27 | Bunnings Warehouse | Air con split | $1,597 | ACT-HV — The Harvest Witta | vendor-rule |
+| 10 | bill | 2025-11-08 | Bunnings Warehouse | Bunnings — Materials & Supplies  | $1,495 | ACT-HV — The Harvest Witta | vendor-rule |
+| 11 | bill | 2025-11-08 | Bunnings Warehouse | Bunnings — Materials & Supplies  | $1,468 | ACT-HV — The Harvest Witta | vendor-rule |
+| 12 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - ASP   / ASP   - S | $1,396 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 13 | bill | 2025-11-03 | Kennards Hire | . | $1,308 | ACT-HV — The Harvest Witta | vendor-rule |
+| 14 | bill | 2026-03-17 | MALENY LANDSCAPING SUPPLIES | Maleny Landscaping — Materials & | $1,305 | ACT-HV — The Harvest Witta | vendor-rule |
+| 15 | bill | 2026-03-17 | MALENY LANDSCAPING SUPPLIES | Maleny Landscaping — Materials & | $1,305 | ACT-HV — The Harvest Witta | vendor-rule |
+| 16 | bill | 2025-11-09 | Kennards Hire | Kennards Hire — Materials & Supp | $1,237 | ACT-HV — The Harvest Witta | vendor-rule |
+| 17 | bill | 2025-12-02 | TNT Plastering & Maintenance | TNT Plastering & Maintenance — C | $1,200 | ACT-HV — The Harvest Witta | vendor-rule |
+| 18 | bill | 2025-10-27 | Trybe Collective | . | $1,100 | ACT-HV — The Harvest Witta | vendor-rule |
+| 19 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - SYD   / SYD   - D | $1,071 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 20 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - SYD   / SYD   - D | $1,071 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 21 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - ASP   / ASP   - B | $1,007 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 22 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - SYD   / SYD   - N | $954 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 23 | spend | 2026-05-22 | Thrifty | . | $923 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 24 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - DRW   / DRW   - B | $886 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 25 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - ADL   / ADL   - B | $751 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 26 | spend | 2025-12-28 | Woodford Folk Festival | Woodford Folk Festival 25/26 | $726 | ACT-HV — The Harvest Witta | vendor-rule |
+| 27 | spend | 2025-11-15 | Qantas Group Accommodation | Accommodation for Nick Maresi | $719 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 28 | bill | 2026-03-18 | MALENY LANDSCAPING SUPPLIES | Maleny Landscaping — Materials & | $653 | ACT-HV — The Harvest Witta | vendor-rule |
+| 29 | bill | 2025-11-30 | Bunnings Warehouse | Decking deck | $633 | ACT-HV — The Harvest Witta | vendor-rule |
+| 30 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - SYD   / SYD   - A | $620 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 31 | bill | 2025-12-13 | Bunnings Warehouse | Bunnings — Materials & Supplies  | $597 | ACT-HV — The Harvest Witta | vendor-rule |
+| 32 | bill | 2025-12-10 | Bunnings Warehouse | Materials and supplies | $549 | ACT-HV — The Harvest Witta | vendor-rule |
+| 33 | spend | 2025-08-20 | Flight Bar Witta | TENNANT FOOD BARN TENNANT CREEK | $503 | ACT-HV — The Harvest Witta | vendor-rule |
+| 34 | spend | 2025-08-20 | Flight Bar Witta | TENNANT FOOD BARN TENNANT CREEK | $500 | ACT-HV — The Harvest Witta | vendor-rule |
+| 35 | bill | 2025-09-30 | Maleny Hardware And Rural Su | . | $497 | ACT-HV — The Harvest Witta | vendor-rule |
+| 36 | bill | 2025-10-04 | Maleny Hardware And Rural Su | . | $497 | ACT-HV — The Harvest Witta | vendor-rule |
+| 37 | bill | 2025-11-29 | Maleny Hardware And Rural Su | Maleny Hardware — Materials & Su | $486 | ACT-HV — The Harvest Witta | vendor-rule |
+| 38 | bill | 2025-11-11 | Kennards Hire | Kennards Hire — Materials & Supp | $424 | ACT-HV — The Harvest Witta | vendor-rule |
+| 39 | bill | 2025-07-31 | Maleny Hardware And Rural Su | . | $424 | ACT-HV — The Harvest Witta | vendor-rule |
+| 40 | bill | 2025-08-01 | Maleny Hardware And Rural Su | . | $424 | ACT-HV — The Harvest Witta | vendor-rule |
+| 41 | bill | 2025-10-05 | Centre Trailer Sales | Centre Trailer Sales — Other — A | $420 | ACT-HV — The Harvest Witta | vendor-rule |
+| 42 | spend | 2026-05-23 | Qantas Group Accommodation | . | $393 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 43 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - SYD   / SYD   - B | $382 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 44 | spend | 2025-08-04 | Chris Witta | CHRIS WITTA B8161124077 Drain an | $360 | ACT-HV — The Harvest Witta | vendor-rule |
+| 45 | bill | 2026-05-26 | Qantas Airways Limited | Flight BNE   - SYD   / SYD   - B | $354 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 46 | spend | 2025-08-18 | Chris Witta | CHRIS WITTA Y5372717898 Pipe tha | $340 | ACT-HV — The Harvest Witta | vendor-rule |
+| 47 | spend | 2025-11-21 | Budget | Car rental for Suzanne | $318 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 48 | bill | 2025-11-04 | Maleny Hardware And Rural Su | . | $285 | ACT-HV — The Harvest Witta | vendor-rule |
+| 49 | spend | 2025-11-15 | Qantas Group Accommodation | Nick Maresi - Accommodation | $275 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 50 | spend | 2025-08-20 | Kennards Hire |  | $265 | ACT-HV — The Harvest Witta | vendor-rule |
+| 51 | bill | 2025-10-09 | Kennards Hire | Kennards Hire — Materials & Supp | $244 | ACT-HV — The Harvest Witta | vendor-rule |
+| 52 | bill | 2025-08-22 | Kennards Hire | . | $244 | ACT-HV — The Harvest Witta | vendor-rule |
+| 53 | spend | 2025-11-15 | Qantas | Kia Cerato Hatch S Safety | $219 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 54 | spend | 2025-11-15 | Qantas Group Accommodation | Nick Maresi - Accommodation | $176 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 55 | spend | 2025-08-22 | Flight Bar Witta | SMP*Devils Marbles Ho Davenport | $141 | ACT-HV — The Harvest Witta | vendor-rule |
+| 56 | spend | 2025-11-15 | Qantas Group Accommodation | Accommodation | $135 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 57 | spend | 2025-07-04 | Flight Bar Witta | Hanuman Restaurant Ali Alice Spr | $135 | ACT-HV — The Harvest Witta | vendor-rule |
+| 58 | bill | 2025-12-01 | Bunnings Warehouse | Cladding Hardiflex | $132 | ACT-HV — The Harvest Witta | vendor-rule |
+| 59 | spend | 2025-11-21 | Budget | Car rental for Melbourne | $128 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 60 | bill | 2025-08-08 | Maleny Hardware And Rural Su | . | $126 | ACT-HV — The Harvest Witta | vendor-rule |
+| 61 | bill | 2025-07-29 | Maleny Hardware And Rural Su | . | $124 | ACT-HV — The Harvest Witta | vendor-rule |
+| 62 | spend | 2025-11-24 | Car Park | Suzie Zemek - Car Parking | $119 | ACT-CA — Caring for those who care | vendor-rule |
+| 63 | bill | 2026-03-26 | Auscot Rural Co Pty Ltd T/As | Maleny Hardware — Materials & Su | $113 | ACT-HV — The Harvest Witta | vendor-rule |
+| 64 | bill | 2026-03-26 | MALENY HARDWARE & RU | Maleny Hardware — Materials & Su | $113 | ACT-HV — The Harvest Witta | vendor-rule |
+| 65 | bill | 2026-03-27 | Bunnings Warehouse | Bunnings — Materials & Supplies  | $111 | ACT-HV — The Harvest Witta | vendor-rule |
+| 66 | bill | 2025-12-11 | Kennards Hire | Kennards Hire — Materials & Supp | $106 | ACT-HV — The Harvest Witta | vendor-rule |
+| 67 | spend | 2025-08-19 | Flight Bar Witta | Hanuman Restaurant Ali Alice Spr | $106 | ACT-HV — The Harvest Witta | vendor-rule |
+| 68 | spend | 2025-07-02 | Flight Bar Witta | SMP*Memories Bistro dcTennant Cr | $103 | ACT-HV — The Harvest Witta | vendor-rule |
+| 69 | bill | 2025-12-16 | Bunnings Warehouse | Bunnings — Materials & Supplies  | $100 | ACT-HV — The Harvest Witta | vendor-rule |
+| 70 | bill | 2025-09-22 | Maleny Hardware And Rural Su | . | $96 | ACT-HV — The Harvest Witta | vendor-rule |
+| 71 | spend | 2025-07-04 | Kennards Hire |  | $83 | ACT-HV — The Harvest Witta | vendor-rule |
+| 72 | spend | 2025-09-02 | Flight Bar Witta | PASADENA FOODLAND PASADENA | $82 | ACT-HV — The Harvest Witta | vendor-rule |
+| 73 | spend | 2025-09-17 | Flight Bar Witta | J R ROWDEN AND F V SNO ALICE SPR | $74 | ACT-HV — The Harvest Witta | vendor-rule |
+| 74 | spend | 2025-11-18 | Qantas | Car rental for Nick | $73 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 75 | bill | 2025-07-29 | Maleny Hardware And Rural Su | . | $69 | ACT-HV — The Harvest Witta | vendor-rule |
+| 76 | spend | 2025-07-04 | Flight Bar Witta | SMP*Devils Marbles Ho Davenport | $64 | ACT-HV — The Harvest Witta | vendor-rule |
+| 77 | spend | 2025-08-11 | Flight Bar Witta | SweetBrew & Co STUART PARK | $58 | ACT-HV — The Harvest Witta | vendor-rule |
+| 78 | bill | 2025-07-30 | Maleny Hardware And Rural Su | . | $58 | ACT-HV — The Harvest Witta | vendor-rule |
+| 79 | spend | 2025-07-01 | Flight Bar Witta | SMP*Memories Bistro dcTennant Cr | $53 | ACT-HV — The Harvest Witta | vendor-rule |
+| 80 | bill | 2025-09-30 | Maleny Hardware And Rural Su | . | $52 | ACT-HV — The Harvest Witta | vendor-rule |
+| 81 | spend | 2025-08-19 | Flight Bar Witta | KFC ALICE SPRINGS ALICE SPRINGS | $50 | ACT-HV — The Harvest Witta | vendor-rule |
+| 82 | bill | 2025-10-22 | Maleny Hardware And Rural Su | . | $46 | ACT-HV — The Harvest Witta | vendor-rule |
+| 83 | spend | 2025-07-02 | Flight Bar Witta | SMP*Memories Bistro dcTennant Cr | $43 | ACT-HV — The Harvest Witta | vendor-rule |
+| 84 | bill | 2025-10-22 | Maleny Hardware And Rural Su | . | $41 | ACT-HV — The Harvest Witta | vendor-rule |
+| 85 | bill | 2025-08-09 | Maleny Hardware And Rural Su | . | $39 | ACT-HV — The Harvest Witta | vendor-rule |
+| 86 | spend | 2025-08-20 | Flight Bar Witta | MRS PERRY S FISH AND TENNANT CRE | $39 | ACT-HV — The Harvest Witta | vendor-rule |
+| 87 | spend | 2025-08-21 | Flight Bar Witta | J R ROWDEN AND F V SNO ALICE SPR | $32 | ACT-HV — The Harvest Witta | vendor-rule |
+| 88 | bill | 2025-07-26 | Maleny Hardware And Rural Su | . | $32 | ACT-HV — The Harvest Witta | vendor-rule |
+| 89 | spend | 2025-08-05 | Flight Bar Witta | SPARS SUPERMARKET DUNWICHDUNWICH | $30 | ACT-HV — The Harvest Witta | vendor-rule |
+| 90 | spend | 2025-09-19 | Flight Bar Witta | J R ROWDEN AND F V SNO ALICE SPR | $29 | ACT-HV — The Harvest Witta | vendor-rule |
+| 91 | spend | 2025-08-27 | Amazon | no invoice | $28 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 92 | bill | 2025-12-30 | Maleny Hardware And Rural Su | Maleny Hardware — Materials & Su | $22 | ACT-HV — The Harvest Witta | vendor-rule |
+| 93 | bill | 2025-11-27 | Maleny Hardware And Rural Su | Maleny Hardware — Materials & Su | $22 | ACT-HV — The Harvest Witta | vendor-rule |
+| 94 | bill | 2025-10-18 | Maleny Hardware And Rural Su | . | $21 | ACT-HV — The Harvest Witta | vendor-rule |
+| 95 | bill | 2025-09-21 | Nest In Witta | . | $19 | ACT-HV — The Harvest Witta | vendor-rule |
+| 96 | bill | 2025-11-16 | Maleny Hardware And Rural Su | Maleny Hardware — Materials & Su | $19 | ACT-HV — The Harvest Witta | vendor-rule |
+| 97 | bill | 2025-10-15 | Maleny Hardware And Rural Su | . | $17 | ACT-HV — The Harvest Witta | vendor-rule |
+| 98 | spend | 2025-08-20 | Flight Bar Witta | SQ *BAY LEAF CAFE Tennant Creek | $14 | ACT-HV — The Harvest Witta | vendor-rule |
+| 99 | spend | 2026-05-29 | Death Before Decaf | No Invoice - Under $82.50 | $13 | ACT-UA — Uncle Allan Palm Island Art | vendor-rule |
+| 100 | spend | 2025-08-20 | Flight Bar Witta | SQ *BAY LEAF CAFE Tennant Creek | $11 | ACT-HV — The Harvest Witta | vendor-rule |
+| 101 | spend | 2025-08-21 | Flight Bar Witta | TI TREE RH 9787 TI TREE | $10 | ACT-HV — The Harvest Witta | vendor-rule |
+| 102 | spend | 2026-05-29 | Anthropic | No Tax Invoice - Under $82.50 | $9 | ACT-IN — ACT Infrastructure | vendor-rule |
+| 103 | spend | 2026-05-29 | NAB International Fee | NAB INTNL TRAN FEE - (SC) | $2 | ACT-CORE — ACT Regenerative Studio | vendor-rule |
+| 104 | spend | 2026-05-29 | NAB |  | $2 | ACT-CORE — ACT Regenerative Studio | vendor-rule |
+| 105 | spend | 2026-05-29 | NAB | NAB INTNL TRAN FEE - (MC) | $0 | ACT-CORE — ACT Regenerative Studio | vendor-rule |
+
+## REVIEW (35) — no signal, need your call
+
+| # | kind | date | contact | desc | $ | → suggest | via |
+|---|---|---|---|---|---|---|---|
+| 106 | spend | 2025-11-21 | Sunnymead Hotel | Suzanne Zemek | $239 | — |  |
+| 107 | spend | 2025-11-15 | Lotte Duty Free | Airfare for Denpasar | $132 | — |  |
+| 108 | bill | 2025-09-08 | SeaLink Queensland | . | $78 | — |  |
+| 109 | bill | 2025-08-05 | Unknown Supplier | . | $69 | — |  |
+| 110 | bill | 2025-07-01 | 3 Legged Thing | . | $58 | — |  |
+| 111 | bill | 2025-08-06 | Im-Am Thai | . | $57 | — |  |
+| 112 | bill | 2025-07-31 | Freedom Fuels | . | $54 | — |  |
+| 113 | bill | 2025-08-20 | Mooloolah River Waterwatch & | . | $53 | — |  |
+| 114 | bill | 2025-10-02 | The Shack Fish & Chippery | . | $49 | — |  |
+| 115 | bill | 2025-12-04 | Hermit Park - Good Morning C | . | $48 | — |  |
+| 116 | bill | 2026-03-03 | Eventfinda Australia | . | $46 | — |  |
+| 117 | bill | 2026-03-03 | GROUP SINGLE | . | $46 | — |  |
+| 118 | bill | 2025-10-22 | Mooloolah Valley Community A | . | $42 | — |  |
+| 119 | bill | 2025-07-17 | AI Builder Club | Receipt auto-imported from dext_ | $37 | — |  |
+| 120 | bill | 2025-07-17 | AI Builder Club | Receipt auto-imported from dext_ | $37 | — |  |
+| 121 | bill | 2025-08-05 | Pearl Energy | . | $35 | — |  |
+| 122 | bill | 2025-10-13 | Sydney Domestic Airport | . | $30 | — |  |
+| 123 | bill | 2025-08-09 | Pop Rocket Cafe And Blast Co | . | $29 | — |  |
+| 124 | bill | 2025-10-15 | Lucinda Store | . | $26 | — |  |
+| 125 | bill | 2026-03-05 | Elsies Kitchen | . | $24 | — |  |
+| 126 | bill | 2025-08-05 | Butcher Baker | . | $20 | — |  |
+| 127 | bill | 2025-07-07 | Do Film! Lab | . | $19 | — |  |
+| 128 | bill | 2025-10-01 | BRIDGECLIMB SYDNEY | . | $14 | — |  |
+| 129 | bill | 2025-12-28 | Fresh & Save Food Warehouse | . | $13 | — |  |
+| 130 | bill | 2025-08-07 | The Cool Spot | . | $13 | — |  |
+| 131 | bill | 2025-12-29 | NUDE JUICE | . | $12 | — |  |
+| 132 | bill | 2025-11-22 | Little Rosebery Cafe | . | $11 | — |  |
+| 133 | bill | 2025-09-04 | Little Florence Coffee | . | $10 | — |  |
+| 134 | bill | 2025-10-17 | Tully Bakery | . | $9 | — |  |
+| 135 | bill | 2025-09-26 | The Lord Lamington | . | $7 | — |  |
+| 136 | bill | 2025-10-13 | T3 Domestic Airport | . | $7 | — |  |
+| 137 | bill | 2025-09-29 | The Quarters TSV | . | $7 | — |  |
+| 138 | bill | 2025-08-02 | The Barn Cafe | . | $6 | — |  |
+| 139 | bill | 2025-09-12 | Norfino | . | $5 | — |  |
+| 140 | bill | 2025-10-13 | The Cheesecake Shop | . | $5 | — |  |
+


### PR DESCRIPTION
Finance prep before the Standard Ledger handoff. Part of the Xero-as-source-of-truth plan (`thoughts/shared/plans/2026-05-30-xero-source-of-truth-goods-ledger.md`).

## 1. Durable voided-receivable guard (`a998a28`)
The query layer was already safe (the `v_funder_summary` view excludes voided; overview/accountant-pack/weekly-review/funders all whitelist AUTHORISED/SENT). The actual hole was the **data layer** — a voided invoice keeping a stale `amount_due` (root cause of the 2026-05-30 $375,100 phantom).
- `sync-xero-to-supabase.mjs`: force `amount_due=0` on VOIDED/DELETED invoices, so the mirror can never persist a stale "due" again.
- `lifetime-ledger`: made the voided exclusion explicit at the query layer.
- Verified 0 voided rows currently carry a non-zero `amount_due`.

## 2. FY26 expense tagging → 100% coverage (`0b19080`, `37832ac`)
Income was already 100% tagged. Of 141 untagged FY26 expenses:
- **106 vendor-rule matches** → ACT-HV 71 ($46.8K Harvest materials) · ACT-IN 20 (travel) · **ACT-GD 10** (Ben's call: Alice Springs/Darwin on-country, incl. 6 "Flight Bar Witta"-mislabelled card spends) · 5 misc.
- **35 incidentals** by location/type signal → ACT-CORE 21 (overhead default) · ACT-IN 7 (travel) · ACT-PI 5 (North QLD) · ACT-EL 2 (photo/film).
- All source `manual-bulk-2026-05-30` (manual-guard protected). **FY26 untagged now 0/0/0** (income/bills/spend).

## 3. Project Money page (`9442d5d`)
New `/finance/project-money` (State nav group) — the single front-door: tagging-coverage banner (income 100% / expense 100%, untagged $ linked to tag) + per-project income/received/expense/net, derived LIVE from the Xero mirror.
- Expense model avoids double-counting: bank/card SPEND + only the UNPAID portion of bills (`amount_due`); calibrated vs `project_monthly_financials` (a naive bills+spend sum had doubled ACT-GD expense → bogus −$184K net; real +$44K).
- FY26, voided excluded, paginated past the 1000-row cap.

tsc clean; API verified live. Scripts-only + one new page/route + nav — no changes to existing finance surfaces.

Plan: 2026-05-30-xero-source-of-truth-goods-ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)