### PR TITLE
chore(wiki): drop per-file regen timestamp from command-center snapshot mirror

### DIFF
--- a/apps/command-center/public/wiki/README.md
+++ b/apps/command-center/public/wiki/README.md
@@ -2,6 +2,6 @@
 
 This folder is a generated legacy mirror of the canonical repo-root wiki at `/wiki`.
 
-- Generated: `2026-06-07T01:07:42.547Z`
+- Build timestamp lives in `snapshot-meta.json`.
 - Use `node scripts/wiki-sync-command-center-snapshot.mjs` to regenerate it.
 - Do not edit these files as the source of truth.

--- a/apps/command-center/public/wiki/act/ai-ethics.md
+++ b/apps/command-center/public/wiki/act/ai-ethics.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/ai-ethics.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # AI Ethics & Agent Strategy
 

--- a/apps/command-center/public/wiki/act/alma.md
+++ b/apps/command-center/public/wiki/act/alma.md
@@ -8,7 +8,7 @@ rewritten: 2026-05-25
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/alma.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # ALMA - Australian Living Map of Alternatives
 

--- a/apps/command-center/public/wiki/act/appendices/alma-template.md
+++ b/apps/command-center/public/wiki/act/appendices/alma-template.md
@@ -1,6 +1,5 @@
 ---
 status: generated
-generated_at: 2026-06-07T01:07:42.547Z
 canonical_source: wiki/concepts/alma.md
 ---
 

--- a/apps/command-center/public/wiki/act/appendices/glossary.md
+++ b/apps/command-center/public/wiki/act/appendices/glossary.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/glossary.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Glossary
 

--- a/apps/command-center/public/wiki/act/appendices/roadmap-2026.md
+++ b/apps/command-center/public/wiki/act/appendices/roadmap-2026.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/decisions/roadmap-2026.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # 2026 Roadmap
 

--- a/apps/command-center/public/wiki/act/appendices/tech-architecture.md
+++ b/apps/command-center/public/wiki/act/appendices/tech-architecture.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/technical/act-architecture.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # ACT Technical Architecture
 

--- a/apps/command-center/public/wiki/act/appendices/transcription-workflow.md
+++ b/apps/command-center/public/wiki/act/appendices/transcription-workflow.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/technical/transcription-workflow.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Descript Transcription & ALMA Review Workflow
 

--- a/apps/command-center/public/wiki/act/appendices/vignette-workflows.md
+++ b/apps/command-center/public/wiki/act/appendices/vignette-workflows.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/technical/vignette-workflows.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Vignette & Media Workflows
 

--- a/apps/command-center/public/wiki/act/appendices/visual-system.md
+++ b/apps/command-center/public/wiki/act/appendices/visual-system.md
@@ -11,7 +11,7 @@ image_model: gemini-3-pro-image-preview via mcp__gemini-image__create_asset
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/visual-system.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # ACT Visual System
 

--- a/apps/command-center/public/wiki/act/beautiful-obsolescence.md
+++ b/apps/command-center/public/wiki/act/beautiful-obsolescence.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/beautiful-obsolescence.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Beautiful Obsolescence
 

--- a/apps/command-center/public/wiki/act/governance.md
+++ b/apps/command-center/public/wiki/act/governance.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/governance-consent.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Governance & Consent (Operational)
 

--- a/apps/command-center/public/wiki/act/governed-proof.md
+++ b/apps/command-center/public/wiki/act/governed-proof.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/governed-proof.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Governed Proof
 

--- a/apps/command-center/public/wiki/act/identity/lcaa-methodology.md
+++ b/apps/command-center/public/wiki/act/identity/lcaa-methodology.md
@@ -1,6 +1,6 @@
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/lcaa-method.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # LCAA Method
 
 > Listen. Curiosity. Action. Art.

--- a/apps/command-center/public/wiki/act/identity/mission.md
+++ b/apps/command-center/public/wiki/act/identity/mission.md
@@ -1,6 +1,5 @@
 ---
 status: generated
-generated_at: 2026-06-07T01:07:42.547Z
 canonical_source: wiki/concepts/act-identity.md
 ---
 

--- a/apps/command-center/public/wiki/act/identity/principles.md
+++ b/apps/command-center/public/wiki/act/identity/principles.md
@@ -1,6 +1,5 @@
 ---
 status: generated
