### PR TITLE
feat(finance): NAB Visa #8815 reconcile co-pilot (read-only, TDD'd)

### DIFF
--- a/apps/command-center/src/app/api/finance/reconcile/route.ts
+++ b/apps/command-center/src/app/api/finance/reconcile/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+import {
+  getReconcileCockpit,
+  RECONCILE_ACCOUNT,
+  RECONCILE_FY_END,
+  RECONCILE_FY_START,
+  type ReconcileActionFilter,
+  type ReconcileFilters,
+  type ReconcileLineResult,
+} from '@/lib/finance/reconcile'
+
+export const dynamic = 'force-dynamic'
+
+const ACTIONS: ReconcileActionFilter[] = ['all', 'duplicate', 'match_bill', 'approve_draft', 'match_txn', 'transfer', 'refund', 'already_reconciled', 'create']
+
+function parseAction(value: string | null): ReconcileActionFilter {
+  return ACTIONS.includes(value as ReconcileActionFilter) ? (value as ReconcileActionFilter) : 'all'
+}
+
+// 'date' mirrors Xero's reconcile screen order (oldest-first); 'action' groups by recommendation.
+// Undefined → the engine's default (action order), so the param is fully back-compat.
+function parseSort(value: string | null): 'action' | 'date' | undefined {
+  return value === 'date' || value === 'action' ? value : undefined
+}
+
+function parseLimit(value: string | null): number {
+  return Math.min(Math.max(parseInt(value || '300', 10), 50), 500)
+}
+
+function parseMinAmount(value: string | null): number {
+  const n = parseFloat(value || '0')
+  return Number.isFinite(n) && n > 0 ? n : 0
+}
+
+const IMAGE_EXT = /\.(jpe?g|png|gif|webp|heic|bmp|tiff?)$/i
+
+// Receipt attachment_url is a storage path inside the 'receipt-attachments' bucket
+// (the 'dext-import/' folder lives there too). Mirrors signedUrlFor in
+// api/finance/receipts-triage/route.ts.
+async function signedUrlFor(path: string | null): Promise<string | null> {
+  if (!path) return null
+  const storagePath = path.startsWith('receipt-attachments/') ? path.replace('receipt-attachments/', '') : path
+  try {
+    const { data, error } = await supabase.storage.from('receipt-attachments').createSignedUrl(storagePath, 3600)
+    if (error) return null
+    return data?.signedUrl ?? null
+  } catch {
+    return null
+  }
+}
+
+interface ApiLineResult extends ReconcileLineResult {
+  receiptSignedUrl: string | null
+  receiptIsImage: boolean
+}
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams
+  const filters: ReconcileFilters = {
+    action: parseAction(params.get('action')),
+    q: (params.get('q') || '').trim(),
+    minAmount: parseMinAmount(params.get('minAmount')),
+    limit: parseLimit(params.get('limit')),
+    sort: parseSort(params.get('sort')),
+  }
+  const window = {
+    start: params.get('start') || RECONCILE_FY_START,
+    end: params.get('end') || RECONCILE_FY_END,
+    account: params.get('account') || RECONCILE_ACCOUNT,
+  }
+
+  try {
+    const cockpit = await getReconcileCockpit(filters, window)
+
+    // Sign receipt images only for the returned (paged) lines that carry one.
+    const results: ApiLineResult[] = await Promise.all(
+      cockpit.results.map(async (r) => ({
+        ...r,
+        receiptSignedUrl: r.receiptUrl ? await signedUrlFor(r.receiptUrl) : null,
+        receiptIsImage: r.receiptUrl ? IMAGE_EXT.test(r.receiptUrl) : false,
+      }))
+    )
+
+    return NextResponse.json({ ...cockpit, results })
+  } catch (error) {
+    console.error('[finance/reconcile] GET failed:', error)
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 })
+  }
+}

