### PR TITLE
finance: sense-check findings (TFN/MOL) + Plasticians retag + colored chips & Project Money→Transactions linking

### DIFF
--- a/apps/command-center/src/app/finance/project-money/page.tsx
+++ b/apps/command-center/src/app/finance/project-money/page.tsx
@@ -120,9 +120,12 @@ export default function ProjectMoneyPage() {
                       {r.untagged ? (
                         <span className="inline-flex items-center gap-1 text-amber-400"><AlertTriangle className="h-3.5 w-3.5" /> Untagged</span>
                       ) : (
-                        <Link href={`/finance/projects/${r.code}`} className="hover:underline">
-                          <span className="font-mono text-xs text-muted-foreground">{r.code}</span> {r.name}
-                        </Link>
+                        <span className="inline-flex items-center gap-2">
+                          <Link href={`/finance/transactions?project=${r.code}&since=2025-07-01`} className="hover:underline" title={`Review & retag ${r.code} transactions`}>
+                            <span className="font-mono text-xs text-muted-foreground">{r.code}</span> {r.name}
+                          </Link>
+                          <Link href={`/finance/projects/${r.code}`} className="text-[10px] uppercase tracking-wide text-muted-foreground/50 hover:text-foreground">P&amp;L</Link>
+                        </span>
                       )}
                     </td>
                     <td className="px-3 py-2 text-right tabular-nums text-emerald-400/90">{r.income ? fmt(r.income) : '—'}</td>

--- a/apps/command-center/src/app/finance/transactions/page.tsx
+++ b/apps/command-center/src/app/finance/transactions/page.tsx
@@ -39,6 +39,33 @@ function chip(text: string, color: string) {
   return <span className={`inline-block rounded px-1.5 py-0.5 text-xs ${color}`} style={{ fontFamily: 'ui-monospace, monospace' }}>{text}</span>
 }
 
+// Deterministic colour per project so the same code reads the same everywhere.
+// Full literal class strings (not interpolated) so Tailwind compiles them.
+const PROJECT_PALETTE = [
+  'bg-emerald-500/15 border-emerald-500/40 text-emerald-200 hover:border-emerald-400',
+  'bg-blue-500/15 border-blue-500/40 text-blue-200 hover:border-blue-400',
+  'bg-purple-500/15 border-purple-500/40 text-purple-200 hover:border-purple-400',
+  'bg-cyan-500/15 border-cyan-500/40 text-cyan-200 hover:border-cyan-400',
+  'bg-pink-500/15 border-pink-500/40 text-pink-200 hover:border-pink-400',
+  'bg-indigo-500/15 border-indigo-500/40 text-indigo-200 hover:border-indigo-400',
+  'bg-teal-500/15 border-teal-500/40 text-teal-200 hover:border-teal-400',
+  'bg-orange-500/15 border-orange-500/40 text-orange-200 hover:border-orange-400',
+  'bg-lime-500/15 border-lime-500/40 text-lime-200 hover:border-lime-400',
+  'bg-violet-500/15 border-violet-500/40 text-violet-200 hover:border-violet-400',
+]
+function projectColor(code: string): string {
+  if (!code || code === 'UNTAGGED') return 'bg-amber-500/10 border-amber-500/50 text-amber-300 hover:border-amber-400'
+  let h = 0
+  for (let i = 0; i < code.length; i++) h = (h * 31 + code.charCodeAt(i)) >>> 0
+  return PROJECT_PALETTE[h % PROJECT_PALETTE.length]
+}
+const SOURCE_COLOR: Record<string, string> = {
+  spend: 'bg-rose-500/15 border-rose-500/40 text-rose-200 hover:border-rose-400',
+  'spend-overpay': 'bg-rose-500/15 border-rose-500/40 text-rose-200 hover:border-rose-400',
+  bill: 'bg-amber-500/15 border-amber-500/40 text-amber-200 hover:border-amber-400',
+  receive: 'bg-emerald-500/15 border-emerald-500/40 text-emerald-200 hover:border-emerald-400',
+}
+
 function auditNote(r: Row): string {
   const id = r.xeroId
   const n = (r.contact || '').toLowerCase()
@@ -69,7 +96,9 @@ export default function TransactionsExplorer() {
   const [initialized, setInitialized] = useState(false)
 
   // server-side filters
-  const [projectFilter, setProjectFilter] = useState<string>('UNTAGGED')
+  // Default to all (tagged + untagged). Untagged is ~empty now that FY26 is fully
+  // tagged, so the old 'UNTAGGED' default landed on a blank list.
+  const [projectFilter, setProjectFilter] = useState<string>('all')
   const [since, setSince] = useState('2025-07-01')
   const [accountFilter, setAccountFilter] = useState<string>('act-only') // 'act-only', 'all', or specific account name
   const [availableAccounts, setAvailableAccounts] = useState<string[]>([])
@@ -197,14 +226,17 @@ export default function TransactionsExplorer() {
   }, [])
 
   // Keep the URL in sync as filters change, so a view is shareable + survives refresh.
+  // Gated on `initialized` so this never overwrites the incoming ?project= before the
+  // init effect above has read it (else a deep-link like ?project=ACT-GD gets clobbered).
   useEffect(() => {
+    if (!initialized) return
     const sp = new URLSearchParams()
-    if (projectFilter !== 'UNTAGGED') sp.set('project', projectFilter)
+    if (projectFilter !== 'all') sp.set('project', projectFilter)
     if (since !== '2025-07-01') sp.set('since', since)
     if (accountFilter !== 'act-only') sp.set('accounts', accountFilter)
     const qs = sp.toString()
     window.history.replaceState(null, '', qs ? `?${qs}` : window.location.pathname)
-  }, [projectFilter, since, accountFilter])
+  }, [projectFilter, since, accountFilter, initialized])
 
   function load() {
     setLoading(true)
@@ -484,8 +516,8 @@ export default function TransactionsExplorer() {
                 return (
                   <button key={code} onClick={() => setProjectFilter(code === 'UNTAGGED' ? 'UNTAGGED' : code)}
                     title={code}
-                    className="text-xs px-2 py-0.5 rounded border border-white/10 hover:border-white/30">
-                    {lbl} · {s.count} · {fmt(s.sum)}
+                    className={`text-xs px-2 py-0.5 rounded border transition-colors ${projectColor(code)} ${projectFilter === code ? 'ring-1 ring-white/50' : ''}`}>
+                    <span className="font-mono opacity-60">{code === 'UNTAGGED' ? '—' : code}</span> {lbl} · {s.count} · {fmt(s.sum)}
                   </button>
                 )
               })}