-generated_at: 2026-06-07T01:07:42.547Z
 canonical_source: wiki/concepts/act-identity.md
 ---
 

--- a/apps/command-center/public/wiki/act/identity/voice-guide.md
+++ b/apps/command-center/public/wiki/act/identity/voice-guide.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/voice-guide.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # ACT Voice Guide
 

--- a/apps/command-center/public/wiki/act/index.md
+++ b/apps/command-center/public/wiki/act/index.md
@@ -6,7 +6,7 @@ source_of_truth: wiki/concepts/soul.md
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/act-identity.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # A Curious Tractor (ACT)
 

--- a/apps/command-center/public/wiki/act/lcaa.md
+++ b/apps/command-center/public/wiki/act/lcaa.md
@@ -1,6 +1,6 @@
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/lcaa-method.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # LCAA Method
 
 > Listen. Curiosity. Action. Art.

--- a/apps/command-center/public/wiki/act/ways-of-working.md
+++ b/apps/command-center/public/wiki/act/ways-of-working.md
@@ -5,7 +5,7 @@ status: Active
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/ways-of-working.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Ways of Working
 

--- a/apps/command-center/public/wiki/empathy-ledger/index.md
+++ b/apps/command-center/public/wiki/empathy-ledger/index.md
@@ -16,7 +16,7 @@ empathy_ledger_key: empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/empathy-ledger.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Empathy Ledger
 

--- a/apps/command-center/public/wiki/goods/index.md
+++ b/apps/command-center/public/wiki/goods/index.md
@@ -16,7 +16,7 @@ empathy_ledger_key: goods
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/goods.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Goods on Country
 

--- a/apps/command-center/public/wiki/justicehub/index.md
+++ b/apps/command-center/public/wiki/justicehub/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/justicehub/justicehub.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # JusticeHub
 

--- a/apps/command-center/public/wiki/place/black-cockatoo-valley.md
+++ b/apps/command-center/public/wiki/place/black-cockatoo-valley.md
@@ -16,7 +16,7 @@ empathy_ledger_key: black-cockatoo-valley
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/act-farm/black-cockatoo-valley.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Black Cockatoo Valley
 

--- a/apps/command-center/public/wiki/place/index.md
+++ b/apps/command-center/public/wiki/place/index.md
@@ -1,6 +1,6 @@
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/concepts/place-land-practice.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Place & Land Practice
 
 ACT's work is grounded in place. Land practice is central to everything — not an add-on or afterthought, but the foundation that shapes how we work.

--- a/apps/command-center/public/wiki/snapshot-meta.json
+++ b/apps/command-center/public/wiki/snapshot-meta.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-07T01:07:42.547Z",
+  "generated_at": "2026-06-08T07:15:47.341Z",
   "canonical_root": "wiki/",
   "direct_mappings": 24,
   "wrapper_pages": 4,

--- a/apps/command-center/public/wiki/stories/a-guarded-to-self-advocate.md
+++ b/apps/command-center/public/wiki/stories/a-guarded-to-self-advocate.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/a-guarded-to-self-advocate.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # A: From Guarded and Disengaged to Articulate Self-Advocate
 

--- a/apps/command-center/public/wiki/stories/atnarpa-boys-trip.md
+++ b/apps/command-center/public/wiki/stories/atnarpa-boys-trip.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/atnarpa-boys-trip.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Atnarpa Station Cultural Learning - Boys Trip
 

--- a/apps/command-center/public/wiki/stories/atnarpa-girls-trip.md
+++ b/apps/command-center/public/wiki/stories/atnarpa-girls-trip.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/atnarpa-girls-trip.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Atnarpa Homestead Cultural Exchange - Girls Trip
 

--- a/apps/command-center/public/wiki/stories/bg-fit-ben-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-ben-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-ben-recording.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Ben - Recording
 
 > Ben

--- a/apps/command-center/public/wiki/stories/bg-fit-benji-youth-day-yarn.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-benji-youth-day-yarn.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-benji-youth-day-yarn.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Benji - Youth Day Yarn
 
 > Benji - Young Person

--- a/apps/command-center/public/wiki/stories/bg-fit-danielle-germaine-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-danielle-germaine-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-danielle-germaine-recording.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Danielle Germaine. - Recording
 
 > Danielle Germaine