--- a/apps/command-center/src/app/finance/reconcile/page.tsx
+++ b/apps/command-center/src/app/finance/reconcile/page.tsx
@@ -1,0 +1,731 @@
+'use client'
+
+import { useDeferredValue, useState } from 'react'
+import Link from 'next/link'
+import { useQuery } from '@tanstack/react-query'
+import {
+  ArrowLeft,
+  ArrowLeftRight,
+  Check,
+  CheckCheck,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Copy,
+  ExternalLink,
+  FileCheck2,
+  Link2,
+  Loader2,
+  PlusCircle,
+  Receipt,
+  ScanSearch,
+  Search,
+  ShieldAlert,
+  Undo2,
+  Zap,
+} from 'lucide-react'
+import { formatMoney } from '@/lib/finance/format'
+import { cn } from '@/lib/utils'
+
+// Mirrors ReconcileAction + ApiLineResult in the engine / route. Read-only co-pilot.
+type ReconcileAction =
+  | 'match_bill'
+  | 'approve_draft'
+  | 'match_txn'
+  | 'already_reconciled'
+  | 'duplicate'
+  | 'create'
+  | 'transfer'
+  | 'refund'
+type ActionFilter = ReconcileAction | 'all'
+type SortMode = 'date' | 'action'
+
+interface CardLine {
+  id: string
+  date: string | null
+  vendor: string
+  amount: number
+  status: string | null
+  projectCode: string | null
+  bankAccount: string | null
+  direction?: 'debit' | 'credit'
+}
+
+interface MatchedRef {
+  contactName: string | null
+  date: string | null
+  amount: number
+  status?: string | null
+  isReconciled?: boolean | null
+  xeroId?: string | null // bill InvoiceID
+  xeroTxnId?: string | null // BankTransactionID
+}
+
+interface LineResult {
+  line: CardLine
+  action: ReconcileAction
+  matchedBill?: MatchedRef
+  matchedTxn?: MatchedRef
+  surcharge: number
+  suggestedProject: string | null
+  suggestedAccount: string | null
+  receiptUrl: string | null
+  receiptSignedUrl: string | null
+  receiptIsImage: boolean
+  fromDext: boolean
+  note: string
+  danger: boolean
+  offsetLineId?: string
+  ruleCovered?: boolean
+}
+
+interface BankRule {
+  matchText: string
+  contactName: string
+  lineCount: number
+  totalValue: number
+  account: string
+  accountConfident: boolean
+  defaultProject: string | null
+  taxHint: string
+  uncertainTax: boolean
+}
+
+interface BankRulePack {
+  rules: BankRule[]
+  ruleCount: number
+  coveredLineCount: number
+  coveredValue: number
+  coveredLineIds: string[]
+}
+
+interface Summary {
+  totalLines: number
+  totalValue: number
+  matchCount: number
+  matchValue: number
+  duplicateCount: number
+  duplicateValue: number
+  createCount: number
+  createValue: number
+  alreadyReconciledCount: number
+  alreadyReconciledValue: number
+  transferCount: number
+  transferValue: number
+  refundCount: number
+  refundValue: number
+  surchargeCount: number
+  surchargeTotal: number
+}
+
+interface ReconcileResponse {
+  window: { start: string; end: string; account: string }
+  filters: { action: ActionFilter; q: string; minAmount: number; limit: number; sort?: SortMode }
+  summary: Summary
+  bankRules: BankRulePack
+  totalMatching: number
+  results: LineResult[]
+  projects: { code: string; name: string | null }[]
+}
+
+const ACTION_META: Record<ReconcileAction, { label: string; xeroVerb: string; icon: typeof Link2; chip: string; bar: string }> = {
+  duplicate: { label: 'Duplicate', xeroVerb: 'Delete the duplicate card txn, match the bill', icon: Copy, chip: 'bg-red-400/15 text-red-100 border-red-400/30', bar: 'bg-red-400/70' },
+  match_bill: { label: 'Match bill', xeroVerb: 'Match this bank line to the bill', icon: Link2, chip: 'bg-cyan-400/15 text-cyan-100 border-cyan-400/30', bar: 'bg-cyan-400/70' },
+  approve_draft: { label: 'Approve draft', xeroVerb: 'Approve the draft bill, then match', icon: FileCheck2, chip: 'bg-amber-400/15 text-amber-100 border-amber-400/30', bar: 'bg-amber-400/70' },
+  match_txn: { label: 'Match txn', xeroVerb: 'Match to the existing card txn', icon: Link2, chip: 'bg-sky-400/15 text-sky-100 border-sky-400/30', bar: 'bg-sky-400/70' },
+  transfer: { label: 'Transfer', xeroVerb: 'Code as Transfer from ACT Everyday', icon: ArrowLeftRight, chip: 'bg-blue-400/15 text-blue-100 border-blue-400/30', bar: 'bg-blue-400/70' },
+  refund: { label: 'Refund', xeroVerb: 'Offset the original charge / match a credit note', icon: Undo2, chip: 'bg-teal-400/15 text-teal-100 border-teal-400/30', bar: 'bg-teal-400/70' },
+  already_reconciled: { label: 'Already in Xero', xeroVerb: 'Verify the existing entry — do NOT create', icon: CheckCheck, chip: 'bg-violet-400/15 text-violet-100 border-violet-400/30', bar: 'bg-violet-400/70' },
+  create: { label: 'Create', xeroVerb: 'Create a coded transaction', icon: PlusCircle, chip: 'bg-emerald-400/15 text-emerald-100 border-emerald-400/30', bar: 'bg-emerald-400/70' },
+}
+
+function dateLabel(date: string | null): string {
+  if (!date) return 'No date'
+  return new Intl.DateTimeFormat('en-AU', { day: '2-digit', month: 'short', year: 'numeric' }).format(new Date(`${date}T00:00:00`))
+}
+
+const XERO_AP_SEARCH = 'https://go.xero.com/app/!/accounting/purchases/invoices'
+
+async function fetchReconcile(params: { action: ActionFilter; q: string; minAmount: number; sort: SortMode }): Promise<ReconcileResponse> {
+  const qs = new URLSearchParams()
+  qs.set('action', params.action)
+  qs.set('sort', params.sort)
+  qs.set('limit', '400')
+  if (params.q.trim()) qs.set('q', params.q.trim())
+  if (params.minAmount > 0) qs.set('minAmount', String(params.minAmount))
+  const res = await fetch(`/api/finance/reconcile?${qs.toString()}`)
+  const data = await res.json()
+  if (!res.ok) throw new Error(data.error || 'Failed to load reconciliation cockpit')
+  return data
+}
+
+// Copy the full Xero ID; show a short, scannable label. The reconcile screen matches on
+// AMOUNT not date, so the exact ID is how Ben confirms he's on the right row.
+function CopyId({ id, label }: { id: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(id)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1200)
+      }}
+      title={`Copy ${label} — ${id}`}
+      className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.04] px-2 py-1 text-[11px] text-white/55 transition hover:border-cyan-300/40 hover:text-white"
+    >
+      {copied ? <Check className="h-3 w-3 text-emerald-300" /> : <Copy className="h-3 w-3" />}
+      <span className="text-white/40">{label}</span>
+      <span className="font-mono text-white/75">{id.slice(0, 8)}…</span>
+    </button>
+  )
+}
+
+// Copy arbitrary text (a rule spec, the whole pack) with a brief "copied" tick.
+function CopyText({ text, label }: { text: string; label: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(text)
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1200)
+      }}
+      className="inline-flex items-center gap-1.5 rounded-lg border border-white/10 bg-white/[0.04] px-2.5 py-1 text-xs text-white/65 transition hover:border-cyan-300/40 hover:text-white"
+    >
+      {copied ? <Check className="h-3.5 w-3.5 text-emerald-300" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? 'Copied' : label}
+    </button>
+  )
+}
+
+function ruleSpec(r: BankRule): string {
+  return [
+    `Bank rule — when Payee contains "${r.matchText}":`,
+    `  Contact:  ${r.contactName}`,
+    `  Account:  ${r.account}`,
+    `  Tax:      ${r.taxHint}`,
+    `  Tracking: ${r.defaultProject || '(set project)'}`,
+    `  (covers ${r.lineCount} line${r.lineCount === 1 ? '' : 's'}, $${r.totalValue.toFixed(2)})`,
+  ].join('\n')
+}
+
+// "Do this first" — the matching-killer. Each rule, set once in Xero's UI, makes its
+// vendor's lines arrive pre-filled so Ben just clicks OK. No bank-rules API, so it's
+// copy-paste; review tax/project before saving (rules fire silently).
+function RuleRow({ r }: { r: BankRule }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+      <span className="rounded-lg bg-cyan-300/10 px-2 py-1 font-mono text-xs text-cyan-100">payee contains “{r.matchText}”</span>
+      <span className="text-sm text-white/85">{r.contactName}</span>
+      <span className={cn('text-xs', r.accountConfident ? 'text-white/65' : 'text-amber-200')}>
+        {r.account}
+        {!r.accountConfident && ' · set once'}
+      </span>
+      {r.defaultProject && (
+        <span className="rounded-md bg-white/[0.06] px-2 py-0.5 font-mono text-xs text-white/75">{r.defaultProject}</span>
+      )}
+      <span className={cn('text-xs', r.uncertainTax ? 'text-amber-200' : 'text-white/45')}>
+        {r.uncertainTax ? '⚠ ' : ''}
+        {r.taxHint}
+      </span>
+      <span className="ml-auto text-xs text-white/45">
+        {r.lineCount} lines · {formatMoney(r.totalValue)}
+      </span>
+      <CopyText text={ruleSpec(r)} label="Copy" />
+    </div>
+  )
+}
+
+const RULE_PRIMARY_MIN_LINES = 3 // 3+ lines = a rule clearly beats hand-coding; 2-line tail is break-even
+
+function BankRulesPanel({ pack }: { pack: BankRulePack }) {
+  const [open, setOpen] = useState(true)
+  const [showTail, setShowTail] = useState(false)
+  if (!pack || pack.ruleCount === 0) return null
+
+  const primary = pack.rules.filter((r) => r.lineCount >= RULE_PRIMARY_MIN_LINES)
+  const tail = pack.rules.filter((r) => r.lineCount < RULE_PRIMARY_MIN_LINES)
+  const primaryLines = primary.reduce((s, r) => s + r.lineCount, 0)
+
+  const copyAll = [
+    `# NAB Visa #8815 — bank rules to set in Xero (Accounting → Bank rules)`,
+    `# Set once → ${pack.coveredLineCount} lines (${formatMoney(pack.coveredValue)}) become one-click OK Creates, no matching.`,
+    `# Top ${primary.length} rules (3+ lines) cover ${primaryLines} of them — set those first.`,
+    `# Review tax + project before saving — rules fire silently.`,
+    '',
+    ...pack.rules.map(ruleSpec),
+  ].join('\n\n')
+
+  return (
+    <section className="mt-8 rounded-3xl border border-cyan-300/25 bg-cyan-300/[0.06] p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <button type="button" onClick={() => setOpen((v) => !v)} className="flex items-center gap-2 text-left">
+          {open ? <ChevronDown className="h-4 w-4 text-cyan-200" /> : <ChevronRight className="h-4 w-4 text-cyan-200" />}
+          <Zap className="h-5 w-5 text-cyan-200" />
+          <div>
+            <h2 className="text-base font-semibold text-white">
+              Set {primary.length} high-leverage bank rules → {primaryLines} lines become one-click OK
+            </h2>
+            <p className="text-xs text-white/55">
+              The whole pack of {pack.ruleCount} rules covers {pack.coveredLineCount} lines ({formatMoney(pack.coveredValue)}) —
+              but the top {primary.length} (3+ lines each) kill most of the matching. No typing, no hunting.
+            </p>
+          </div>
+        </button>
+        <CopyText text={copyAll} label="Copy all rules" />
+      </div>
+
+      {open && (
+        <>
+          <p className="mt-3 text-xs leading-5 text-cyan-50/60">
+            Xero has no bank-rules API, so paste each into <span className="text-cyan-100">Accounting → Bank rules</span>{' '}
+            (match on payee contains the text → set contact + account + tax + tracking), then run it over the open lines.
+            Review tax and project before saving — rules fire silently, so a wrong default bakes in on a fast OK.
+          </p>
+          <div className="mt-4 space-y-2">
+            {primary.map((r) => (
+              <RuleRow key={r.matchText} r={r} />
+            ))}
+          </div>
+
+          {tail.length > 0 && (
+            <div className="mt-3">
+              <button
+                type="button"
+                onClick={() => setShowTail((v) => !v)}
+                className="inline-flex items-center gap-1.5 text-xs text-white/45 transition hover:text-white"
+              >
+                {showTail ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                {showTail ? 'Hide' : 'Show'} {tail.length} low-volume rules (2 lines each — break-even vs hand-coding in the co-pilot)
+              </button>
+              {showTail && (
+                <div className="mt-2 space-y-2">
+                  {tail.map((r) => (
+                    <RuleRow key={r.matchText} r={r} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+function StatCard({
+  title,
+  value,
+  detail,
+  icon: Icon,
+  active,
+  onClick,
+}: {
+  title: string
+  value: string
+  detail: string
+  icon: typeof Receipt
+  active?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-3xl border border-white/10 bg-white/[0.04] p-4 text-left transition hover:border-cyan-300/40 hover:bg-cyan-300/10',
+        active && 'border-cyan-300/50 bg-cyan-300/10'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.24em] text-white/40">{title}</p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-white">{value}</p>
+        </div>
+        <Icon className="h-5 w-5 text-cyan-200" />
+      </div>
+      <p className="mt-2 text-xs leading-5 text-white/50">{detail}</p>
+    </button>
+  )
+}
+
+function RefBadge({ label, ref: r }: { label: string; ref: MatchedRef }) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-2">
+      <p className="text-[10px] uppercase tracking-[0.2em] text-white/40">{label}</p>
+      <p className="mt-1 text-sm text-white/85">{r.contactName || 'Unknown contact'}</p>
+      <p className="mt-0.5 text-xs text-white/45">
+        {formatMoney(r.amount)} · {dateLabel(r.date)}
+        {r.status ? ` · ${r.status}` : ''}
+        {r.isReconciled === false ? ' · unreconciled' : ''}
+      </p>
+      {(r.xeroTxnId || r.xeroId) && (
+        <div className="mt-2">
+          {r.xeroTxnId ? (
+            <CopyId id={r.xeroTxnId} label="BankTransactionID" />
+          ) : (
+            <CopyId id={r.xeroId!} label="Bill ID" />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LineCard({ r }: { r: LineResult }) {
+  const meta = ACTION_META[r.action]
+  const Icon = meta.icon
+  const isCredit = r.line.direction === 'credit'
+  return (
+    <article className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/[0.03]">
+      <div className={cn('absolute inset-y-0 left-0 w-1', r.danger ? 'bg-red-500' : meta.bar)} />
+      <div className="grid grid-cols-1 lg:grid-cols-2">
+        {/* LEFT — the bank line, as Xero shows it on the reconcile screen */}
+        <div className="p-5 pl-6">
+          <p className="text-[10px] uppercase tracking-[0.2em] text-white/35">
+            Bank line · {isCredit ? 'credit (money in)' : 'debit'}
+          </p>
+          <h3 className="mt-2 truncate text-lg font-semibold text-white">{r.line.vendor}</h3>
+          <p className="mt-1 text-xs text-white/45">
+            {dateLabel(r.line.date)}
+            {r.line.projectCode ? ` · tagged ${r.line.projectCode}` : ' · untagged'}
+          </p>
+          <p className={cn('mt-3 text-2xl font-semibold tracking-tight', isCredit ? 'text-emerald-200' : 'text-white')}>
+            {isCredit ? '+' : ''}
+            {formatMoney(r.line.amount)}
+          </p>
+          <p className="mt-3 inline-flex items-center gap-1.5 text-[11px] text-white/35">
+            <Clock className="h-3 w-3" />
+            mirror: {r.line.status || 'unreconciled'} — snapshot, confirm live in Xero
+          </p>
+        </div>
+
+        {/* RIGHT — what to do in Xero */}
+        <div className="border-t border-white/10 bg-white/[0.02] p-5 lg:border-l lg:border-t-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={cn('inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium', meta.chip)}>
+              <Icon className="h-3.5 w-3.5" />
+              {meta.label}
+            </span>
+            {r.danger && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-red-400/40 bg-red-500/15 px-2.5 py-1 text-xs font-semibold text-red-100">
+                <ShieldAlert className="h-3.5 w-3.5" /> DANGER — real payment or phantom?
+              </span>
+            )}
+            {Math.abs(r.surcharge) >= 0.005 && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/30 bg-amber-400/10 px-2.5 py-1 text-xs text-amber-100">
+                ⚠️ surcharge {r.surcharge > 0 ? '+' : '−'}${Math.abs(r.surcharge).toFixed(2)}
+              </span>
+            )}
+            {r.offsetLineId && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-teal-400/25 bg-teal-400/10 px-2.5 py-1 text-xs text-teal-100">
+                ↔ offsets a charge
+              </span>
+            )}
+            {r.fromDext && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/25 bg-emerald-400/10 px-2.5 py-1 text-xs text-emerald-100">
+                <Receipt className="h-3 w-3" /> receipt
+              </span>
+            )}
+            {r.ruleCovered && (
+              <span className="inline-flex items-center gap-1 rounded-full border border-cyan-300/30 bg-cyan-300/10 px-2.5 py-1 text-xs text-cyan-100">
+                <Zap className="h-3 w-3" /> bank rule → one-click
+              </span>
+            )}
+          </div>
+
+          <div className="mt-3 rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-2.5">
+            <p className="text-[10px] uppercase tracking-[0.2em] text-cyan-200/60">In Xero</p>
+            {r.ruleCovered ? (
+              <p className="mt-1 text-sm font-medium leading-6 text-cyan-100">
+                Set the bank rule (above) → this lands pre-filled, just click OK. No matching.
+              </p>
+            ) : (
+              <p className="mt-1 text-sm font-medium leading-6 text-white/90">{meta.xeroVerb}</p>
+            )}
+            <p className="mt-1 text-sm leading-6 text-white/55">{r.note}</p>
+          </div>
+
+          {(r.suggestedProject || r.suggestedAccount) && (
+            <div className="mt-3 flex flex-wrap gap-2 text-xs">
+              {r.suggestedProject && (
+                <span className="rounded-lg bg-white/[0.06] px-2 py-1 text-white/70">
+                  project: <span className="font-mono text-white/90">{r.suggestedProject}</span>
+                </span>
+              )}
+              {r.suggestedAccount && (
+                <span className="rounded-lg bg-white/[0.06] px-2 py-1 text-white/70">
+                  account: <span className="text-white/90">{r.suggestedAccount}</span>
+                </span>
+              )}
+            </div>
+          )}
+
+          {(r.matchedBill || r.matchedTxn || r.receiptSignedUrl) && (
+            <div className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+              {r.matchedBill && <RefBadge label="Xero bill" ref={r.matchedBill} />}
+              {r.matchedTxn && <RefBadge label="Card txn" ref={r.matchedTxn} />}
+              {r.receiptSignedUrl && (
+                <a
+                  href={r.receiptSignedUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group flex items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.03] px-3 py-2 transition hover:border-emerald-300/40"
+                >
+                  {r.receiptIsImage ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={r.receiptSignedUrl} alt="receipt" className="h-12 w-12 rounded-lg object-cover" />
+                  ) : (
+                    <Receipt className="h-6 w-6 text-emerald-200" />
+                  )}
+                  <div>
+                    <p className="text-[10px] uppercase tracking-[0.2em] text-white/40">Receipt</p>
+                    <p className="text-sm text-emerald-100 group-hover:underline">View {r.receiptIsImage ? 'image' : 'file'}</p>
+                  </div>
+                </a>
+              )}
+            </div>
+          )}
+
+          {(r.action === 'match_bill' || r.action === 'approve_draft' || r.action === 'duplicate' || r.action === 'already_reconciled') && (
+            <a
+              href={XERO_AP_SEARCH}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-white/10 px-2.5 py-1 text-xs text-white/60 transition hover:border-cyan-300/40 hover:text-white"
+            >
+              Open Xero bills <ExternalLink className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+export default function ReconcileCockpitPage() {
+  const [action, setAction] = useState<ActionFilter>('all')
+  const [search, setSearch] = useState('')
+  const [minAmount, setMinAmount] = useState(0)
+  const [sort, setSort] = useState<SortMode>('date')
+  const [dangerOnly, setDangerOnly] = useState(false)
+  const deferredSearch = useDeferredValue(search)
+
+  const query = useQuery({
+    queryKey: ['finance', 'reconcile', action, deferredSearch, minAmount, sort],
+    queryFn: () => fetchReconcile({ action, q: deferredSearch, minAmount, sort }),
+  })
+
+  const data = query.data
+  const summary = data?.summary
+  const allResults = data?.results || []
+  const results = dangerOnly ? allResults.filter((r) => r.danger) : allResults
+  const dangerCount = allResults.filter((r) => r.danger).length
+
+  return (
+    <main className="min-h-screen overflow-hidden bg-[#05070a] text-white">
+      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_90%_20%,rgba(248,113,113,0.16),transparent_30%),linear-gradient(135deg,rgba(15,23,42,0.9),rgba(2,6,23,0.94))]" />
+      <div className="relative mx-auto max-w-[1560px] px-6 py-8">
+        <Link href="/finance" className="mb-6 inline-flex items-center gap-2 text-sm text-white/45 transition hover:text-white">
+          <ArrowLeft className="h-4 w-4" />
+          Finance
+        </Link>
+
+        <header className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_420px] lg:items-start">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs uppercase tracking-[0.24em] text-cyan-100/75">
+              <ScanSearch className="h-3.5 w-3.5" />
+              Reconciliation Cockpit
+            </div>
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight md:text-5xl">
+              Every NAB Visa line, beside your Xero screen.
+            </h1>
+            <p className="mt-4 max-w-4xl text-sm leading-6 text-white/60">
+              Read down in lockstep with Xero&apos;s reconcile screen (oldest-first). For each line the
+              co-pilot says exactly what to do: match a bill (adding any card surcharge), kill a duplicate,
+              code a Transfer for a card repayment, offset a refund, or create a coded transaction with the
+              learned project and receipt image. You transcribe; you don&apos;t decide.
+            </p>
+          </div>
+
+          <aside className="rounded-3xl border border-amber-300/20 bg-amber-500/[0.08] p-5">
+            <div className="flex gap-3">
+              <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-amber-200" />
+              <div>
+                <h2 className="font-semibold text-amber-50">Read-only — the reconcile click stays in Xero</h2>
+                <p className="mt-2 text-sm leading-6 text-amber-50/70">
+                  The Xero API cannot set IsReconciled (Xero policy, 6 May 2026). Statuses here are a mirror
+                  snapshot — the live state is always in Xero. <span className="font-semibold text-amber-50">DANGER</span> lines
+                  match an AUTHORISED (unpaid) bill: a real payment or a phantom to void, so check each one.
+                </p>
+              </div>
+            </div>
+          </aside>
+        </header>
+
+        {data?.bankRules && <BankRulesPanel pack={data.bankRules} />}
+
+        {summary && (
+          <section className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <StatCard
+              title="To reconcile"
+              value={summary.totalLines.toLocaleString()}
+              detail={`${formatMoney(summary.totalValue)} of unreconciled card lines`}
+              icon={ScanSearch}
+              active={action === 'all'}
+              onClick={() => setAction('all')}
+            />
+            <StatCard
+              title="Duplicates"
+              value={summary.duplicateCount.toLocaleString()}
+              detail={`${formatMoney(summary.duplicateValue)} double-counted — delete the card txn`}
+              icon={Copy}
+              active={action === 'duplicate'}
+              onClick={() => setAction('duplicate')}
+            />
+            <StatCard
+              title="Match to bill"
+              value={summary.matchCount.toLocaleString()}
+              detail={`${formatMoney(summary.matchValue)} have a bill/txn to match`}
+              icon={Link2}
+              active={action === 'match_bill'}
+              onClick={() => setAction('match_bill')}
+            />
+            <StatCard
+              title="Transfers"
+              value={summary.transferCount.toLocaleString()}
+              detail={`${formatMoney(summary.transferValue)} card repayments — code as Transfer, not income`}
+              icon={ArrowLeftRight}
+              active={action === 'transfer'}
+              onClick={() => setAction('transfer')}
+            />
+            <StatCard
+              title="Refunds"
+              value={summary.refundCount.toLocaleString()}
+              detail={`${formatMoney(summary.refundValue)} merchant credits — offset the charge`}
+              icon={Undo2}
+              active={action === 'refund'}
+              onClick={() => setAction('refund')}
+            />
+            <StatCard
+              title="Already in Xero"
+              value={summary.alreadyReconciledCount.toLocaleString()}
+              detail={`${formatMoney(summary.alreadyReconciledValue)} match a reconciled txn — verify, don't create`}
+              icon={CheckCheck}
+              active={action === 'already_reconciled'}
+              onClick={() => setAction('already_reconciled')}
+            />
+            <StatCard
+              title="Create"
+              value={summary.createCount.toLocaleString()}
+              detail={`${formatMoney(summary.createValue)} need a coded transaction`}
+              icon={PlusCircle}
+              active={action === 'create'}
+              onClick={() => setAction('create')}
+            />
+            <StatCard
+              title="Surcharges"
+              value={summary.surchargeCount.toLocaleString()}
+              detail={`${formatMoney(summary.surchargeTotal)} of card fees to add as Adjustments`}
+              icon={ShieldAlert}
+            />
+          </section>
+        )}
+
+        <section className="mt-6 flex flex-wrap items-center gap-3">
+          <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2">
+            <Search className="h-4 w-4 text-white/40" />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search vendor, project, account…"
+              className="w-64 bg-transparent text-sm text-white placeholder:text-white/30 focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.04] px-3 py-2 text-sm text-white/60">
+            <span className="text-white/40">min $</span>
+            <input
+              type="number"
+              min={0}
+              value={minAmount || ''}
+              onChange={(e) => setMinAmount(Math.max(0, Number(e.target.value) || 0))}
+              placeholder="0"
+              className="w-20 bg-transparent text-white placeholder:text-white/30 focus:outline-none"
+            />
+          </div>
+
+          {/* Sort — date mirrors Xero's reconcile screen order (read down in lockstep) */}
+          <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-white/[0.04] p-1 text-sm">
+            <button
+              type="button"
+              onClick={() => setSort('date')}
+              className={cn('rounded-xl px-3 py-1.5 transition', sort === 'date' ? 'bg-cyan-300/15 text-white' : 'text-white/50 hover:text-white')}
+            >
+              Xero order
+            </button>
+            <button
+              type="button"
+              onClick={() => setSort('action')}
+              className={cn('rounded-xl px-3 py-1.5 transition', sort === 'action' ? 'bg-cyan-300/15 text-white' : 'text-white/50 hover:text-white')}
+            >
+              By action
+            </button>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setDangerOnly((v) => !v)}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-2xl border px-3 py-2 text-sm transition',
+              dangerOnly
+                ? 'border-red-400/50 bg-red-500/15 text-red-100'
+                : 'border-white/10 text-white/55 hover:text-white'
+            )}
+          >
+            <ShieldAlert className="h-4 w-4" />
+            Danger only{dangerCount ? ` (${dangerCount})` : ''}
+          </button>
+
+          {action !== 'all' && (
+            <button
+              type="button"
+              onClick={() => setAction('all')}
+              className="rounded-2xl border border-white/10 px-3 py-2 text-sm text-white/55 transition hover:text-white"
+            >
+              Clear action filter ({ACTION_META[action as ReconcileAction]?.label})
+            </button>
+          )}
+          <span className="ml-auto text-sm text-white/45">
+            {query.isFetching ? (
+              <span className="inline-flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+              </span>
+            ) : data ? (
+              `${results.length} shown · ${data.totalMatching.toLocaleString()} matching`
+            ) : null}
+          </span>
+        </section>
+
+        {query.isError && (
+          <div className="mt-8 rounded-3xl border border-red-400/30 bg-red-500/10 p-6 text-red-100">
+            {(query.error as Error).message}
+          </div>
+        )}
+
+        {data && results.length === 0 && !query.isFetching && (
+          <div className="mt-8 rounded-3xl border border-white/10 bg-white/[0.03] p-10 text-center text-white/50">
+            {dangerOnly ? 'No DANGER lines in this view.' : 'No card lines match these filters.'}
+          </div>
+        )}
+
+        <section className="mt-6 space-y-3 pb-16">
+          {results.map((r) => (
+            <LineCard key={r.line.id} r={r} />
+          ))}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/command-center/src/lib/finance/reconcile.test.ts
+++ b/apps/command-center/src/lib/finance/reconcile.test.ts
@@ -1,0 +1,328 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  amountCloseness,
+  buildBankRulePack,
+  buildReconcileResponse,
+  classifyLine,
+  normalizeVendor,
+  summarizeReconcile,
+  surchargeOf,
+  vendorMatch,
+  type CardLine,
+  type DextCoding,
+  type ReconcileContext,
+  type ReconcileFilters,
+  type XeroBill,
+  type XeroSpendTxn,
+} from './reconcile'
+
+// ---------------------------------------------------------------------------
+// Amount closeness — the surcharge engine. A bank charge is often the receipt
+// amount + a card surcharge, so exact-amount matching alone fails. 'exact' wins
+// over 'surcharge'; anything outside the tight band is no match.
+// ---------------------------------------------------------------------------
+test('amountCloseness: exact within half a cent', () => {
+  assert.equal(amountCloseness(100, 100), 'exact')
+  assert.equal(amountCloseness(100.004, 100), 'exact')
+})
+
+test('amountCloseness: surcharge band (<=$15 and <=6% of ref)', () => {
+  // Centre Trailer: bank $424.91 vs $420 bill = $4.91 surcharge → in band
+  assert.equal(amountCloseness(424.91, 420), 'surcharge')
+  assert.equal(amountCloseness(105, 100), 'surcharge') // $5 / 5%
+})
+
+test('amountCloseness: rejects gaps that are too large by dollars or by percent', () => {
+  assert.equal(amountCloseness(120, 100), null) // $20 > $15 cap
+  assert.equal(amountCloseness(7, 6), null) // $1 but 16.7% > 6% cap
+  assert.equal(amountCloseness(2000, 1980), null) // $20 > $15 cap even though <6%
+})
+
+test('surchargeOf: bank minus matched reference, 2dp', () => {
+  assert.equal(surchargeOf(424.91, 420), 4.91)
+  assert.equal(surchargeOf(100, 100), 0)
+})
+
+// ---------------------------------------------------------------------------
+// Vendor matching — token overlap after normalisation. The stricter vendor
+// gate (commit adba653) means a matching amount alone must NOT match.
+// ---------------------------------------------------------------------------
+test('normalizeVendor strips card prefixes, suffixes, digits, punctuation', () => {
+  assert.equal(normalizeVendor('SQ *NEST IN WITTA'), 'NEST IN WITTA')
+  assert.equal(normalizeVendor('AMZNPRIME MEMBERSHIP 1234'), 'AMZNPRIME MEMBERSHIP') // digits gone
+  assert.equal(normalizeVendor('HATCH ELECTRICAL PTY LTD'), 'HATCH ELECTRICAL') // suffix gone
+})
+
+test('vendorMatch: shared significant token matches; unrelated names do not', () => {
+  assert.equal(vendorMatch('OPENAI CHATGPT', 'OpenAI'), true)
+  assert.equal(vendorMatch('BOOKING.COM AMSTERDAM', 'Booking.com'), true)
+  assert.equal(vendorMatch('CENTRE TRAILER SALES', 'Random Vendor Xyz'), false)
+})
+
+// ---------------------------------------------------------------------------
+// Classification cascade + a 5-line summary with hand-computed totals.
+// ---------------------------------------------------------------------------
+const lines: CardLine[] = [
+  // 1. surcharge bill match: bank $424.91 vs bill $420 → MATCH_BILL, surcharge $4.91
+  { id: 'L1', date: '2025-10-07', vendor: 'CENTRE TRAILER SALES CICCONE', amount: 424.91, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+  // 2. duplicate: bank $239 has BOTH a bill AND a card txn → DUPLICATE
+  { id: 'L2', date: '2025-10-14', vendor: 'BOOKING.COM AMSTERDAM', amount: 239, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+  // 3. create from Dext: no bill/txn, Dext has coding + receipt image
+  { id: 'L3', date: '2025-10-29', vendor: 'OPENAI CHATGPT', amount: 33.63, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+  // 4. create heuristic: AMZNPRIME → no match anywhere → Drawings guess
+  { id: 'L4', date: '2025-10-16', vendor: 'AMZNPRIME MEMBERSHIP', amount: 9.99, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+  // 5. vendor-gate guard: amount matches a bill but vendor does NOT → CREATE, not match
+  { id: 'L5', date: '2025-10-20', vendor: 'MYSTERY MERCHANT 1234', amount: 420, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+]
+
+const bills: XeroBill[] = [
+  { contactName: 'Centre Trailer Sales', date: '2025-10-07', amount: 420, status: 'AUTHORISED', hasAttachments: true },
+  { contactName: 'Booking.com', date: '2025-10-14', amount: 239, status: 'AUTHORISED', hasAttachments: true },
+]
+
+const txns: XeroSpendTxn[] = [
+  { contactName: 'Booking.com', date: '2025-10-14', amount: 239, isReconciled: false },
+]
+
+const dext: DextCoding[] = [
+  { vendor: 'OpenAI', project: 'ACT-RD', amount: 33.63, date: '2025-10-29', receiptUrl: 'https://example.test/openai.png' },
+]
+
+const ctx: ReconcileContext = { bills, txns, dext }
+
+test('classifyLine: surcharge bill match', () => {
+  const r = classifyLine(lines[0], ctx)
+  assert.equal(r.action, 'match_bill')
+  assert.equal(r.surcharge, 4.91)
+  assert.equal(r.matchedBill?.contactName, 'Centre Trailer Sales')
+})
+
+test('classifyLine: duplicate when both a bill and a card txn match', () => {
+  const r = classifyLine(lines[1], ctx)
+  assert.equal(r.action, 'duplicate')
+  assert.equal(r.surcharge, 0)
+})
+
+test('classifyLine: create from Dext carries coding + receipt image', () => {
+  const r = classifyLine(lines[2], ctx)
+  assert.equal(r.action, 'create')
+  assert.equal(r.fromDext, true)
+  assert.equal(r.suggestedProject, 'ACT-RD')
+  assert.equal(r.receiptUrl, 'https://example.test/openai.png')
+})
+
+test('classifyLine: heuristic create flags AMZNPRIME as drawings/personal', () => {
+  const r = classifyLine(lines[3], ctx)
+  assert.equal(r.action, 'create')
+  assert.equal(r.fromDext, false)
+  assert.match(r.suggestedAccount || '', /Drawings/i)
+})
+
+test('classifyLine: vendor gate — matching amount with wrong vendor does NOT match', () => {
+  const r = classifyLine(lines[4], ctx)
+  assert.equal(r.action, 'create')
+  assert.equal(r.matchedBill, undefined)
+})
+
+test('classifyLine: a matching but already-reconciled txn blocks CREATE (no double-count)', () => {
+  // Recurring subscription: a $35 Belong card line whose only match is an ALREADY-reconciled
+  // Xero txn. Must NOT be CREATE (that would duplicate an entry already in Xero).
+  const line: CardLine = { id: 'L6', date: '2025-10-06', vendor: 'BELONG MELBOURNE', amount: 35, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' }
+  const reconciledCtx: ReconcileContext = {
+    bills: [],
+    txns: [{ contactName: 'Belong', date: '2025-10-06', amount: 35, isReconciled: true }],
+    dext: [],
+  }
+  const r = classifyLine(line, reconciledCtx)
+  assert.equal(r.action, 'already_reconciled')
+  assert.notEqual(r.action, 'create')
+  assert.equal(r.matchedTxn?.contactName, 'Belong')
+})
+
+test('summarizeReconcile: hand-computed totals across the 5 lines', () => {
+  const results = lines.map((l) => classifyLine(l, ctx))
+  const s = summarizeReconcile(results)
+
+  assert.equal(s.totalLines, 5)
+  assert.equal(s.totalValue, 1127.53) // 424.91+239+33.63+9.99+420
+
+  assert.equal(s.matchCount, 1) // L1 only (L2 is a duplicate, not a plain match)
+  assert.equal(s.matchValue, 424.91)
+
+  assert.equal(s.duplicateCount, 1) // L2
+  assert.equal(s.duplicateValue, 239) // double-counted money to recover
+
+  assert.equal(s.createCount, 3) // L3, L4, L5
+  assert.equal(s.createValue, 463.62) // 33.63+9.99+420
+
+  assert.equal(s.alreadyReconciledCount, 0) // none in this fixture
+  assert.equal(s.alreadyReconciledValue, 0)
+
+  assert.equal(s.surchargeCount, 1) // only L1 has a non-zero surcharge
+  assert.equal(s.surchargeTotal, 4.91)
+
+  // invariant: every line lands in exactly one of the four buckets
+  assert.equal(s.matchCount + s.duplicateCount + s.createCount + s.alreadyReconciledCount, s.totalLines)
+})
+
+// ---------------------------------------------------------------------------
+// Response builder — filtering, sorting, summary always over the FULL set.
+// ---------------------------------------------------------------------------
+const baseFilters: ReconcileFilters = { action: 'all', q: '', minAmount: 0, limit: 100 }
+
+test('buildReconcileResponse: summary covers all lines even when filtered/paged', () => {
+  const res = buildReconcileResponse(lines, ctx, { ...baseFilters, action: 'create', limit: 1 })
+  // summary is over all 5 lines, not just the filtered/paged view
+  assert.equal(res.summary.totalLines, 5)
+  // filter keeps only the 3 create lines
+  assert.equal(res.totalMatching, 3)
+  // limit caps the returned page
+  assert.equal(res.results.length, 1)
+})
+
+test('buildReconcileResponse: minAmount threshold filters small lines', () => {
+  const res = buildReconcileResponse(lines, ctx, { ...baseFilters, minAmount: 100 })
+  // only L1 (424.91), L2 (239), L5 (420) clear $100
+  assert.equal(res.totalMatching, 3)
+  assert.ok(res.results.every((r) => r.line.amount >= 100))
+})
+
+test('buildReconcileResponse: q matches vendor text', () => {
+  const res = buildReconcileResponse(lines, ctx, { ...baseFilters, q: 'booking' })
+  assert.equal(res.totalMatching, 1)
+  assert.equal(res.results[0].line.id, 'L2')
+})
+
+// ---------------------------------------------------------------------------
+// Co-pilot Phase 1 — the credit side (repayments → Transfer, refunds → offset),
+// the DANGER flag on AUTHORISED-unpaid bills, and the Xero-mirror date order.
+// A $40K repayment misclassified as income/create is the expensive failure, so
+// the new money totals are hand-computed here first.
+// ---------------------------------------------------------------------------
+const emptyCtx: ReconcileContext = { bills: [], txns: [], dext: [] }
+
+const repaymentLine: CardLine = {
+  id: 'C1', date: '2025-12-10', vendor: 'Internet Payment',
+  particulars: 'INTERNET PAYMENT Linked Acc Trns', amount: 40000,
+  status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815', direction: 'credit',
+}
+const refundLine: CardLine = {
+  id: 'C2', date: '2025-11-28', vendor: 'AIRBNB * HMNFDHSXP9 SURRY HILLS',
+  particulars: 'AIRBNB * HMNFDHSXP9 SURRY HILLS', amount: 2324.8,
+  status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815', direction: 'credit',
+}
+const airbnbCharge: CardLine = {
+  id: 'D2', date: '2025-11-26', vendor: 'AIRBNB SURRY HILLS', amount: 2324.8,
+  status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815', direction: 'debit',
+}
+
+test('classifyLine: credit repayment → Transfer from ACT Everyday (never income/create)', () => {
+  const r = classifyLine(repaymentLine, emptyCtx)
+  assert.equal(r.action, 'transfer')
+  assert.match(r.note, /Everyday/i)
+  assert.equal(r.suggestedAccount, null) // a transfer is not coded to an account
+})
+
+test('classifyLine: merchant credit → refund', () => {
+  const r = classifyLine(refundLine, emptyCtx)
+  assert.equal(r.action, 'refund')
+})
+
+test('classifyLine: AUTHORISED (unpaid) bill match is flagged DANGER; PAID is not', () => {
+  const authR = classifyLine(lines[0], ctx) // Centre Trailer bill is AUTHORISED
+  assert.equal(authR.action, 'match_bill')
+  assert.equal(authR.danger, true)
+
+  const paidCtx: ReconcileContext = {
+    bills: [{ contactName: 'Centre Trailer Sales', date: '2025-10-07', amount: 420, status: 'PAID', hasAttachments: true }],
+    txns: [], dext: [],
+  }
+  const paidR = classifyLine(lines[0], paidCtx)
+  assert.equal(paidR.action, 'match_bill')
+  assert.equal(paidR.danger, false)
+})
+
+test('buildReconcileResponse: a refund credit offsets a same-amount, same-vendor debit charge', () => {
+  const res = buildReconcileResponse([airbnbCharge, refundLine], emptyCtx, { ...baseFilters })
+  const refund = res.results.find((r) => r.line.id === 'C2')
+  assert.equal(refund?.action, 'refund')
+  assert.equal(refund?.offsetLineId, 'D2')
+  assert.match(refund?.note || '', /offset/i)
+})
+
+test('summarizeReconcile: transfer and refund land in their own money buckets', () => {
+  const results = [repaymentLine, refundLine].map((l) => classifyLine(l, emptyCtx))
+  const s = summarizeReconcile(results)
+  assert.equal(s.transferCount, 1)
+  assert.equal(s.transferValue, 40000)
+  assert.equal(s.refundCount, 1)
+  assert.equal(s.refundValue, 2324.8)
+  // neither a transfer nor a refund is a "create" — they must not double-count as spend
+  assert.equal(s.createCount, 0)
+})
+
+test('buildReconcileResponse: sort=date mirrors Xero by ordering oldest-first', () => {
+  const res = buildReconcileResponse(lines, ctx, { ...baseFilters, sort: 'date' })
+  const dates = res.results.map((r) => r.line.date)
+  const ascending = [...dates].sort()
+  assert.deepEqual(dates, ascending)
+})
+
+// ---------------------------------------------------------------------------
+// Bank-rule pack — the matching-killer. A rule turns recurring no-bill vendors
+// into one-click OK Creates in Xero. Money totals are hand-computed; the safety
+// invariant (NEVER rule a match-to-bill line → no double-count) is asserted.
+// ---------------------------------------------------------------------------
+const ruleLines: CardLine[] = [
+  // KENNARDS recurs (2 lines) → one rule; account not in the guess vocab → accountConfident false
+  { id: 'K1', date: '2025-10-01', vendor: 'KENNARDS HIRE SUNSHINE', amount: 100, status: 'unreconciled', projectCode: 'ACT-GD', bankAccount: 'NAB Visa ACT #8815' },
+  { id: 'K2', date: '2025-10-08', vendor: 'KENNARDS HIRE PTY', amount: 200, status: 'unreconciled', projectCode: 'ACT-GD', bankAccount: 'NAB Visa ACT #8815' },
+  // BUNNINGS is a one-off → below the recurring threshold → no rule
+  { id: 'BN', date: '2025-10-02', vendor: 'BUNNINGS WAREHOUSE', amount: 50, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+]
+
+test('buildBankRulePack: recurring CREATE vendor → one rule, $ summed; one-off + match excluded', () => {
+  const results = [
+    ...ruleLines.map((l) => classifyLine(l, emptyCtx)), // all CREATE (no bill/txn/dext)
+    classifyLine(lines[0], ctx), // L1 = Centre Trailer → match_bill, must NEVER be ruled
+  ]
+  const pack = buildBankRulePack(results)
+
+  assert.equal(pack.ruleCount, 1) // KENNARDS only (BUNNINGS one-off, Centre Trailer is a match)
+  const k = pack.rules[0]
+  assert.equal(k.matchText, 'KENNARDS')
+  assert.equal(k.lineCount, 2)
+  assert.equal(k.totalValue, 300) // 100 + 200 — hand-computed
+  assert.equal(k.accountConfident, false) // Kennards isn't in the guess vocab → Ben sets account once
+  assert.equal(k.defaultProject, 'ACT-GD')
+
+  assert.equal(pack.coveredLineCount, 2)
+  assert.equal(pack.coveredValue, 300)
+
+  // SAFETY invariant: a matched (real-bill) line is never collapsed into a create-rule
+  const matched = results.find((r) => r.line.id === 'L1')
+  assert.equal(matched?.action, 'match_bill')
+  assert.notEqual(matched?.ruleCovered, true)
+})
+
+test('buildBankRulePack: payment-rail text (INTERNET PAYMENT, GOPAYID) never becomes a rule', () => {
+  // These are bank-generic / payment-rail lines, not vendors. A rule on "INTERNET" would
+  // misfire across unrelated lines — it must produce NO rule (the lines stay manual).
+  const railLines: CardLine[] = [
+    { id: 'R1', date: '2025-10-01', vendor: 'INTERNET PAYMENT', particulars: 'INTERNET PAYMENT', amount: 500, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+    { id: 'R2', date: '2025-10-03', vendor: 'INTERNET PAYMENT', particulars: 'INTERNET PAYMENT', amount: 600, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+    { id: 'R3', date: '2025-10-05', vendor: 'GOPAYID 123', amount: 1.5, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+    { id: 'R4', date: '2025-10-06', vendor: 'GOPAYID 456', amount: 2.5, status: 'unreconciled', projectCode: null, bankAccount: 'NAB Visa ACT #8815' },
+  ]
+  const pack = buildBankRulePack(railLines.map((l) => classifyLine(l, emptyCtx)))
+  assert.equal(pack.ruleCount, 0)
+  assert.equal(pack.coveredLineCount, 0)
+})
+
+test('buildReconcileResponse: exposes the bank-rule pack and flags rule-covered lines', () => {
+  const res = buildReconcileResponse(ruleLines, emptyCtx, { ...baseFilters, sort: 'date' })
+  assert.ok(res.bankRules.ruleCount >= 1)
+  assert.equal(res.results.find((r) => r.line.id === 'K1')?.ruleCovered, true)
+  assert.notEqual(res.results.find((r) => r.line.id === 'BN')?.ruleCovered, true) // one-off, no rule
+})

--- a/apps/command-center/src/lib/finance/reconcile.ts
+++ b/apps/command-center/src/lib/finance/reconcile.ts
@@ -1,0 +1,903 @@
+import { supabase } from '@/lib/supabase'
+import { fetchAllRows } from './query'
+
+/**
+ * Reconciliation engine — the typed, unit-tested core of the Reconciliation Cockpit
+ * (plan: thoughts/shared/plans/2026-06-01-reconciliation-cockpit.md).
+ *
+ * For each NAB Visa card line it decides exactly what to do in Xero — MATCH an
+ * existing bill (adding any card surcharge as an Adjustment), kill a DUPLICATE
+ * (Dext published a bill AND the bank feed created a spend-line for the same
+ * purchase), or CREATE with coding learned from how that vendor was coded in the
+ * receipt pipeline. READ-ONLY: this prepares/codes/flags — it never writes to Xero.
+ * The Xero API cannot set IsReconciled (UI-only), so the final reconcile click
+ * always stays with Ben/SL.
+ *
+ * Lifted from scripts/reconcile-line-lookup.mjs so the API, the cockpit UI and the
+ * scripts share ONE matching source of truth. The money math (surcharge sums,
+ * duplicate value, totals) is TDD'd in reconcile.test.ts — a silent wrong number
+ * is the expensive finance failure.
+ */
+
+// Match a card line against a Xero row within this many days either side.
+export const RECONCILE_DATE_WINDOW_DAYS = 12
+
+// A card surcharge/fee is small in both absolute and relative terms. Outside this
+// band the amounts are different purchases, not the same one + a fee.
+const SURCHARGE_MAX_DOLLARS = 15
+const SURCHARGE_MAX_FRACTION = 0.06
+
+export type ReconcileAction =
+  | 'match_bill'
+  | 'approve_draft'
+  | 'match_txn'
+  | 'already_reconciled'
+  | 'duplicate'
+  | 'create'
+  | 'transfer' // credit repayment of the card from the linked Everyday account
+  | 'refund' // credit refund from a merchant (offsets a debit charge / a credit note)
+
+export interface CardLine {
+  id: string
+  date: string | null
+  vendor: string
+  amount: number // ABS bank charge
+  status: string | null // 'reconciled' | 'unreconciled'
+  projectCode: string | null
+  bankAccount: string | null
+  direction?: 'debit' | 'credit' // undefined = debit (back-compat); credits are repayments/refunds
+  particulars?: string | null // raw bank particulars — used to spot "INTERNET PAYMENT" repayments
+}
+
+export interface XeroBill {
+  contactName: string | null
+  date: string | null
+  amount: number
+  status: string | null // AUTHORISED | PAID | DRAFT | ...
+  hasAttachments: boolean | null
+  xeroId?: string | null // Xero InvoiceID — copy to find/verify the bill (esp. the DANGER cluster)
+}
+
+export interface XeroSpendTxn {
+  contactName: string | null
+  date: string | null
+  amount: number
+  isReconciled: boolean | null
+  xeroTxnId?: string | null // Xero BankTransactionID — copy to find the spend-money txn on the reconcile screen
+}
+
+export interface DextCoding {
+  vendor: string
+  project: string | null
+  amount: number | null
+  date: string | null
+  receiptUrl: string | null
+}
+
+export interface ReconcileContext {
+  bills: XeroBill[]
+  txns: XeroSpendTxn[]
+  dext: DextCoding[]
+}
+
+export interface ReconcileLineResult {
+  line: CardLine
+  action: ReconcileAction
+  matchedBill?: XeroBill
+  matchedTxn?: XeroSpendTxn
+  surcharge: number // bank amount − matched reference amount (0 if exact / no match)
+  suggestedProject: string | null
+  suggestedAccount: string | null
+  receiptUrl: string | null
+  fromDext: boolean
+  note: string
+  danger: boolean // true = matching an AUTHORISED unpaid bill: real-payment-or-phantom, needs per-line judgement
+  offsetLineId?: string // a refund credit that cancels this debit charge (and vice-versa)
+  ruleCovered?: boolean // a generated bank rule will pre-fill this CREATE line → one-click OK in Xero (no matching)
+}
+
+export interface ReconcileSummary {
+  totalLines: number
+  totalValue: number
+  matchCount: number
+  matchValue: number
+  duplicateCount: number
+  duplicateValue: number
+  createCount: number
+  createValue: number
+  alreadyReconciledCount: number
+  alreadyReconciledValue: number
+  transferCount: number
+  transferValue: number
+  refundCount: number
+  refundValue: number
+  surchargeCount: number
+  surchargeTotal: number
+}
+
+/**
+ * A draft Xero bank rule for a recurring no-bill vendor. Setting it once in the
+ * Xero UI (there is NO bank-rules API — verified) makes every future line from that
+ * vendor arrive on the reconcile screen pre-filled → one-click OK, with NO matching.
+ * This is the only auto-suggest lever Xero gives; the pack is the matching-killer for
+ * the recurring CREATE bulk. Rules NEVER target match-to-bill lines (that would double-count).
+ */
+export interface BankRule {
+  matchText: string // the "Payee contains <X>" token Xero matches on
+  contactName: string // the contact to set
+  lineCount: number // recurring lines this rule collapses to one-click
+  totalValue: number // $ this rule would auto-code (money — TDD'd)
+  account: string // learned/guessed account code; UNKNOWN_ACCOUNT placeholder if not inferable
+  accountConfident: boolean // false = Ben sets the account on first use (rule still scopes contact+project+match)
+  defaultProject: string | null // most-common project across the vendor's lines
+  taxHint: string // GST guidance (SaaS/subscriptions vary — overseas often GST-free)
+  uncertainTax: boolean // true = set tax per vendor (don't blanket-apply GST)
+}
+
+export interface BankRulePack {
+  rules: BankRule[]
+  ruleCount: number
+  coveredLineCount: number // CREATE lines that become one-click OK once the rules are set
+  coveredValue: number
+  coveredLineIds: string[]
+}
+
+export type ReconcileActionFilter = ReconcileAction | 'all'
+
+export interface ReconcileFilters {
+  action: ReconcileActionFilter
+  q: string
+  minAmount: number
+  limit: number
+  sort?: 'action' | 'date' // 'date' mirrors Xero's reconcile screen order (oldest-first); default 'action'
+}
+
+export interface ReconcileResponse {
+  filters: ReconcileFilters
+  summary: ReconcileSummary
+  bankRules: BankRulePack
+  totalMatching: number
+  results: ReconcileLineResult[]
+}
+
+// --- numeric helpers -------------------------------------------------------
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100
+}
+
+function dayGap(a: string | null, b: string | null): number {
+  if (!a || !b) return Infinity
+  return Math.abs((new Date(a).getTime() - new Date(b).getTime()) / 86_400_000)
+}
+
+/**
+ * 'exact' when within half a cent; 'surcharge' when the bank charge is the
+ * reference + a small card fee (both an absolute and a percentage cap so a $20
+ * gap never passes and a $1 gap on a $6 purchase never passes); else null.
+ */
+export function amountCloseness(bankAmt: number, refAmt: number): 'exact' | 'surcharge' | null {
+  const diff = Math.abs(bankAmt - refAmt)
+  if (diff < 0.005) return 'exact'
+  if (diff <= SURCHARGE_MAX_DOLLARS && diff <= refAmt * SURCHARGE_MAX_FRACTION) return 'surcharge'
+  return null
+}
+
+export function surchargeOf(bankAmt: number, refAmt: number): number {
+  return round2(bankAmt - refAmt)
+}
+
+// --- vendor matching -------------------------------------------------------
+
+const VENDOR_STOPWORDS = new Set([
+  'THE', 'AND', 'PAYMENT', 'PURCHASE', 'CARD', 'AUSTRALIA', 'PTY', 'COM', 'AUS',
+  'BUSINESS', 'HELP', 'MEMBERSHIP', 'LIMITED', 'SYDNEY', 'STORES', 'CENTRE',
+  'GROUP', 'SALES', 'SERVICES', 'SERVICE', 'STORE', 'SHOP', 'ONLINE',
+  'COMMUNITY', 'HIRE', 'CO', 'OF',
+])
+
+export function normalizeVendor(s: string | null | undefined): string {
+  return (s || '')
+    .toUpperCase()
+    .replace(/SQ ?\*?|SQSP ?\*?|UBER ?\*?|SP ?\*?|X{4,}\d*|PTY LTD| LTD| INC|\d{3,}|[^A-Z ]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function vendorTokens(s: string | null | undefined): Set<string> {
+  return new Set(
+    normalizeVendor(s)
+      .split(' ')
+      .filter((w) => w.length >= 3 && !VENDOR_STOPWORDS.has(w))
+  )
+}
+
+/** True when the two names share at least one significant token. */
+export function vendorMatch(a: string | null | undefined, b: string | null | undefined): boolean {
+  const ta = vendorTokens(a)
+  const tb = vendorTokens(b)
+  if (!ta.size || !tb.size) return false
+  for (const t of ta) if (tb.has(t)) return true
+  return false
+}
+
+// --- finders (vendor-gated; exact amount beats surcharge; nearest date) -----
+
+interface Scored<T> {
+  row: T
+  closeness: 'exact' | 'surcharge'
+}
+
+function bestMatch<T extends { date: string | null; amount: number; contactName?: string | null }>(
+  rows: T[],
+  line: CardLine
+): T | undefined {
+  const scored: Scored<T>[] = []
+  for (const row of rows) {
+    const c = amountCloseness(line.amount, row.amount)
+    if (!c) continue
+    if (dayGap(row.date, line.date) > RECONCILE_DATE_WINDOW_DAYS) continue
+    if (!vendorMatch(line.vendor, row.contactName)) continue
+    scored.push({ row, closeness: c })
+  }
+  scored.sort(
+    (a, b) =>
+      (a.closeness === 'exact' ? 0 : 1) - (b.closeness === 'exact' ? 0 : 1) ||
+      dayGap(a.row.date, line.date) - dayGap(b.row.date, line.date)
+  )
+  return scored[0]?.row
+}
+
+function bestDext(dext: DextCoding[], line: CardLine): DextCoding | undefined {
+  const scored: Scored<DextCoding>[] = []
+  for (const row of dext) {
+    if (row.amount == null) continue
+    const c = amountCloseness(line.amount, row.amount)
+    if (!c) continue
+    if (dayGap(row.date, line.date) > RECONCILE_DATE_WINDOW_DAYS) continue
+    if (!vendorMatch(line.vendor, row.vendor)) continue
+    scored.push({ row, closeness: c })
+  }
+  scored.sort(
+    (a, b) =>
+      (a.closeness === 'exact' ? 0 : 1) - (b.closeness === 'exact' ? 0 : 1) ||
+      dayGap(a.row.date, line.date) - dayGap(b.row.date, line.date)
+  )
+  return scored[0]?.row
+}
+
+/**
+ * Learned coding: most-common project seen for this vendor across the receipt
+ * pipeline. (Account is not captured per-receipt in the DB, so accounts fall to
+ * the heuristic guess below — see plan note on the Dext CSV vs receipt_emails.)
+ */
+function learnedProject(dext: DextCoding[], vendor: string): string | null {
+  const counts = new Map<string, number>()
+  for (const row of dext) {
+    if (!row.project) continue
+    if (!vendorMatch(vendor, row.vendor)) continue
+    counts.set(row.project, (counts.get(row.project) || 0) + 1)
+  }
+  let best: string | null = null
+  let bestN = 0
+  for (const [proj, n] of counts) if (n > bestN) ((best = proj), (bestN = n))
+  return best
+}
+
+// Account we couldn't infer — the line (and any rule for it) needs a human to set the code.
+const UNKNOWN_ACCOUNT = '? - code by hand'
+
+// Last-resort heuristic for vendors never seen in the receipt pipeline:
+// keyword → account; location → project hint. Mirrors guess() in the script.
+function guessAccount(vendor: string): string {
+  const u = vendor.toUpperCase()
+  if (/UBER|CAB|TAXI/.test(u)) return '452 - Taxis'
+  if (/HOTEL|NOVOTEL|BOOKING|DAYUSE|AIRBNB|QANTAS|VIRGIN|AVIS/.test(u)) return '493 - Travel'
+  if (/XERO|SQUARESPACE|OPENAI|GARMIN|ADOBE|FIGMA/.test(u)) return '485 - Subscriptions'
+  if (/AMZNPRIME|AUDIBLE|PRIME/.test(u)) return '880 - Drawings (personal?)'
+  if (/ECOFLO|HARDWARE|STRATCO|BUNNINGS/.test(u)) return '446 - Materials & Supplies'
+  if (/NEWS PTY/.test(u)) return '485 - Subscriptions'
+  if (/WOOLW|COLES|ALDI|IGA|SUPERMARKET|FOODS|BUTCHER|GUZMAN|CAFE|SUSHI|RICEBOI|BONKERS|BUFFET/.test(u)) {
+    return '421 - Light meals'
+  }
+  return UNKNOWN_ACCOUNT
+}
+
+function guessProjectHint(vendor: string): string | null {
+  const u = vendor.toUpperCase()
+  if (/ALICE|AMPIL|LARRAKEYAH|MANINGRIDA|BARLMARRK|AHERRENGE|TENNANT/.test(u)) return 'NT trip → ACT-GD/OO?'
+  if (/MALENY|WITTA|CALOUNDRA|MOOLOOLABA|CONONDALE/.test(u)) return 'ACT-FM (Farm)?'
+  if (/SURRY|SYDNEY|GEORGE|EDGECLIFF|MASCOT/.test(u)) return 'Sydney → ?'
+  return null
+}
+
+// --- classification cascade ------------------------------------------------
+
+// A linked-account card repayment ("INTERNET PAYMENT Linked Acc Trns" / "...Up").
+function isRepayment(line: CardLine): boolean {
+  return /INTERNET PAYMENT/i.test(`${line.particulars || ''} ${line.vendor || ''}`)
+}
+
+/**
+ * Credit-side classifier. A credit on a credit-card feed is money coming IN:
+ * either a repayment of the card from the linked Everyday account (→ Transfer,
+ * never an account-coded line) or a merchant refund (→ offset the original
+ * charge / match a credit note). Coding either as income/create double-counts.
+ */
+function classifyCreditLine(line: CardLine): ReconcileLineResult {
+  const base: ReconcileLineResult = {
+    line,
+    action: 'refund',
+    surcharge: 0,
+    suggestedProject: null,
+    suggestedAccount: null,
+    receiptUrl: null,
+    fromDext: false,
+    danger: false,
+    note: '',
+  }
+  if (isRepayment(line)) {
+    return {
+      ...base,
+      action: 'transfer',
+      note: 'Transfer from NJ Marchesi T/as ACT Everyday — no account, no GST, no project',
+    }
+  }
+  return {
+    ...base,
+    action: 'refund',
+    note: 'Merchant refund — match a credit note, or offset the original charge of the same amount',
+  }
+}
+
+export function classifyLine(line: CardLine, ctx: ReconcileContext): ReconcileLineResult {
+  if (line.direction === 'credit') return classifyCreditLine(line)
+
+  const bill = bestMatch(ctx.bills, line)
+  const txn = bestMatch(ctx.txns, line)
+  const dx = bestDext(ctx.dext, line)
+
+  const base = {
+    line,
+    suggestedProject: line.projectCode,
+    suggestedAccount: null as string | null,
+    receiptUrl: null as string | null,
+    fromDext: false,
+    danger: false,
+  }
+
+  // 1. Same purchase exists as BOTH a bill and a card txn → duplicate.
+  if (bill && txn) {
+    return {
+      ...base,
+      action: 'duplicate',
+      matchedBill: bill,
+      matchedTxn: txn,
+      surcharge: surchargeOf(line.amount, bill.amount),
+      suggestedProject: line.projectCode,
+      receiptUrl: null,
+      note: `Match the BILL (${bill.status}, ${bill.contactName}); delete the duplicate card txn`,
+    }
+  }
+
+  // 2. Draft bill — approve, then match.
+  if (bill && bill.status === 'DRAFT') {
+    return {
+      ...base,
+      action: 'approve_draft',
+      matchedBill: bill,
+      surcharge: surchargeOf(line.amount, bill.amount),
+      note: `Approve draft bill (${bill.contactName}), then match`,
+    }
+  }
+
+  // 3. Approved/paid bill → match. AUTHORISED (unpaid) = DANGER: matching pays it,
+  // but it might be a phantom to void instead — needs per-line judgement (SL cluster).
+  if (bill) {
+    return {
+      ...base,
+      action: 'match_bill',
+      matchedBill: bill,
+      surcharge: surchargeOf(line.amount, bill.amount),
+      danger: bill.status === 'AUTHORISED',
+      note: `Match to bill — search name "${bill.contactName}" (${bill.status}${bill.hasAttachments ? ', has receipt' : ''})`,
+    }
+  }
+
+  // 4. Unreconciled card txn already in Xero → match.
+  if (txn && txn.isReconciled === false) {
+    return {
+      ...base,
+      action: 'match_txn',
+      matchedTxn: txn,
+      surcharge: surchargeOf(line.amount, txn.amount),
+      note: `Match to existing card txn (${txn.contactName})`,
+    }
+  }
+
+  // 4b. A matching txn exists but is ALREADY reconciled (or its reconcile state is unknown).
+  // The charge is already entered in Xero — creating would double-count. The bank line either
+  // needs reconciling against the existing entry, or it's a stale/duplicate bank-feed import.
+  // This is the recurring-subscription trap (e.g. Belong $35/mo): without this branch a line whose
+  // only match is a reconciled txn falls through to CREATE and recommends a duplicate.
+  if (txn) {
+    return {
+      ...base,
+      action: 'already_reconciled',
+      matchedTxn: txn,
+      surcharge: surchargeOf(line.amount, txn.amount),
+      note: `A matching txn already exists in Xero (${txn.contactName}, reconciled) — likely already entered. Verify/reconcile the bank line; do NOT create a duplicate.`,
+    }
+  }
+
+  // 5. Create from a receipt-pipeline match → carry its coding + receipt image.
+  if (dx) {
+    return {
+      ...base,
+      action: 'create',
+      surcharge: dx.amount != null ? surchargeOf(line.amount, dx.amount) : 0,
+      suggestedProject: dx.project || line.projectCode,
+      suggestedAccount: guessAccount(line.vendor),
+      receiptUrl: dx.receiptUrl,
+      fromDext: true,
+      note: `Create — ${dx.project || 'no project'} · receipt attached`,
+    }
+  }
+
+  // 6. Create with a project learned from how this vendor was coded before.
+  const learned = learnedProject(ctx.dext, line.vendor)
+  if (learned) {
+    return {
+      ...base,
+      action: 'create',
+      surcharge: 0,
+      suggestedProject: learned,
+      suggestedAccount: guessAccount(line.vendor),
+      note: 'Create — project learned from prior coding of this vendor',
+    }
+  }
+
+  // 7. Create with the last-resort heuristic guess (human confirms).
+  const hint = guessProjectHint(line.vendor)
+  return {
+    ...base,
+    action: 'create',
+    surcharge: 0,
+    suggestedProject: line.projectCode,
+    suggestedAccount: guessAccount(line.vendor),
+    note: `Create — heuristic${hint ? ` · ${hint}` : ''} (confirm)`,
+  }
+}
+
+// --- aggregation (money math — TDD'd) --------------------------------------
+
+export function summarizeReconcile(results: ReconcileLineResult[]): ReconcileSummary {
+  const summary: ReconcileSummary = {
+    totalLines: results.length,
+    totalValue: 0,
+    matchCount: 0,
+    matchValue: 0,
+    duplicateCount: 0,
+    duplicateValue: 0,
+    createCount: 0,
+    createValue: 0,
+    alreadyReconciledCount: 0,
+    alreadyReconciledValue: 0,
+    transferCount: 0,
+    transferValue: 0,
+    refundCount: 0,
+    refundValue: 0,
+    surchargeCount: 0,
+    surchargeTotal: 0,
+  }
+
+  for (const r of results) {
+    summary.totalValue = round2(summary.totalValue + r.line.amount)
+
+    if (r.action === 'duplicate') {
+      summary.duplicateCount += 1
+      summary.duplicateValue = round2(summary.duplicateValue + r.line.amount)
+    } else if (r.action === 'create') {
+      summary.createCount += 1
+      summary.createValue = round2(summary.createValue + r.line.amount)
+    } else if (r.action === 'already_reconciled') {
+      summary.alreadyReconciledCount += 1
+      summary.alreadyReconciledValue = round2(summary.alreadyReconciledValue + r.line.amount)
+    } else if (r.action === 'transfer') {
+      summary.transferCount += 1
+      summary.transferValue = round2(summary.transferValue + r.line.amount)
+    } else if (r.action === 'refund') {
+      summary.refundCount += 1
+      summary.refundValue = round2(summary.refundValue + r.line.amount)
+    } else {
+      // match_bill | approve_draft | match_txn
+      summary.matchCount += 1
+      summary.matchValue = round2(summary.matchValue + r.line.amount)
+    }
+
+    if (Math.abs(r.surcharge) >= 0.005) {
+      summary.surchargeCount += 1
+      summary.surchargeTotal = round2(summary.surchargeTotal + r.surcharge)
+    }
+  }
+
+  return summary
+}
+
+// --- bank-rule pack (the matching-killer; money totals TDD'd) --------------
+
+function mostCommon<T>(items: T[]): T | null {
+  const counts = new Map<T, number>()
+  for (const it of items) counts.set(it, (counts.get(it) || 0) + 1)
+  let best: T | null = null
+  let bestN = 0
+  for (const [k, n] of counts) if (n > bestN) ((best = k), (bestN = n))
+  return best
+}
+
+// Payment-rail / bank-generic tokens — never a vendor identity. A rule on "INTERNET" or
+// "GOPAYID" would catch unrelated lines and misfire silently (the Garmin→Shipstation class).
+// We skip them as rule keys; lines whose only token is one of these fall to manual coding.
+const RULE_KEY_DENYLIST = new Set([
+  'INTERNET', 'PAYMENT', 'TRANSFER', 'GOPAYID', 'PAYID', 'BPAY', 'OSKO', 'EFTPOS',
+  'WITHDRAWAL', 'DEPOSIT', 'DIRECT', 'DEBIT', 'CREDIT', 'REVERSAL', 'REFUND', 'FEE',
+  'WWW', 'HTTP',
+])
+
+// The first vendor-like token — the text a Xero bank rule matches "contains" on, and the
+// grouping key so "KENNARDS HIRE SUNSHINE" + "KENNARDS HIRE PTY" share one rule. Skips
+// payment-rail words so "DIRECT DEBIT TELSTRA" keys on TELSTRA, and "INTERNET PAYMENT"
+// (no real vendor) keys on nothing → no rule.
+function vendorRuleKey(vendor: string): string | null {
+  for (const t of normalizeVendor(vendor).split(' ')) {
+    if (t.length >= 3 && !VENDOR_STOPWORDS.has(t) && !RULE_KEY_DENYLIST.has(t)) return t
+  }
+  return null
+}
+
+const RULE_MIN_LINES = 2 // a one-off isn't worth a rule; rules are for RECURRING vendors
+
+/**
+ * Build the draft bank-rule pack from already-classified results. Only CREATE lines are
+ * eligible — a rule pre-fills a Spend Money, so ruling a vendor that has a real bill would
+ * double-count (you must MATCH those, not create). Recurring vendors (≥RULE_MIN_LINES) become
+ * one rule each, carrying the account/project/tax the classifier already inferred; setting the
+ * pack once in Xero collapses every covered line to a one-click OK with no matching.
+ *
+ * Mutates each covered result's `ruleCovered = true` so the UI can badge it.
+ */
+export function buildBankRulePack(results: ReconcileLineResult[]): BankRulePack {
+  const groups = new Map<string, ReconcileLineResult[]>()
+  for (const r of results) {
+    if (r.action !== 'create') continue // SAFETY: never rule a match-to-bill line (double-count guard)
+    const key = vendorRuleKey(r.line.vendor)
+    if (!key) continue
+    const g = groups.get(key)
+    if (g) g.push(r)
+    else groups.set(key, [r])
+  }
+
+  const rules: BankRule[] = []
+  const coveredLineIds: string[] = []
+  let coveredValue = 0
+
+  for (const [key, group] of groups) {
+    if (group.length < RULE_MIN_LINES) continue
+    const account = mostCommon(
+      group.map((r) => r.suggestedAccount).filter((a): a is string => !!a && a !== UNKNOWN_ACCOUNT)
+    )
+    const defaultProject = mostCommon(
+      group.map((r) => r.suggestedProject).filter((p): p is string => !!p)
+    )
+    const contactName = mostCommon(group.map((r) => r.line.vendor)) || key
+    const uncertainTax = !!account && /Subscription/i.test(account)
+    const totalValue = round2(group.reduce((s, r) => s + r.line.amount, 0))
+
+    rules.push({
+      matchText: key,
+      contactName,
+      lineCount: group.length,
+      totalValue,
+      account: account || UNKNOWN_ACCOUNT,
+      accountConfident: !!account,
+      defaultProject,
+      taxHint: uncertainTax
+        ? 'GST varies — overseas SaaS often GST-free; set tax per vendor'
+        : 'GST on Expenses',
+      uncertainTax,
+    })
+    for (const r of group) {
+      r.ruleCovered = true
+      coveredLineIds.push(r.line.id)
+    }
+    coveredValue = round2(coveredValue + totalValue)
+  }
+
+  // Rank by clicks eliminated (lines collapsed), then $ — the goal is "fewest matches left",
+  // so a 10-line rule beats a 2-line rule even if the 2-liner is higher value.
+  rules.sort((a, b) => b.lineCount - a.lineCount || b.totalValue - a.totalValue)
+
+  return {
+    rules,
+    ruleCount: rules.length,
+    coveredLineCount: coveredLineIds.length,
+    coveredValue,
+    coveredLineIds,
+  }
+}
+
+// --- response builder (pure; mirrors workbench.ts) -------------------------
+
+const ACTION_ORDER: Record<ReconcileAction, number> = {
+  duplicate: 0,
+  match_bill: 1,
+  approve_draft: 2,
+  match_txn: 3,
+  transfer: 4,
+  refund: 5,
+  already_reconciled: 6,
+  create: 7,
+}
+
+function matchesAction(result: ReconcileLineResult, action: ReconcileActionFilter): boolean {
+  return action === 'all' || result.action === action
+}
+
+function matchesQuery(result: ReconcileLineResult, q: string): boolean {
+  if (!q) return true
+  const haystack = [
+    result.line.vendor,
+    result.line.projectCode,
+    result.suggestedProject,
+    result.suggestedAccount,
+    result.matchedBill?.contactName,
+    result.matchedTxn?.contactName,
+    result.note,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return haystack.includes(q.toLowerCase())
+}
+
+export function buildReconcileResponse(
+  lines: CardLine[],
+  ctx: ReconcileContext,
+  filters: ReconcileFilters
+): ReconcileResponse {
+  const all = lines.map((line) => classifyLine(line, ctx))
+
+  // Refund-offset pass: a merchant refund that exactly matches a debit charge of
+  // the same vendor cancels it (e.g. an Airbnb charge + its Airbnb refund) — flag
+  // the pair so both reconcile against each other instead of looking like spend.
+  const debits = all.filter((r) => r.line.direction !== 'credit')
+  for (const r of all) {
+    if (r.action !== 'refund') continue
+    const charge = debits.find(
+      (d) =>
+        d.line.id !== r.line.id &&
+        amountCloseness(d.line.amount, r.line.amount) === 'exact' &&
+        vendorMatch(d.line.vendor, r.line.vendor) &&
+        dayGap(d.line.date, r.line.date) <= 60
+    )
+    if (charge) {
+      r.offsetLineId = charge.line.id
+      r.note = `Refund — offsets the $${r.line.amount.toFixed(2)} ${charge.line.vendor} charge (line ${charge.line.id}); reconcile them against each other`
+    }
+  }
+
+  const byActionThenAmount = (a: ReconcileLineResult, b: ReconcileLineResult) =>
+    ACTION_ORDER[a.action] - ACTION_ORDER[b.action] || b.line.amount - a.line.amount
+  // 'date' mirrors Xero's reconcile screen (oldest-first); null dates sort last.
+  const byDate = (a: ReconcileLineResult, b: ReconcileLineResult) =>
+    (a.line.date || '9999').localeCompare(b.line.date || '9999') || b.line.amount - a.line.amount
+
+  // Build the rule pack over the FULL set (it's a setup artifact, filter-independent) BEFORE
+  // filtering — it also stamps ruleCovered on the shared result objects, so the flag flows
+  // through to the filtered/paged view.
+  const bankRules = buildBankRulePack(all)
+
+  const filtered = all
+    .filter((r) => matchesAction(r, filters.action))
+    .filter((r) => r.line.amount >= filters.minAmount)
+    .filter((r) => matchesQuery(r, filters.q))
+    .sort(filters.sort === 'date' ? byDate : byActionThenAmount)
+
+  return {
+    filters,
+    summary: summarizeReconcile(all),
+    bankRules,
+    totalMatching: filtered.length,
+    results: filtered.slice(0, filters.limit),
+  }
+}
+
+// --- data loaders (Supabase; 1000-cap-safe pagination) ---------------------
+// bills (1,479) / spend txns (1,711) / receipt_emails (2,434) all exceed the
+// PostgREST ~1000-row cap, so every load pages via fetchAllRows.
+
+export const RECONCILE_FY_START = '2025-07-01'
+export const RECONCILE_FY_END = '2026-06-30'
+// NAB Visa ACT #8815 — matched as a substring to survive Xero's trailing-space drift.
+export const RECONCILE_ACCOUNT = '8815'
+
+export interface ReconcileWindow {
+  start: string
+  end: string
+  account: string
+}
+
+export interface ReconcileProjectOption {
+  code: string
+  name: string | null
+}
+
+export interface ReconcileCockpitResponse extends ReconcileResponse {
+  window: ReconcileWindow
+  projects: ReconcileProjectOption[]
+}
+
+const num = (v: unknown): number => {
+  const n = typeof v === 'number' ? v : Number(v)
+  return Number.isFinite(n) ? n : 0
+}
+
+async function loadCardLines(w: ReconcileWindow): Promise<CardLine[]> {
+  const rows = await fetchAllRows<{
+    id: string
+    date: string | null
+    payee: string | null
+    particulars: string | null
+    reference: string | null
+    amount: number | string | null
+    status: string | null
+    project_code: string | null
+    bank_account: string | null
+    direction: string | null
+  }>((from, to) =>
+    supabase
+      .from('bank_statement_lines')
+      .select('id, date, payee, particulars, reference, amount, status, project_code, bank_account, direction')
+      // both directions: debits = card spend, credits = repayments (→Transfer) + refunds.
+      .ilike('bank_account', `%${w.account}%`)
+      .eq('status', 'unreconciled')
+      .gte('date', w.start)
+      .lte('date', w.end)
+      .order('date', { ascending: false })
+      .range(from, to)
+  )
+
+  return rows.map((r) => ({
+    id: r.id,
+    date: r.date,
+    vendor: (r.payee || r.particulars || r.reference || 'Bank line').trim(),
+    amount: Math.abs(num(r.amount)),
+    status: r.status,
+    projectCode: r.project_code,
+    bankAccount: r.bank_account,
+    direction: r.direction === 'credit' ? 'credit' : 'debit',
+    particulars: r.particulars,
+  }))
+}
+
+async function loadBills(w: ReconcileWindow): Promise<XeroBill[]> {
+  const rows = await fetchAllRows<{
+    xero_id: string | null
+    contact_name: string | null
+    date: string | null
+    total: number | string | null
+    status: string | null
+    has_attachments: boolean | null
+  }>((from, to) =>
+    supabase
+      .from('xero_invoices')
+      .select('xero_id, contact_name, date, total, status, has_attachments')
+      .eq('type', 'ACCPAY')
+      .or('status.is.null,and(status.neq.DELETED,status.neq.VOIDED)')
+      .gte('date', w.start)
+      .lte('date', w.end)
+      .range(from, to)
+  )
+
+  return rows.map((r) => ({
+    contactName: r.contact_name,
+    date: r.date,
+    amount: Math.abs(num(r.total)),
+    status: r.status,
+    hasAttachments: r.has_attachments,
+    xeroId: r.xero_id,
+  }))
+}
+
+async function loadSpendTxns(w: ReconcileWindow): Promise<XeroSpendTxn[]> {
+  const rows = await fetchAllRows<{
+    xero_transaction_id: string | null
+    contact_name: string | null
+    date: string | null
+    total: number | string | null
+    is_reconciled: boolean | null
+  }>((from, to) =>
+    supabase
+      .from('xero_transactions')
+      .select('xero_transaction_id, contact_name, date, total, is_reconciled')
+      .like('type', 'SPEND%')
+      .ilike('bank_account', `%${w.account}%`)
+      .or('status.is.null,status.neq.DELETED')
+      .gte('date', w.start)
+      .lte('date', w.end)
+      .range(from, to)
+  )
+
+  return rows.map((r) => ({
+    contactName: r.contact_name,
+    date: r.date,
+    amount: Math.abs(num(r.total)),
+    isReconciled: r.is_reconciled,
+    xeroTxnId: r.xero_transaction_id,
+  }))
+}
+
+// Learned coding + receipt images come from the live receipt pipeline
+// (receipt_emails), NOT the point-in-time Dext CSV the script used. attachment_url
+// is a storage path inside the 'receipt-attachments' bucket — the route signs it.
+async function loadDextCoding(w: ReconcileWindow): Promise<DextCoding[]> {
+  const rows = await fetchAllRows<{
+    vendor_name: string | null
+    amount_detected: number | string | null
+    project_code: string | null
+    attachment_url: string | null
+    received_at: string | null
+  }>((from, to) =>
+    supabase
+      .from('receipt_emails')
+      .select('vendor_name, amount_detected, project_code, attachment_url, received_at')
+      .not('vendor_name', 'is', null)
+      .gte('received_at', w.start)
+      .lte('received_at', `${w.end}T23:59:59`)
+      .range(from, to)
+  )
+
+  return rows.map((r) => ({
+    vendor: r.vendor_name || '',
+    amount: r.amount_detected == null ? null : num(r.amount_detected),
+    project: r.project_code,
+    date: r.received_at ? r.received_at.slice(0, 10) : null,
+    receiptUrl: r.attachment_url,
+  }))
+}
+
+async function loadProjects(): Promise<ReconcileProjectOption[]> {
+  const { data, error } = await supabase
+    .from('projects')
+    .select('code, name')
+    .not('code', 'is', null)
+    .or('status.is.null,status.neq.archived')
+    .order('code', { ascending: true })
+    .limit(500)
+  if (error) throw new Error(`projects: ${error.message}`)
+  return ((data || []) as ReconcileProjectOption[]).map((p) => ({ code: p.code, name: p.name }))
+}
+
+export async function loadReconcileContext(w: ReconcileWindow): Promise<{
+  lines: CardLine[]
+  ctx: ReconcileContext
+  projects: ReconcileProjectOption[]
+}> {
+  const [lines, bills, txns, dext, projects] = await Promise.all([
+    loadCardLines(w),
+    loadBills(w),
+    loadSpendTxns(w),
+    loadDextCoding(w),
+    loadProjects(),
+  ])
+  return { lines, ctx: { bills, txns, dext }, projects }
+}
+
+export async function getReconcileCockpit(
+  filters: ReconcileFilters,
+  window: ReconcileWindow = { start: RECONCILE_FY_START, end: RECONCILE_FY_END, account: RECONCILE_ACCOUNT }
+): Promise<ReconcileCockpitResponse> {
+  const { lines, ctx, projects } = await loadReconcileContext(window)
+  const response = buildReconcileResponse(lines, ctx, filters)
+  return { ...response, window, projects }
+}


### PR DESCRIPTION
Read-only reconcile co-pilot for **NAB Visa ACT #8815** at `/finance/reconcile`. Mirrors Xero's reconcile screen so clearing the card is **click, not match**. Tight PR — **4 files**, branched fresh off `main`.

> Verified ceiling (do not re-litigate): no reconcile API, no bank-rules API — Xero policy declined 6 May 2026. The reconcile click stays in Xero. This is read-only; it prepares/codes/flags only.

## What it does
- **Engine** (`lib/finance/reconcile.ts`, pure + TDD'd): per-line action — match_bill / approve_draft / match_txn / already_reconciled / duplicate / create — plus the credit side: **transfer** (card repayment → Transfer from ACT Everyday, never income) and **refund** (merchant credit → offset the charge). `danger` flag on AUTHORISED-unpaid bill matches. Surcharge math, learned vendor coding, 1000-cap-safe pagination.
- **Bank-rule pack** (`buildBankRulePack`) — the matching-killer: recurring no-bill vendors (≥2 lines) → copy-paste Xero bank rules so those lines arrive pre-filled → one-click OK, no matching. **Safety: rules only target CREATE lines (never match-to-bill → no double-count); payment-rail tokens (INTERNET/GOPAYID/…) denylisted to stop misfires.**
- **API**: signs receipt URLs; surfaces direction/danger/sort/transfer+refund filters/matched `BankTransactionID` + the rule pack.
- **UI**: two-column Xero-mirror rows (date order, action pills, DANGER badge, copyable BankTransactionID, mirror-staleness notes, receipt thumbs) + "set once → one-click" rule panel (high-leverage rules split from the 2-line tail).

## Verification
- Money math TDD'd — **25/25** in `reconcile.test.ts` (per-rule totals + coverage hand-computed; safety invariant asserted: a match-to-bill line is never collapsed into a create-rule).
- `tsc --noEmit` + `eslint` clean.
- Verified live against #8815: 518 lines / $649K; 57 rules cover 193 create lines ($107K); top 28 rules → 135 lines one-click. API HTTP 200.

## Scope notes
- The same code rides the larger WIP branch in #138 — this PR isolates the reconcile co-pilot for clean review; merge whichever you prefer (not both — the file content is identical).
- Two known data caveats to eyeball when setting rules: a place-name match ("ALICE") survives (panel warns to review each rule before saving), and an "INTERNET PAYMENT" create cluster (~11 lines, ~$12K) may be repayments that weren't tagged as credits — worth a look, separate from this PR.

Plan: `thoughts/shared/plans/2026-06-02-reconcile-copilot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