@@ -495,7 +527,8 @@ export default function TransactionsExplorer() {
             <div className="text-xs text-white/40 mb-2">By source</div>
             <div className="flex flex-wrap gap-1">
               {stats.bySource.map(([src, s]) => (
-                <button key={src} onClick={() => setSource(src)} className="text-xs px-2 py-0.5 rounded border border-white/10 hover:border-white/30">
+                <button key={src} onClick={() => setSource(src)}
+                  className={`text-xs px-2 py-0.5 rounded border transition-colors ${SOURCE_COLOR[src] || 'border-white/10 hover:border-white/30'} ${source === src ? 'ring-1 ring-white/50' : ''}`}>
                   {src} · {s.count} · {fmt(s.sum)}
                 </button>
               ))}

--- a/scripts/retag-plasticians-xero.mjs
+++ b/scripts/retag-plasticians-xero.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * One-off Tier-3 Xero re-tag: The Plasticians AP bill ($29,800, AUTHORISED, unlocked)
+ * Project Tracking ACT-IN → ACT-GD (Goods HDPE materials; confirmed with Ben 2026-05-30).
+ * Tracking-only, no amount change. Same safety harness as apply-xero-tracking-backfill.mjs:
+ * GET-fresh → modify Tracking only (preserve Business Divisions + all other fields) →
+ * revert log BEFORE write → POST → verify totals byte-identical + option set.
+ *
+ *   node scripts/retag-plasticians-xero.mjs            # live dry-run (no write)
+ *   node scripts/retag-plasticians-xero.mjs --apply    # write
+ */
+import '../lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const TENANT = process.env.XERO_TENANT_ID;
+const PROJECT_CAT = 'Project Tracking';
+const TARGET = 'ACT-GD';
+const LOCK_DATE = '2025-09-30';
+const APPLY = process.argv.includes('--apply');
+
+function token() { return JSON.parse(readFileSync('.xero-tokens.json', 'utf8')).access_token; }
+async function xero(method, path, body) {
+  const res = await fetch(`https://api.xero.com/api.xro/2.0/${path}`, {
+    method,
+    headers: { Authorization: `Bearer ${token()}`, 'xero-tenant-id': TENANT, Accept: 'application/json', 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json; try { json = JSON.parse(text); } catch { json = null; }
+  return { ok: res.ok, status: res.status, json, text };
+}
+const projOption = (li = []) => { for (const l of li) for (const t of (l.Tracking || [])) if (t.Name === PROJECT_CAT) return t.Option; return null; };
+
+// 0. identify the invoice in the mirror (one Plasticians ACCPAY AUTHORISED)
+const { data: cands } = await sb.from('xero_invoices')
+  .select('xero_id,invoice_number,contact_name,type,status,date,total,project_code')
+  .ilike('contact_name', '%plasticians%').eq('type', 'ACCPAY').not('status', 'in', '(VOIDED,DELETED)');
+if (!cands || cands.length !== 1) { console.error(`Expected exactly 1 Plasticians AP bill, found ${cands?.length}`); process.exit(1); }
+const cand = cands[0];
+console.log(`Target: ${cand.contact_name} ${cand.date} ${cand.status} $${cand.total} [mirror ${cand.project_code}] xero_id ${cand.xero_id}`);
+
+// 1. resolve Project Tracking category + ACT-GD option
+const tcRes = await xero('GET', 'TrackingCategories');
+if (!tcRes.ok) { console.error('TrackingCategories', tcRes.status, tcRes.text.slice(0, 200)); process.exit(1); }
+const cat = (tcRes.json.TrackingCategories || []).find(c => c.Name === PROJECT_CAT);
+const opt = (cat?.Options || []).find(o => o.Name.split('—')[0].trim() === TARGET);
+if (!opt) { console.error(`No ${TARGET} option in Project Tracking`); process.exit(1); }
+const canonical = opt.Name;
+
+// 2. GET-fresh
+const g = await xero('GET', `Invoices/${cand.xero_id}`);
+if (!g.ok) { console.error(`GET ${g.status} ${g.text.slice(0, 200)}`); process.exit(1); }
+const inv = g.json.Invoices?.[0];
+if (!inv) { console.error('Invoice not found'); process.exit(1); }
+const date = (inv.DateString || inv.Date || '').slice(0, 10);
+console.log(`Live Xero: ${inv.Type} ${inv.Status} ${date} Total $${inv.Total} | current Project Tracking = "${projOption(inv.LineItems)}"`);
+
+// 3. validate eligibility (ACCPAY/ACCREC ok; must be unlocked + active)
+if (!['AUTHORISED', 'PAID'].includes(inv.Status) || date <= LOCK_DATE) {
+  console.error(`Not eligible: status ${inv.Status} date ${date} (locked or wrong status)`); process.exit(1);
+}
+if (projOption(inv.LineItems) === canonical) { console.log(`Already ${canonical} — nothing to do`); process.exit(0); }
+
+// 4. build modified line items — preserve everything, replace Project Tracking only
+const newLines = inv.LineItems.map(li => ({
+  LineItemID: li.LineItemID,
+  Description: li.Description,
+  Quantity: li.Quantity,
+  UnitAmount: li.UnitAmount,
+  AccountCode: li.AccountCode,
+  TaxType: li.TaxType,
+  Tracking: [
+    ...(li.Tracking || []).filter(t => t.Name !== PROJECT_CAT),  // keep Business Divisions
+    { TrackingCategoryID: cat.TrackingCategoryID, TrackingOptionID: opt.TrackingOptionID },
+  ],
+}));
+
+if (!existsSync('scripts/output')) mkdirSync('scripts/output', { recursive: true });
+const revert = [{ invoiceId: inv.InvoiceID, original: inv.LineItems, before: { Total: inv.Total, SubTotal: inv.SubTotal, AmountDue: inv.AmountDue } }];
+
+console.log(`\nPLAN: set Project Tracking "${projOption(inv.LineItems)}" → "${canonical}" on ${newLines.length} line(s); totals must stay $${inv.Total}/${inv.AmountDue}`);
+if (!APPLY) { console.log('(dry-run — pass --apply to write)'); process.exit(0); }
+
+writeFileSync('scripts/output/retag-plasticians-revert-2026-05-30.json', JSON.stringify(revert, null, 2));
+const body = { Invoices: [{ InvoiceID: inv.InvoiceID, LineAmountTypes: inv.LineAmountTypes, LineItems: newLines }] };
+const p = await xero('POST', 'Invoices', body);
+if (!p.ok) { console.error(`POST ${p.status} ${p.text.slice(0, 300)}`); process.exit(1); }
+const u = p.json.Invoices?.[0];
+const moneyOk = u && u.Total === inv.Total && u.AmountDue === inv.AmountDue;
+const optSet = projOption(u?.LineItems) === canonical;
+if (!moneyOk) { console.error(`CRITICAL: totals changed ${inv.Total}/${inv.AmountDue} → ${u?.Total}/${u?.AmountDue}`); process.exit(1); }
+if (!optSet) { console.error('WARN: posted but option not confirmed'); process.exit(1); }
+console.log(`✅ Re-tagged → ${canonical} | totals intact ($${u.Total}/${u.AmountDue}) | revert: scripts/output/retag-plasticians-revert-2026-05-30.json`);

--- a/thoughts/shared/financials/2026-05-30-locked-tracking-for-sl.md
+++ b/thoughts/shared/financials/2026-05-30-locked-tracking-for-sl.md
@@ -15,6 +15,33 @@ project classification isn't required for your process.
 **Ask:** apply the `→ Set` option to each invoice's line items (or advise if a manual journal /
 reclassification is the right mechanism for locked periods). No amounts change — this is dimensional tagging only.
 
+---
+
+## ⚠️ SEPARATE FINDING — $144K Goods grant booked as an expense (RECLASSIFICATION, not tagging)
+
+Surfaced 2026-05-30 during a per-project sense-check. **This is a misclassification that changes amounts**, unlike the dimension-tagging above. Confirmed with Ben: this is **The Funding Network "Goods" grant — income received for the Goods project (ACT-GD)** — but it is recorded in Xero as **Accounts Payable bills (expenses) coded to `ACT-CE` (Custodian Economy)**. There is **no income (ACCREC) record** for the grant anywhere in the ledger.
+
+| Ref | Date | Type | Status | Amount | Currently |
+|---|---|---|---|---|---|
+| (no #) | 2025-11-27 | ACCPAY | AUTHORISED (unpaid) | **$89,361** | ACT-CE expense |
+| (no #) | 2025-12-17 | ACCPAY | AUTHORISED (unpaid) | **$55,197** | ACT-CE expense |
+| R-8469621 | 2025-09-03 | ACCPAY | PAID | $6,000 | ACT-CE expense |
+| R-8469458 | 2025-09-03 | ACCPAY | PAID | $500 | ACT-CE expense |
+| | | | **Total** | **$151,058** | |
+
+**Effect of the error:** Goods income is understated by ~$144–151K and expenses overstated by the same, and **ACT-CE (Custodian Economy) shows a phantom ~$144K loss** it never incurred. The two large bills are AUTHORISED/unpaid — they will never be paid because they are not real payables.
+
+**Ask (SL):** reclassify The Funding Network amounts from AP expense (ACT-CE) to **Goods grant income (ACCREC / income account, `ACT-GD — Goods` Project Tracking)** — reverse/credit the AP bills and recognise the grant as income. Dates are unlocked (Sep–Dec 2025) but the treatment is an accounting decision, so flagging rather than auto-fixing. Please confirm the correct income account + mechanism.
+
+### More sense-check follow-ups (2026-05-30, confirmed with Ben)
+
+Two more AUTHORISED/unpaid AP bills surfaced in the same review (both `xero_tracking`, auto-pushed via Dext):
+
+1. **The Plasticians — $29,800** (2025-12-17, AUTHORISED). Xero `Project Tracking` = `ACT-IN`, but Ben confirms this is **plastic/HDPE materials for Goods beds → should be `ACT-GD — Goods`**. Unlocked + amount-unchanged, so this is a simple **Project Tracking re-tag in Xero** (same mechanism as the Phase 2 backfill) — does not need SL unless you'd prefer SL to do it. Once re-tagged in Xero + re-synced, $29.8K moves ACT-IN → Goods.
+2. **MOL Nyrt. — $30,691** (2026-03-27, AUTHORISED). Line item: "MOL Nyrt. — Other — ACT-IN **[native USD 30691.00 — adjustment]**". Vendor + the "native USD … adjustment" note suggest a **Dext/FX import artifact or duplicate**, not a genuine payable. **Ask (SL): verify this is a real bill; if it's an FX/import artifact, void it** — it's inflating ACT-IN expense and outstanding AP by ~$30K.
+
+---
+
 ## By project
 
 | project_code → option | invoices | total |


### PR DESCRIPTION
Outcome of a front-end sense-check of `/finance/project-money` (2026-05-30). Three things:

## 1. Standard Ledger findings doc (`3d041f7`)
Added to `thoughts/shared/financials/2026-05-30-locked-tracking-for-sl.md`:
- **TFN "Goods grant" $151K** booked as ACT-CE *expense* (no income record) — confirmed with Ben it's Goods grant *income*. SL to reclassify (reverse AP bills → ACCREC `ACT-GD` income). ACT-CE's −$144K is phantom; Goods understated ~$144K.
- **MOL Nyrt. $30,691** — "native USD adjustment" Dext artifact; SL to verify/void.
- Sweep of 2,018 AP bills confirms the grant-as-expense miscoding is isolated to TFN.

## 2. The Plasticians retag (`1b8d8f6`)
$29,800 Goods HDPE materials mis-tagged ACT-IN — retagged → ACT-GD in **live Xero** (tracking-only, totals intact, revert log). Tool `scripts/retag-plasticians-xero.mjs` reuses the Phase-2 safety harness.

## 3. UI: colored chips + Project Money → Transactions linking (`e9a9941`)
- `/finance/transactions`: the flat By-project / By-source chips are now color-coded (deterministic per-project palette; By-source by direction — spend/bill/receive), with an active-filter ring + code prefix.
- `/finance/project-money` rows now click through to `/finance/transactions?project=<code>` (the editable surface, pre-filtered), with a small P&L link kept.
- Default the transactions filter to `all` (UNTAGGED is empty now that FY26 is 100% tagged); fixed a URL-sync race that clobbered `?project=` on deep-link.

tsc clean. Scripts + docs + two finance pages — no changes to other surfaces.

Plan: 2026-05-30-xero-source-of-truth-goods-ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)