--- a/apps/command-center/public/wiki/stories/bg-fit-doomadgee-camp-taking-it-remote.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-doomadgee-camp-taking-it-remote.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-doomadgee-camp-taking-it-remote.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Doomadgee Camp — Taking It Remote
 
 > Doomadgee Camp Participant

--- a/apps/command-center/public/wiki/stories/bg-fit-gracie-ryder-youth-police.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-gracie-ryder-youth-police.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-gracie-ryder-youth-police.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Gracie Ryder - Youth Police
 
 > Gracie Ryder

--- a/apps/command-center/public/wiki/stories/bg-fit-jay-young-person-interview.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-jay-young-person-interview.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-jay-young-person-interview.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Jay - Young Person interview
 
 > Jay

--- a/apps/command-center/public/wiki/stories/bg-fit-mount-isa-bush-camp-first-one-on-country.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-mount-isa-bush-camp-first-one-on-country.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-mount-isa-bush-camp-first-one-on-country.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Mount Isa Bush Camp — First One on Country
 
 > Mount Isa Camp Participant

--- a/apps/command-center/public/wiki/stories/bg-fit-rashad-gavin-isaacson-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-rashad-gavin-isaacson-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-rashad-gavin-isaacson-recording.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Rashad Gavin Isaacson - Recording
 
 > Rashad Gavin Isaacson

--- a/apps/command-center/public/wiki/stories/bg-fit-siva-recording.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-siva-recording.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-siva-recording.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Siva - Recording
 
 > Siva

--- a/apps/command-center/public/wiki/stories/bg-fit-spinifex-residential-getting-through-to-the-hard-cases.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-spinifex-residential-getting-through-to-the-hard-cases.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-spinifex-residential-getting-through-to-the-hard-cases.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Spinifex Residential — Getting Through to the Hard Cases
 
 > Spinifex Res Youth

--- a/apps/command-center/public/wiki/stories/bg-fit-tuesday-gym-sessions-building-consistency.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-tuesday-gym-sessions-building-consistency.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-tuesday-gym-sessions-building-consistency.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Tuesday Gym Sessions — Building Consistency
 
 > Flexi Group Voices

--- a/apps/command-center/public/wiki/stories/bg-fit-why-i-started-bg-fit.md
+++ b/apps/command-center/public/wiki/stories/bg-fit-why-i-started-bg-fit.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:bg-fit"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/bg-fit-why-i-started-bg-fit.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Why I Started BG Fit
 
 > Brodie Germaine

--- a/apps/command-center/public/wiki/stories/building-empathy-ledger.md
+++ b/apps/command-center/public/wiki/stories/building-empathy-ledger.md
@@ -6,7 +6,7 @@ projects: empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/building-empathy-ledger.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Building Empathy Ledger: A Journey of Connection
 

--- a/apps/command-center/public/wiki/stories/cb-cultural-leadership.md
+++ b/apps/command-center/public/wiki/stories/cb-cultural-leadership.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/cb-cultural-leadership.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # CB: Understanding Cultural Responsibility and Leadership
 

--- a/apps/command-center/public/wiki/stories/community-innovation-goods.md
+++ b/apps/command-center/public/wiki/stories/community-innovation-goods.md
@@ -6,7 +6,7 @@ projects: goods, picc-storm-stories
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/community-innovation-goods.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Community Innovation: Beds, Washing Machines, and Orange Sky
 

--- a/apps/command-center/public/wiki/stories/community-recognition-referrals.md
+++ b/apps/command-center/public/wiki/stories/community-recognition-referrals.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/community-recognition-referrals.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Community Recognition and External Referral Requests
 

--- a/apps/command-center/public/wiki/stories/educational-transformation.md
+++ b/apps/command-center/public/wiki/stories/educational-transformation.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/educational-transformation.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Educational Transformation: 72% Return to School
 

--- a/apps/command-center/public/wiki/stories/elders-speak-consulted.md
+++ b/apps/command-center/public/wiki/stories/elders-speak-consulted.md
@@ -6,7 +6,7 @@ projects: picc-storm-stories
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/elders-speak-consulted.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Elders Speak: "We Should Have Been Consulted"
 

--- a/apps/command-center/public/wiki/stories/ellen-friday-fridge.md
+++ b/apps/command-center/public/wiki/stories/ellen-friday-fridge.md
@@ -6,7 +6,7 @@ projects: goods, picc-storm-stories
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/ellen-friday-fridge.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Ellen Friday: Still Waiting for a Fridge
 

--- a/apps/command-center/public/wiki/stories/finke-desert-race.md
+++ b/apps/command-center/public/wiki/stories/finke-desert-race.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/finke-desert-race.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Finke Desert Race Country Experience
 

--- a/apps/command-center/public/wiki/stories/girls-day-out-standley-chasm.md
+++ b/apps/command-center/public/wiki/stories/girls-day-out-standley-chasm.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/girls-day-out-standley-chasm.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Girls Day Out: Cultural Empowerment at Standley Chasm
 

--- a/apps/command-center/public/wiki/stories/healing-journey-country.md
+++ b/apps/command-center/public/wiki/stories/healing-journey-country.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/healing-journey-country.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Healing Journey to Country: Young Men Find Connection at Atnarpa Station
 

--- a/apps/command-center/public/wiki/stories/index.md
+++ b/apps/command-center/public/wiki/stories/index.md
@@ -5,7 +5,7 @@ status: Internal
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/index.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Stories
 

--- a/apps/command-center/public/wiki/stories/jesus-teruel-diagrama.md
+++ b/apps/command-center/public/wiki/stories/jesus-teruel-diagrama.md
@@ -6,7 +6,7 @@ projects: diagrama, justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/jesus-teruel-diagrama.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Jesús Teruel — Diagrama Key Story
 

--- a/apps/command-center/public/wiki/stories/m-homelessness-independent.md
+++ b/apps/command-center/public/wiki/stories/m-homelessness-independent.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/m-homelessness-independent.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # M: From Homelessness to Independent Living
 

--- a/apps/command-center/public/wiki/stories/mounty-yarns-mounty-yarns-in-their-own-words.md
+++ b/apps/command-center/public/wiki/stories/mounty-yarns-mounty-yarns-in-their-own-words.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:mounty-yarns"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/mounty-yarns-mounty-yarns-in-their-own-words.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Mounty Yarns: In Their Own Words
 
 > Mounty Yarns Community

--- a/apps/command-center/public/wiki/stories/ms-future-entrepreneur.md
+++ b/apps/command-center/public/wiki/stories/ms-future-entrepreneur.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/ms-future-entrepreneur.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # MS: From Disconnected Youth to Future Tourism Entrepreneur
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-aunty-bev-and-uncle-tony-s-story.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-aunty-bev-and-uncle-tony-s-story.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-aunty-bev-and-uncle-tony-s-story.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Aunty Bev and Uncle Tony's Story
 
 > Aunty Barb and Uncle Tony

--- a/apps/command-center/public/wiki/stories/oonchiumpa-bringing-kids-back-to-country.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-bringing-kids-back-to-country.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-bringing-kids-back-to-country.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Bringing Kids Back to Country
 
 > Kristy Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-coming-home-to-love-s-creek.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-coming-home-to-love-s-creek.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-coming-home-to-love-s-creek.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Coming Home to Love's Creek
 
 > Henry Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-creating-our-own-history.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-creating-our-own-history.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-creating-our-own-history.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Creating Our Own History
 
 > Kylie Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-fred-xavier-trust.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-fred-xavier-trust.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, trust, case-work, stretch-bed, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-fred-xavier-trust.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # He trusts us. We earned that trust.
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-detention.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-detention.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, detention, young-people, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-jackquann-detention.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Detention. That's not my home.
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-nigel-programs.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-jackquann-nigel-programs.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, young-people, school, programs, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-jackquann-nigel-programs.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Programs. Go to school every day.
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-kristy-bloomfield-interview-transcript.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-kristy-bloomfield-interview-transcript.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-kristy-bloomfield-interview-transcript.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Kristy Bloomfield - Interview Transcript
 
 > Kristy Bloomfield

--- a/apps/command-center/public/wiki/stories/oonchiumpa-kristy-tanya-founders.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-kristy-tanya-founders.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, founders, cultural-authority, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-kristy-tanya-founders.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Our young people are just collateral in a bigger issue
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-laquisha-darwin.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-laquisha-darwin.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, detention, darwin, young-people, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-laquisha-darwin.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Court is scary because you don't know whether you're getting out or not
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-nigel-court.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-nigel-court.md
@@ -11,7 +11,7 @@ tags: [oonchiumpa, court, young-people, mparntwe, judges-on-country]
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-nigel-court.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # When I'm talking to the judge, I feel like I'm panicking
 

--- a/apps/command-center/public/wiki/stories/oonchiumpa-oonchiumpa-what-happens-when-community-leads.md
+++ b/apps/command-center/public/wiki/stories/oonchiumpa-oonchiumpa-what-happens-when-community-leads.md
@@ -15,7 +15,7 @@ el_v2_match_via: "org:oonchiumpa"
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/oonchiumpa-oonchiumpa-what-happens-when-community-leads.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 # Oonchiumpa: What Happens When Community Leads
 
 > Benjamin Knight

--- a/apps/command-center/public/wiki/stories/operation-luna-success.md
+++ b/apps/command-center/public/wiki/stories/operation-luna-success.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/operation-luna-success.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Operation Luna Success: Dramatic Reduction in Youth Offending
 

--- a/apps/command-center/public/wiki/stories/origin-curious-tractor.md
+++ b/apps/command-center/public/wiki/stories/origin-curious-tractor.md
@@ -6,7 +6,7 @@ projects: a-curious-tractor, empathy-ledger, justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/origin-curious-tractor.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # The Origin of A Curious Tractor
 

--- a/apps/command-center/public/wiki/stories/peggy-palm-island.md
+++ b/apps/command-center/public/wiki/stories/peggy-palm-island.md
@@ -6,7 +6,7 @@ projects: picc-photo-kiosk, empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/peggy-palm-island.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Peggy Palm Island's Story
 

--- a/apps/command-center/public/wiki/stories/proud-pita-pita-wayaka-man.md
+++ b/apps/command-center/public/wiki/stories/proud-pita-pita-wayaka-man.md
@@ -6,7 +6,7 @@ projects: bg-fit
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/proud-pita-pita-wayaka-man.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Proud Pita Pita Wayaka Man: My Roots
 

--- a/apps/command-center/public/wiki/stories/returning-home-atnarpa.md
+++ b/apps/command-center/public/wiki/stories/returning-home-atnarpa.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/returning-home-atnarpa.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Returning Home to Atnarpa: The Bloomfield Family's Journey
 

--- a/apps/command-center/public/wiki/stories/school-partnership-success.md
+++ b/apps/command-center/public/wiki/stories/school-partnership-success.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/school-partnership-success.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # School Partnership Success Stories
 

--- a/apps/command-center/public/wiki/stories/storytelling-data-sovereignty.md
+++ b/apps/command-center/public/wiki/stories/storytelling-data-sovereignty.md
@@ -6,7 +6,7 @@ projects: picc-storm-stories, empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/storytelling-data-sovereignty.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Storytelling, Data Sovereignty, and Community Recovery
 

--- a/apps/command-center/public/wiki/stories/uncle-alan-palm-island.md
+++ b/apps/command-center/public/wiki/stories/uncle-alan-palm-island.md
@@ -6,7 +6,7 @@ projects: uncle-allan-palm-island-art, empathy-ledger
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/uncle-alan-palm-island.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Uncle Alan Palm Island — Key Story
 

--- a/apps/command-center/public/wiki/stories/uncle-dale-healing-path.md
+++ b/apps/command-center/public/wiki/stories/uncle-dale-healing-path.md
@@ -6,7 +6,7 @@ projects: justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/uncle-dale-healing-path.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Building a Healing Path: Uncle Dale's Vision for Youth Justice Reform
 

--- a/apps/command-center/public/wiki/stories/vignette-template.md
+++ b/apps/command-center/public/wiki/stories/vignette-template.md
@@ -1,6 +1,5 @@
 ---
 status: generated
-generated_at: 2026-06-07T01:07:42.547Z
 canonical_source: wiki/technical/vignette-workflows.md
 ---
 

--- a/apps/command-center/public/wiki/stories/young-fellas-standley-chasm.md
+++ b/apps/command-center/public/wiki/stories/young-fellas-standley-chasm.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/young-fellas-standley-chasm.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Young Fellas Experience Cultural Connection at Standley Chasm
 

--- a/apps/command-center/public/wiki/stories/young-people-murcia.md
+++ b/apps/command-center/public/wiki/stories/young-people-murcia.md
@@ -6,7 +6,7 @@ projects: diagrama, justicehub
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/young-people-murcia.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Young People Murcia — Key Story
 

--- a/apps/command-center/public/wiki/stories/young-person-returns-school.md
+++ b/apps/command-center/public/wiki/stories/young-person-returns-school.md
@@ -7,7 +7,7 @@ series: judges-on-country-postcards
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/stories/young-person-returns-school.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # Young Person Returns to School After Cultural Healing
 

--- a/apps/command-center/public/wiki/the-farm/index.md
+++ b/apps/command-center/public/wiki/the-farm/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: act-farm
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/act-farm/act-farm.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # ACT Farm
 

--- a/apps/command-center/public/wiki/the-harvest/index.md
+++ b/apps/command-center/public/wiki/the-harvest/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: the-harvest
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/the-harvest/the-harvest.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # The Harvest / Witta Harvest HQ
 

--- a/apps/command-center/public/wiki/the-studio/index.md
+++ b/apps/command-center/public/wiki/the-studio/index.md
@@ -15,7 +15,7 @@ empathy_ledger_key: act-studio
 
 > Generated legacy mirror for command-center.
 > Source of truth: `wiki/projects/act-studio/act-studio.md`.
-> Regenerated: `2026-06-07T01:07:42.547Z` via `node scripts/wiki-sync-command-center-snapshot.mjs`.
+> Regenerate via `node scripts/wiki-sync-command-center-snapshot.mjs`. Build timestamp lives in `snapshot-meta.json`.
 
 # ACT Regenerative Studio
 

--- a/scripts/wiki-sync-command-center-snapshot.mjs
+++ b/scripts/wiki-sync-command-center-snapshot.mjs
@@ -87,7 +87,7 @@ function injectBanner(content, sourcePath) {
   const banner = [
     `> Generated legacy mirror for command-center.`,
     `> Source of truth: \`${sourcePath}\`.`,
-    `> Regenerated: \`${GENERATED_AT}\` via \`node scripts/wiki-sync-command-center-snapshot.mjs\`.`,
+    `> Regenerate via \`node scripts/wiki-sync-command-center-snapshot.mjs\`. Build timestamp lives in \`snapshot-meta.json\`.`,
     '',
   ].join('\n')
 
@@ -116,7 +116,6 @@ function writeWrapper(destRel, title, canonical, bodyLines) {
   const content = [
     '---',
     'status: generated',
-    `generated_at: ${GENERATED_AT}`,
     `canonical_source: ${canonical}`,
     '---',
     '',
@@ -162,7 +161,7 @@ writeFileSync(
     '',
     `This folder is a generated legacy mirror of the canonical repo-root wiki at \`/wiki\`.`,
     '',
-    `- Generated: \`${GENERATED_AT}\``,
+    '- Build timestamp lives in `snapshot-meta.json`.',
     '- Use `node scripts/wiki-sync-command-center-snapshot.mjs` to regenerate it.',
     '- Do not edit these files as the source of truth.',
     '',


### PR DESCRIPTION
## What

The command-center wiki snapshot script (`scripts/wiki-sync-command-center-snapshot.mjs`) stamped a fresh `GENERATED_AT` timestamp into **every** generated file on each run. So every regeneration churned ~100 mirror files with **zero content change** — `84 files changed, 84 insertions(+), 84 deletions(-)`, all a one-line timestamp bump.

## Why it mattered

That churn buried genuine wiki content edits in the diff and trained blind `git checkout` of the whole batch — which would **silently discard a real (often OCAP-sensitive) story edit** if one were hiding in the noise. Many of these mirror files are Oonchiumpa / BG-Fit storyteller pages.

## Fix

Removed the per-file timestamp from all three injection sites:
- mirror banner (`injectBanner`) — the 84-file churn source
- wrapper frontmatter (`writeWrapper`)
- `README.md`

Kept the useful per-file `Source of truth: <path>` provenance pointer. The single build timestamp now lives **only** in `snapshot-meta.json`.

## Verification

Output is now **idempotent** — two consecutive runs produce byte-identical mirror files (md5-checked). From here, regens diff only on `snapshot-meta.json` (the intended freshness signal) plus any genuine content change.

The 84-file diff in this PR is the **one-time** de-timestamping; future runs are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)