### PR TITLE
GHL: phantom-consent guard (audit+revoke, held) + root-cause finding

### DIFF
--- a/config/campaigns/contained-adelaide-2026.json
+++ b/config/campaigns/contained-adelaide-2026.json
@@ -1,0 +1,159 @@
+{
+  "version": 1,
+  "updated": "2026-06-09",
+  "status": "draft-for-build",
+  "description": "Canonical GHL campaign config for CONTAINED Adelaide 2026. P1 of thoughts/shared/plans/2026-06-08-contained-adelaide-campaign-crm.md, under the R4 ruling (CONTAINED conforms to the one-account canonical contract: project:act-jh + source:event:contained-adelaide + interest:justice-reform + comms:justicehub-newsletter). DATA ONLY. No code here applies anything; live GHL writes are Tier 3, day-shift, gated to the 16 Jun go/no-go. Source evidence cited in thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md.",
+  "meta": {
+    "campaign_code": "ACT-CN",
+    "campaign_name": "CONTAINED Adelaide 2026",
+    "campaign_slug": "contained-adelaide",
+    "event": "Reintegration Puzzle Conference @ Tandanya",
+    "event_dates": "2026-06-24/2026-06-25",
+    "go_no_go": "2026-06-16",
+    "ghl_location_id": "agzsSZWgovjwgpcoASWG",
+    "ghl_location_name": "A Curious Tractor",
+    "_comment": "campaign_slug drives the source:event:contained-<slug> tag. Per-stop campaigns reuse this config with a new slug (contained-mount-druitt, etc.)."
+  },
+  "canonical_contract": {
+    "_comment": "Every CONTAINED contact gets these identity tags regardless of which form they arrived through. Identity tags NEVER trigger a send (5-layer model: DESCRIBE). Only comms:* enrols, and only with captured consent.",
+    "always": [
+      "project:act-jh",
+      "source:event:contained-adelaide",
+      "interest:justice-reform"
+    ],
+    "role_map": {
+      "_comment": "JusticeHub register/signup role dropdown -> canonical role: namespace (8 canonical roles: funder/partner/buyer/supporter/storyteller/researcher/media/community). 'ruling' flags are OPEN (RC1) - PROPOSED mappings, not final.",
+      "researcher": { "tags": ["role:researcher"], "ruling": "locked" },
+      "media": { "tags": ["role:media"], "ruling": "locked" },
+      "funder": { "tags": ["role:funder"], "ruling": "locked" },
+      "community": { "tags": ["role:community"], "ruling": "locked" },
+      "lived_experience": { "tags": ["lane:community", "role:storyteller"], "suppress_comms": true, "ruling": "locked-R3", "_comment": "OCAP: never auto-enrolled into comms:*; automation suppressed even on a newsletter tick; explicit opt-in human-confirmed." },
+      "service_org": { "tags": ["role:partner"], "ruling": "PROPOSED-RC1" },
+      "practitioner": { "tags": ["role:supporter"], "ruling": "PROPOSED-RC1" },
+      "policymaker": { "tags": ["role:partner"], "ruling": "PROPOSED-RC1" },
+      "advocate": { "tags": ["role:supporter"], "ruling": "PROPOSED-RC1" },
+      "artist": { "tags": ["role:supporter", "interest:storytelling"], "ruling": "PROPOSED-RC1" },
+      "student": { "tags": ["role:supporter"], "ruling": "PROPOSED-RC1" },
+      "supporter": { "tags": ["role:supporter"], "ruling": "locked" }
+    },
+    "state_to_place": {
+      "_comment": "Use STATE_TO_PLACE (place:<x>), NOT the legacy state:<x>. Mirrors JusticeHub src/lib/ghl/client.ts GHL_CANONICAL.",
+      "NSW": "place:nsw", "VIC": "place:vic", "QLD": "place:qld", "SA": "place:sa",
+      "WA": "place:wa", "TAS": "place:tas", "NT": "place:nt", "ACT": "place:act"
+    },
+    "community_line": {
+      "tag": "lane:community",
+      "rule": "Never auto-enrolled into any comms:* drip/newsletter; never an automation segment. comms:* sits on a community-line contact ONLY with explicit newsletter_consent=Yes evidence (their choice; storyteller/Elder opt-ins human-confirmed). NOT exclusion - operational + 1:1 + opt-in messages still reach them.",
+      "_comment": "OCAP agency model, forms-plan R3/R9. Canon: wiki/concepts/ghl-audience-comms-automation.md §5."
+    },
+    "consent_gate": {
+      "rule": "No comms:justicehub-newsletter without newsletter_consent=Yes captured at the form (Spam Act 2003). Inquiry is not consent.",
+      "consent_field": "newsletter_consent",
+      "consent_field_id": "aVnqmajnysMtGYhLD0oA"
+    }
+  },
+  "newsletter": {
+    "_comment": "R4: the build spec's '6 CONTAINED streams' are NOT six new comms: tags. There is ONE enrolment tag (comms:justicehub-newsletter, consent-gated). The streams become smart-list SEGMENTS keyed on canonical tags. A send targets a segment, not a tag.",
+    "enrolment_tag": "comms:justicehub-newsletter",
+    "consent_required": true,
+    "segments": {
+      "adelaide-invite": { "query": ["comms:justicehub-newsletter", "source:event:contained-adelaide", "place:sa"], "build_spec_name": "Adelaide Warm Invite", "legacy_tag_migrated_from": "newsletter-stream:contained-adelaide-invite" },
+      "daily-recap": { "query": ["comms:justicehub-newsletter", "source:event:contained-adelaide", "engagement:experienced"], "build_spec_name": "Daily CONTAINED Recap" },
+      "youth-justice": { "query": ["comms:justicehub-newsletter", "interest:justice-reform"], "build_spec_name": "JusticeHub / Youth Justice", "_comment": "roles service/practitioner/policy/researcher all carry interest:justice-reform" },
+      "media-pack": { "query": ["comms:justicehub-newsletter", "role:media"], "build_spec_name": "Media Pack" },
+      "funder-brief": { "query": ["comms:justicehub-newsletter", "role:funder"], "build_spec_name": "Funder / Partner Brief" },
+      "future-cities": { "query": ["comms:justicehub-newsletter", "source:event:contained-next-city"], "build_spec_name": "Future Cities" }
+    }
+  },
+  "calendar": {
+    "_comment": "Self-serve booking (Ben, 2026-06-09) - the precondition that un-defers the pipeline (campaign-CRM plan D1). Live creation = Tier 3, gated to go/no-go.",
+    "name": "CONTAINED Adelaide Walkthroughs",
+    "venue": "Tandanya, Adelaide",
+    "slot_minutes": 30,
+    "on_booking_confirmed": { "set_field": "slot_confirmed", "move_opportunity_to": "Booked" },
+    "consent_capture": "newsletter_consent on the booking form",
+    "ocap": "Never auto-drip a lane:community booker; re-offer no-shows by human follow-up."
+  },
+  "pipeline": {
+    "_comment": "Now SCOPED (was deferred D1) because the self-serve calendar exists. Triggers re-based onto canonical signals (replacing project:contained-adelaide-2026 / cohort: / engagement:booked tags). Build = Tier 3, gated.",
+    "name": "CONTAINED Adelaide 2026",
+    "stages": [
+      { "n": 1, "name": "Captured", "entry": "source:event:contained-adelaide added" },
+      { "n": 2, "name": "Needs enrichment", "entry": "no role:* OR no org" },
+      { "n": 3, "name": "Warm - review", "entry": "role:* + inbound signal" },
+      { "n": 4, "name": "Personal invite", "entry": "role:funder OR role:media OR VIP segment" },
+      { "n": 5, "name": "Booking link sent", "entry": "calendar link sent" },
+      { "n": 6, "name": "Booked", "entry": "calendar booking confirmed -> slot_confirmed" },
+      { "n": 7, "name": "Experienced", "entry": "check-in (engagement:experienced)" },
+      { "n": 8, "name": "Activated", "entry": "journal/story/pledge captured" },
+      { "n": 9, "name": "Post-week nurture", "entry": "+7d after Activated" },
+      { "n": 10, "name": "Future city / partner", "entry": "source:event:contained-<next-city> interest" },
+      { "n": 11, "name": "Closed / no contact", "entry": "done OR lane:community no-contact" }
+    ],
+    "suppression_guard": {
+      "_comment": "Build FIRST (A8). Safety backstop before any send.",
+      "triggers": ["DND", "Email Unsubscribed", "consent_status=No consent", "lane:community", "comms:do-not-bulk"],
+      "action": "strip from all comms:*; stop other workflows"
+    }
+  },
+  "lifecycle_layer": {
+    "_comment": "RC2 open: are engagement:/campaign-stage: formal-taxonomy keepers or do they migrate? Pending that ruling, treat as the campaign lifecycle SEGMENT layer, keyed to CONTAINED by source:event:contained-adelaide.",
+    "namespaces": ["engagement:", "campaign-stage:"],
+    "dropped": ["cohort:", "newsletter-stream:"]
+  },
+  "custom_fields": {
+    "_comment": "Verified live 2026-06-09 (read-only). Most exist; 2 to create. cohort retained as a FIELD (not a tag) for views; cohort: TAG is dropped (R4).",
+    "existing": {
+      "consent_status": "MtsIWjiOFaplbdN74aZq",
+      "newsletter_consent": "aVnqmajnysMtGYhLD0oA",
+      "consent_source": "HdnMUyXkZRPZG7l7cygG",
+      "accessibility_needs": "5rqthmNGSZjWvNRjprsq",
+      "contained_feelings": "jdg2CKTbwB9Ok0jbOjZO",
+      "world_tour_stop": "wCYkjkrJZT0y1wepQULe",
+      "engagement_score": "jHzIS8jdfj0VUMzPm1dT",
+      "engagement_tier": "c0BjCYwdA3iNK5DS8N2A"
+    },
+    "to_create": {
+      "cohort": { "type": "SINGLE_OPTIONS", "options": ["young-people", "student-service", "conference-delegate", "vip-media", "next-city", "public"], "_comment": "mirrors the old cohort:<x> tag for views/reporting; tag itself dropped" },
+      "slot_confirmed": { "type": "DATE", "_comment": "set when the self-serve calendar booking is confirmed" }
+    }
+  },
+  "cta_map": {
+    "_comment": "Condensed from the JusticeHub 24-CTA inventory (thoughts/shared/handoffs/contained-cta-ghl-inventory.md). status: canonical | migrate | build | local-only.",
+    "register": { "route": "/api/ghl/register", "status": "migrate", "from": ["project:contained", "project:contained-adelaide-2026", "source:form", "state:<x>", "newsletter-stream:contained-adelaide-invite"], "to": ["project:act-jh", "source:event:contained-adelaide", "interest:justice-reform", "place:<x>", "role:<x>", "comms:justicehub-newsletter (consent)"] },
+    "register_interest": { "route": "/api/ghl/signup", "status": "migrate", "fix": "drop underscore customTags contained/contained_<role>; add source:event:contained-adelaide + interest:justice-reform" },
+    "join": { "route": "/api/ghl/signup", "status": "canonical", "fix": "add source:event:contained-adelaide on CONTAINED-origin signups" },
+    "reaction": { "route": "/api/contained/reaction", "status": "migrate", "from": ["Reacted", "CONTAINED", "contained_adelaide", "public_visitor", "youth_remand"], "to": ["project:act-jh", "source:event:contained-adelaide", "interest:justice-reform", "role:supporter", "tier:curious"] },
+    "share_story": { "route": "/api/projects/the-contained/tour-stories", "status": "migrate", "note": "legacy GHL_TAGS on email; canonicalise" },
+    "help": { "route": "/api/contact", "status": "canonical", "fix": "source:event:contained -> source:event:contained-adelaide" },
+    "canberra": { "route": "/api/contact", "status": "canonical", "fix": "same as help" },
+    "tour_newsletter": { "route": "/api/ghl/newsletter", "status": "migrate", "fix": "add source:event:contained-adelaide + interest:justice-reform" },
+    "nominate_leader": { "route": "/api/projects/[slug]/nominations", "status": "build", "gap": "dead anchor /contained#nominate (empty section); backend exists, no form renders", "to": ["project:act-jh", "source:event:contained-adelaide", "interest:justice-reform"], "field": "nominated_person" },
+    "host_back_tour": { "route": "(none)", "status": "build", "gap": "anchor/static card; no capture", "to": ["project:act-jh", "source:event:contained-adelaide", "role:partner|role:supporter", "interest:justice-reform"], "note": "host offer -> opportunity; pricing ladder $5K-$75K via Xero ACT-CN" },
+    "funder_partner_outreach": { "route": "mailto", "status": "build", "gap": "mailto only, zero CRM capture", "to": ["project:act-jh", "source:event:contained-adelaide", "role:funder|partner|media"], "note": "open opportunity; reply-to benjamin@act.place" },
+    "in_experience_widgets": { "route": "/api/contained/reflections,/stories/submit,/tour-stories", "status": "build", "gap": "Supabase only, no GHL contact", "to": ["project:act-jh", "source:event:contained-adelaide", "role:storyteller", "lane:community (if lived-exp)"], "note": "upsert only when name/email attached; no comms:" },
+    "enroll_device": { "route": "/api/enrollment/*", "status": "local-only", "note": "anonymous device session by design; product decision on kiosk opt-in (open, low priority)" }
+  },
+  "preflight": {
+    "_comment": "From the campaign-CRM plan P0 evidence. The port's dry-run must reproduce these before any apply.",
+    "import_rows": 269,
+    "matchable_by_email": 260,
+    "ghl_id_conflicts": 9,
+    "conflict_policy": "additive-tags-only; if export GHL-ID and email-lookup return different IDs -> mark pending, skip. 9 conflicts are multi-way email dupes (3-5 records each) -> human merge in GHL UI. Kristy Bloomfield = community line.",
+    "eligibility_gate": { "eligible": 113, "blocked": 2916, "verified": "2026-06-09" }
+  },
+  "migration": {
+    "_comment": "Off-contract -> canonical rename map for the gated taxonomy migration (Tier 3, day-shift, additive-then-strip, conflict-guarded, re-assert community-line guard after each bucket). Run via scripts/ghl-taxonomy-migrate.mjs --dry-run first. RC3 open: strip the legacy tag after adding canonical (recommended) vs leave as marker.",
+    "map": {
+      "project:contained": "project:act-jh + source:event:contained-adelaide",
+      "project:contained-adelaide-2026": "source:event:contained-adelaide (+ keep project:act-jh)",
+      "source:form": "source:event:contained-adelaide",
+      "state:<x>": "place:<x>",
+      "newsletter-stream:contained-adelaide-invite": "comms:justicehub-newsletter (only if newsletter_consent=Yes) + smart-list segment",
+      "cohort:<x>": "drop tag; set cohort custom field",
+      "role:lived-experience": "lane:community + role:storyteller (suppress comms)"
+    },
+    "live_counts_2026-06-09": { "project:contained-adelaide-2026": 260, "newsletter-stream:contained-adelaide-invite": 28 }
+  },
+  "tier_discipline": "This file is DATA (Tier 1). The dry-run validator (scripts/campaign-preflight.mjs) makes no GHL calls (Tier 1). The preflight module --apply, the tag migration, custom-field/calendar/pipeline creation, automations, and any send are Tier 3, day-shift, human-in-loop, gated to the 16 Jun go/no-go. Never AFK."
+}

--- a/config/campaigns/contained-adelaide-2026.json
+++ b/config/campaigns/contained-adelaide-2026.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "updated": "2026-06-09",
-  "status": "draft-for-build",
-  "description": "Canonical GHL campaign config for CONTAINED Adelaide 2026. P1 of thoughts/shared/plans/2026-06-08-contained-adelaide-campaign-crm.md, under the R4 ruling (CONTAINED conforms to the one-account canonical contract: project:act-jh + source:event:contained-adelaide + interest:justice-reform + comms:justicehub-newsletter). DATA ONLY. No code here applies anything; live GHL writes are Tier 3, day-shift, gated to the 16 Jun go/no-go. Source evidence cited in thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md.",
+  "status": "rulings-locked",
+  "description": "Canonical GHL campaign config for CONTAINED Adelaide 2026. P1 of thoughts/shared/plans/2026-06-08-contained-adelaide-campaign-crm.md, under the R4 ruling (CONTAINED conforms to the one-account canonical contract: project:act-jh + source:event:contained-adelaide + interest:justice-reform + comms:justicehub-newsletter). RC1-RC4 LOCKED 2026-06-09: RC1 Professional->partner; RC2 keep engagement:/campaign-stage: lifecycle; RC3 strip legacy tag after canonical; RC4 GHL native calendar. DATA ONLY. No code here applies anything; live GHL writes are Tier 3, day-shift, gated to the 16 Jun go/no-go. Source evidence cited in thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md.",
   "meta": {
     "campaign_code": "ACT-CN",
     "campaign_name": "CONTAINED Adelaide 2026",
@@ -22,18 +22,18 @@
       "interest:justice-reform"
     ],
     "role_map": {
-      "_comment": "JusticeHub register/signup role dropdown -> canonical role: namespace (8 canonical roles: funder/partner/buyer/supporter/storyteller/researcher/media/community). 'ruling' flags are OPEN (RC1) - PROPOSED mappings, not final.",
+      "_comment": "JusticeHub register/signup role dropdown -> canonical role: namespace (8 canonical roles: funder/partner/buyer/supporter/storyteller/researcher/media/community). RC1 LOCKED 2026-06-09 (Professional->partner scheme): service_org/practitioner/policymaker->role:partner; advocate/artist/student->role:supporter.",
       "researcher": { "tags": ["role:researcher"], "ruling": "locked" },
       "media": { "tags": ["role:media"], "ruling": "locked" },
       "funder": { "tags": ["role:funder"], "ruling": "locked" },
       "community": { "tags": ["role:community"], "ruling": "locked" },
       "lived_experience": { "tags": ["lane:community", "role:storyteller"], "suppress_comms": true, "ruling": "locked-R3", "_comment": "OCAP: never auto-enrolled into comms:*; automation suppressed even on a newsletter tick; explicit opt-in human-confirmed." },
-      "service_org": { "tags": ["role:partner"], "ruling": "PROPOSED-RC1" },
-      "practitioner": { "tags": ["role:supporter"], "ruling": "PROPOSED-RC1" },
-      "policymaker": { "tags": ["role:partner"], "ruling": "PROPOSED-RC1" },
-      "advocate": { "tags": ["role:supporter"], "ruling": "PROPOSED-RC1" },
-      "artist": { "tags": ["role:supporter", "interest:storytelling"], "ruling": "PROPOSED-RC1" },
-      "student": { "tags": ["role:supporter"], "ruling": "PROPOSED-RC1" },
+      "service_org": { "tags": ["role:partner"], "ruling": "locked-RC1" },
+      "practitioner": { "tags": ["role:partner"], "ruling": "locked-RC1" },
+      "policymaker": { "tags": ["role:partner"], "ruling": "locked-RC1" },
+      "advocate": { "tags": ["role:supporter"], "ruling": "locked-RC1" },
+      "artist": { "tags": ["role:supporter", "interest:storytelling"], "ruling": "locked-RC1" },
+      "student": { "tags": ["role:supporter"], "ruling": "locked-RC1" },
       "supporter": { "tags": ["role:supporter"], "ruling": "locked" }
     },
     "state_to_place": {
@@ -66,7 +66,8 @@
     }
   },
   "calendar": {
-    "_comment": "Self-serve booking (Ben, 2026-06-09) - the precondition that un-defers the pipeline (campaign-CRM plan D1). Live creation = Tier 3, gated to go/no-go.",
+    "_comment": "Self-serve booking (Ben, 2026-06-09) - the precondition that un-defers the pipeline (campaign-CRM plan D1). Live creation = Tier 3, gated to go/no-go. RC4 LOCKED 2026-06-09: GHL native Calendar, not an embedded form.",
+    "type": "ghl-native-calendar",
     "name": "CONTAINED Adelaide Walkthroughs",
     "venue": "Tandanya, Adelaide",
     "slot_minutes": 30,
@@ -97,7 +98,7 @@
     }
   },
   "lifecycle_layer": {
-    "_comment": "RC2 open: are engagement:/campaign-stage: formal-taxonomy keepers or do they migrate? Pending that ruling, treat as the campaign lifecycle SEGMENT layer, keyed to CONTAINED by source:event:contained-adelaide.",
+    "_comment": "RC2 LOCKED 2026-06-09: keep engagement:/campaign-stage: as the campaign lifecycle SEGMENT layer, keyed to CONTAINED by source:event:contained-adelaide. No migration of these namespaces for this campaign.",
     "namespaces": ["engagement:", "campaign-stage:"],
     "dropped": ["cohort:", "newsletter-stream:"]
   },
@@ -143,7 +144,8 @@
     "eligibility_gate": { "eligible": 113, "blocked": 2916, "verified": "2026-06-09" }
   },
   "migration": {
-    "_comment": "Off-contract -> canonical rename map for the gated taxonomy migration (Tier 3, day-shift, additive-then-strip, conflict-guarded, re-assert community-line guard after each bucket). Run via scripts/ghl-taxonomy-migrate.mjs --dry-run first. RC3 open: strip the legacy tag after adding canonical (recommended) vs leave as marker.",
+    "_comment": "Off-contract -> canonical rename map for the gated taxonomy migration (Tier 3, day-shift, additive-then-strip, conflict-guarded, re-assert community-line guard after each bucket). Run via scripts/ghl-taxonomy-migrate.mjs --dry-run first. RC3 LOCKED 2026-06-09: STRIP the legacy tag after adding canonical (additive-then-strip).",
+    "strip_legacy_after_canonical": true,
     "map": {
       "project:contained": "project:act-jh + source:event:contained-adelaide",
       "project:contained-adelaide-2026": "source:event:contained-adelaide (+ keep project:act-jh)",

--- a/scripts/campaign-preflight.mjs
+++ b/scripts/campaign-preflight.mjs
@@ -89,7 +89,7 @@ for (const t of cfg.canonical_contract?.always || []) line(`  ${t}`);
 line(`  newsletter (consent-gated): ${cfg.newsletter?.enrolment_tag}`);
 line(`  community line: ${cfg.canonical_contract?.community_line?.tag} (no auto comms:*)`);
 
-line(`\n-- role map (RC1: PROPOSED entries need a ruling) --`);
+line(`\n-- role map (canonical role: tags; "<-- needs ruling" only if any remain PROPOSED) --`);
 for (const [role, def] of realEntries(cfg.canonical_contract?.role_map)) {
   const flag = def.ruling?.startsWith('PROPOSED') ? '  <-- needs ruling' : '';
   line(`  ${role.padEnd(16)} -> ${def.tags.join(', ')}${def.suppress_comms ? '  [suppress comms]' : ''}${flag}`);

--- a/scripts/campaign-preflight.mjs
+++ b/scripts/campaign-preflight.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/**
+ * campaign-preflight.mjs — DRY-RUN campaign config validator + printer.
+ *
+ * Scaffold for P1/P2 of thoughts/shared/plans/2026-06-08-contained-adelaide-campaign-crm.md.
+ * Loads a config/campaigns/<campaign>.json, validates its shape, and prints the
+ * canonical contract, the CTA -> canonical migration map, the off-contract tag
+ * migration map, and the preflight gate.
+ *
+ * TIER 1 ONLY. This script makes NO GHL calls and imports no GHLService. It reads
+ * a local JSON file and prints. The live preflight (GHLService, dry-run counts) is
+ * P2 (scripts/lib/campaign-ghl-preflight.mjs, to build). Any --apply is Tier 3,
+ * day-shift, explicit verb, gated to the go/no-go — this scaffold refuses it.
+ *
+ * Usage:
+ *   node scripts/campaign-preflight.mjs                       # validates contained-adelaide-2026
+ *   node scripts/campaign-preflight.mjs <path-to-config.json>
+ *   node scripts/campaign-preflight.mjs --apply               # refused (Tier 3 gate)
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const DEFAULT_CONFIG = join(REPO_ROOT, 'config/campaigns/contained-adelaide-2026.json');
+
+const args = process.argv.slice(2);
+
+if (args.includes('--apply')) {
+  console.error(
+    '\nREFUSED: --apply is a Tier 3 action (live GHL writes).\n' +
+    'This scaffold is dry-run only. Live apply (tag migration, custom-field/calendar/\n' +
+    'pipeline creation, automations, sends) is day-shift, human-in-loop, explicit verb,\n' +
+    'gated to the campaign go/no-go. Use the P2 module (scripts/lib/campaign-ghl-preflight.mjs)\n' +
+    'with the existing field-align/orbit gated-apply pattern, not this validator.\n'
+  );
+  process.exit(2);
+}
+
+const configPath = args.find((a) => !a.startsWith('--')) || DEFAULT_CONFIG;
+
+let cfg;
+try {
+  cfg = JSON.parse(readFileSync(configPath, 'utf8'));
+} catch (err) {
+  console.error(`FAILED to read/parse config: ${configPath}\n  ${err.message}`);
+  process.exit(1);
+}
+
+// --- validation -----------------------------------------------------------
+const problems = [];
+const require = (cond, msg) => { if (!cond) problems.push(msg); };
+
+require(cfg.meta?.ghl_location_id, 'meta.ghl_location_id missing');
+require(cfg.meta?.campaign_slug, 'meta.campaign_slug missing');
+require(Array.isArray(cfg.canonical_contract?.always) && cfg.canonical_contract.always.length > 0,
+  'canonical_contract.always must be a non-empty array');
+require(cfg.canonical_contract?.consent_gate?.consent_field, 'canonical_contract.consent_gate.consent_field missing');
+require(cfg.newsletter?.enrolment_tag?.startsWith('comms:'), 'newsletter.enrolment_tag must be a comms:* tag (consent-gated)');
+
+// skip annotation keys (_comment, etc.) when iterating maps
+const realEntries = (o) => Object.entries(o || {}).filter(([k]) => !k.startsWith('_'));
+
+// every role_map entry must carry at least one tag
+for (const [role, def] of realEntries(cfg.canonical_contract?.role_map)) {
+  require(Array.isArray(def.tags) && def.tags.length > 0, `role_map.${role} has no tags`);
+}
+// every cta_map entry needs a known status
+const OK_STATUS = new Set(['canonical', 'migrate', 'build', 'local-only']);
+for (const [cta, def] of realEntries(cfg.cta_map)) {
+  require(OK_STATUS.has(def.status), `cta_map.${cta}.status="${def.status}" not one of ${[...OK_STATUS].join('|')}`);
+}
+// every always tag must be a colon-namespaced canonical tag (no underscore aliases)
+for (const t of cfg.canonical_contract?.always || []) {
+  require(t.includes(':') && !t.includes('_'), `canonical_contract.always tag "${t}" is not colon-canonical`);
+}
+
+// --- print ----------------------------------------------------------------
+const line = (s = '') => console.log(s);
+line(`\n=== campaign-preflight (DRY-RUN, no GHL calls) ===`);
+line(`config:   ${configPath}`);
+line(`campaign: ${cfg.meta?.campaign_name}  [${cfg.meta?.campaign_code}]  status=${cfg.status}`);
+line(`location: ${cfg.meta?.ghl_location_name} (${cfg.meta?.ghl_location_id})`);
+line(`go/no-go: ${cfg.meta?.go_no_go}   event: ${cfg.meta?.event_dates}`);
+
+line(`\n-- canonical contract (every contact) --`);
+for (const t of cfg.canonical_contract?.always || []) line(`  ${t}`);
+line(`  newsletter (consent-gated): ${cfg.newsletter?.enrolment_tag}`);
+line(`  community line: ${cfg.canonical_contract?.community_line?.tag} (no auto comms:*)`);
+
+line(`\n-- role map (RC1: PROPOSED entries need a ruling) --`);
+for (const [role, def] of realEntries(cfg.canonical_contract?.role_map)) {
+  const flag = def.ruling?.startsWith('PROPOSED') ? '  <-- needs ruling' : '';
+  line(`  ${role.padEnd(16)} -> ${def.tags.join(', ')}${def.suppress_comms ? '  [suppress comms]' : ''}${flag}`);
+}
+
+const ctaEntries = realEntries(cfg.cta_map);
+line(`\n-- CTA map (${ctaEntries.length} CTAs) --`);
+const byStatus = { migrate: [], build: [], canonical: [], 'local-only': [] };
+for (const [cta, def] of ctaEntries) (byStatus[def.status] ||= []).push(cta);
+for (const s of ['migrate', 'build', 'canonical', 'local-only']) {
+  if (byStatus[s]?.length) line(`  ${s.padEnd(11)}: ${byStatus[s].join(', ')}`);
+}
+
+line(`\n-- off-contract -> canonical migration (Tier 3, gated) --`);
+for (const [from, to] of Object.entries(cfg.migration?.map || {})) line(`  ${from}  ->  ${to}`);
+const liveCounts = cfg.migration?.['live_counts_2026-06-09'];
+if (liveCounts) line(`  live counts: ${Object.entries(liveCounts).map(([k, v]) => `${k}=${v}`).join(', ')}`);
+
+line(`\n-- preflight gate --`);
+const pf = cfg.preflight || {};
+line(`  import rows ${pf.import_rows} | matchable ${pf.matchable_by_email} | conflicts ${pf.ghl_id_conflicts}`);
+line(`  eligibility: ${pf.eligibility_gate?.eligible} eligible / ${pf.eligibility_gate?.blocked} blocked`);
+
+line(`\n-- validation --`);
+if (problems.length === 0) {
+  line('  OK: config is internally consistent (dry-run; not checked against live GHL).');
+} else {
+  line(`  ${problems.length} problem(s):`);
+  for (const p of problems) line(`    - ${p}`);
+}
+line(`\nNote: dry-run only. Live apply is Tier 3 / day-shift / gated to ${cfg.meta?.go_no_go}.\n`);
+
+process.exit(problems.length === 0 ? 0 : 1);

--- a/scripts/phantom-consent-guard.mjs
+++ b/scripts/phantom-consent-guard.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * phantom-consent-guard.mjs — audit (default) + revoke (--apply) PHANTOM newsletter consent.
+ *
+ * PHANTOM consent = GHL `Newsletter Consent = Yes` with NO `Consent Source` AND NO `Consent Timestamp`.
+ * Real opt-ins always carry a source + timestamp; a bare Yes is consent that was never given (root cause:
+ * a manual GHL-UI prospect import — see thoughts/shared/reviews/2026-06-09_phantom-consent-root-cause.md).
+ * Phantom consent passes a naive `Yes`-only send gate → Spam Act exposure.
+ *
+ * MODES
+ *   (default, dry-run)  AUDIT — read-only. Scans consented contacts live, reports every phantom, writes
+ *                       a dated audit md. Cron-safe; alert when count > 0. This is the standing monitor.
+ *   --apply             REVOKE — set `Newsletter Consent = No` on each phantom (re-verified live first).
+ *                       Tier-2/3 write — HELD; needs explicit human authorisation. Revoking never-given
+ *                       consent is the always-safe direction. NEVER sets Yes; never touches a real opt-in.
+ *
+ *   --sample N          only check the first N consented contacts (fast smoke test).
+ *
+ * Truth source: LIVE GHL (the mirror carries newsletter_consent but NOT source/timestamp). Mirror is used
+ * only to enumerate candidate ghl_ids (consent=true).
+ */
+import 'dotenv/config';
+import fs from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+import { createGHLService } from './lib/ghl-api-service.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const sIx = process.argv.indexOf('--sample');
+const SAMPLE = sIx > -1 ? parseInt(process.argv[sIx + 1], 10) : 0;
+const EXPECT_LOC = 'agzsSZWgovjwgpcoASWG';
+const CONSENT_FIELD_ID = 'aVnqmajnysMtGYhLD0oA'; // "Newsletter Consent" (Yes|No)
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (process.env.GHL_LOCATION_ID !== EXPECT_LOC) throw new Error(`GHL_LOCATION_ID mismatch: ${process.env.GHL_LOCATION_ID}`);
+const sb = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const ghl = createGHLService();
+const cfs = await ghl.getCustomFields();
+const id2n = new Map(cfs.map((f) => [f.id, f.name]));
+const val = (live, re) => { const f = (live.customFields || []).find((x) => re.test(id2n.get(x.id) || '')); return f ? String(f.value || '') : ''; };
+
+console.log(`\n=== Phantom-consent guard — ${APPLY ? 'REVOKE (--apply)' : 'AUDIT (dry-run)'}${SAMPLE ? ` --sample ${SAMPLE}` : ''} ===\n`);
+
+// 1. enumerate consented candidates from the mirror (paginated past the 1000-cap)
+let cand = [], from = 0;
+for (;;) {
+  const { data } = await sb.from('ghl_contacts').select('ghl_id,email,full_name,tags').eq('newsletter_consent', true).range(from, from + 999);
+  cand = cand.concat(data || []); if (!data || data.length < 1000) break; from += 1000;
+}
+cand = cand.filter((r) => !(r.tags || []).some((t) => String(t).startsWith('gone-from-ghl')));
+if (SAMPLE) cand = cand.slice(0, SAMPLE);
+console.log(`consented candidates (mirror): ${cand.length} — checking live provenance…\n`);
+
+// 2. live provenance per candidate → classify PHANTOM vs REAL
+const phantom = [];
+let i = 0;
+for (const c of cand) {
+  i++;
+  try {
+    const live = await ghl.getContactById(c.ghl_id); await sleep(1100);
+    const nl = val(live, /newsletter consent/i);
+    if (!/^yes$/i.test(nl)) continue; // mirror said Yes but live isn't — skip (stale)
+    const src = val(live, /consent source/i), ts = val(live, /consent timestamp/i);
+    if (!src && !ts) phantom.push({ ...c, dateAdded: (live.dateAdded || '').slice(0, 10), source: live.source || '' });
+  } catch { /* transient — skip this pass */ }
+  if (i % 50 === 0) console.error(`  …${i}/${cand.length}`);
+}
+console.log(`\nPHANTOM consent found: ${phantom.length} / ${cand.length} checked`);
+phantom.slice(0, 30).forEach((p) => console.log(`  - ${(p.full_name || p.email || p.ghl_id).padEnd(34)} added=${p.dateAdded} src="${p.source}"`));
+if (phantom.length > 30) console.log(`  …and ${phantom.length - 30} more`);
+
+const today = new Date().toISOString().slice(0, 10);
+const audit = `thoughts/shared/reviews/${today}_phantom-consent-audit.md`;
+fs.writeFileSync(audit, `# Phantom-consent audit — ${today}\n\nconsented checked: ${cand.length}${SAMPLE ? ' (sampled)' : ''}\nPHANTOM (Yes, no source/timestamp): **${phantom.length}**\n\n${phantom.map((p) => `- ${p.full_name || p.email} \`${p.ghl_id}\` added=${p.dateAdded} src="${p.source}"`).join('\n')}\n`);
+console.log(`\naudit → ${audit}`);
+
+if (!APPLY) { console.log(`\n[dry-run / AUDIT] No writes. ${phantom.length} phantom consent(s). Run with --apply to REVOKE (set Newsletter Consent = No).\n`); process.exit(0); }
+
+// 3. REVOKE — re-verify live, then set Newsletter Consent = No (never Yes)
+let revoked = 0;
+for (const p of phantom) {
+  try {
+    const live = await ghl.getContactById(p.ghl_id); await sleep(1100);
+    if (!/^yes$/i.test(val(live, /newsletter consent/i))) { console.log(`SKIP ${p.email} — not Yes now`); continue; }
+    if (val(live, /consent source/i) || val(live, /consent timestamp/i)) { console.log(`SKIP ${p.email} — has provenance now`); continue; }
+    await ghl.updateContact(p.ghl_id, { customFields: [{ id: CONSENT_FIELD_ID, value: 'No' }] }); await sleep(1100);
+    revoked++; console.log(`✓ revoked ${p.email}`);
+  } catch (e) { console.log(`✗ ${p.email}: ${String(e.message).slice(0, 60)}`); }
+}
+console.log(`\nRevoked ${revoked}/${phantom.length}. (Newsletter Consent → No; never set Yes; mirror re-syncs on next sync-ghl-to-supabase.)\n`);

--- a/thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md
+++ b/thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md
@@ -126,19 +126,21 @@ Suppression guard (A8 in the build spec) is unchanged and must be built FIRST: D
 
 **Phase D — gated live build (Tier 3, day-shift, 16 Jun go/no-go):** create the 2 missing custom fields (`cohort`, `slot_confirmed`); create the calendar; create the pipeline + 11 stages; build A1-A8 automations on canonical triggers; **run the off-contract → canonical tag migration on the ~260 contacts** (additive-then-strip, conflict-guarded, re-assert community-line guard after each bucket); resolve the 9 multi-way duplicate contacts in the GHL UI (Kristy Bloomfield = community line). First send of every stream = preview to Ben, then enable.
 
-## Open rulings (do not guess)
+## Locked rulings (Ben, 2026-06-09)
 
-- **RC1 — role mapping for CONTAINED's 12-role dropdown → 8 canonical roles.** Obvious: researcher/media/funder/community map 1:1; lived_experience→`lane:community`+`role:storyteller` (R3). **Needs ruling:** practitioner, service_org, student, policymaker, advocate, artist → which canonical `role:` / `interest:`? (Config encodes PROPOSED mappings, marked.)
-- **RC2 — `engagement:`/`campaign-stage:` keepers?** Are these formal-taxonomy namespaces or do they migrate in the taxonomy worksheet? The lifecycle layer depends on the answer.
-- **RC3 — the ~260 live `project:contained-adelaide-2026` contacts.** Strip the tag after adding canonical, or leave as a legacy campaign marker? (Recommend: add canonical, strip the off-contract tag in the gated migration.)
-- **RC4 — calendar location of record.** GHL native calendar vs an embedded booking form that writes the booking. (Spec assumes GHL native calendar.)
+- **RC1 — role mapping → LOCKED (Professional→partner).** researcher/media/funder/community map 1:1; lived_experience→`lane:community`+`role:storyteller` (R3); **service_org + practitioner + policymaker → `role:partner`**; **advocate + artist + student → `role:supporter`** (artist also `interest:storytelling`).
+- **RC2 — `engagement:`/`campaign-stage:` → LOCKED (keep).** They remain the CONTAINED lifecycle layer, keyed by `source:event:contained-adelaide`. No migration of these namespaces for this campaign.
+- **RC3 — the ~260 `project:contained-adelaide-2026` contacts → LOCKED (strip).** Gated migration adds canonical, then strips the off-contract tag (additive-then-strip).
+- **RC4 — booking → LOCKED (GHL native Calendar).** GHL Calendars, not an embedded form; a confirmed booking sets `slot_confirmed` and moves the opportunity to Booked.
 
 ## Decision + verification log
 
 - 2026-06-09 — **R4 wins (Ben, AskUserQuestion):** CONTAINED conforms to canonical; register route + build spec + ~260 contacts migrate. Self-serve calendar chosen (un-defers pipeline). All CTAs in scope.
+- 2026-06-09 — **RC1-RC4 locked (Ben, AskUserQuestion):** RC1 Professional→partner (service_org/practitioner/policymaker→`role:partner`; advocate/artist/student→`role:supporter`); RC2 keep `engagement:`/`campaign-stage:` lifecycle; RC3 strip legacy tag after canonical; RC4 GHL native Calendar.
 - 2026-06-09 VERIFIED (read-only, live GHL, loc `agzsSZWgovjwgpcoASWG`): custom fields present except `cohort`+`slot_confirmed` (to create); no "CONTAINED Adelaide 2026" pipeline yet; eligibility gate 113 eligible / 2916 blocked; `newsletter-stream:contained-adelaide-invite`=28; `project:contained-adelaide-2026`=260. Evidence: JusticeHub `eligibility-verification-2026-06-09.md`.
 - 2026-06-09 VERIFIED (read-only, JusticeHub): 24 CTAs mapped, 9 capture gaps, `GHL_CANONICAL` exists, 4/5 routes already canonical, `project:` split. Evidence: `contained-cta-ghl-inventory.md`.
 - 2026-06-09 FLAGGED: a colon→underscore `tag-normalize` dry-run artifact in JusticeHub `output/ghl-contained-adelaide-audit/` is wrong-direction (would orphan the register form's colon tags); do NOT apply it.
 
 ## Changelog
 - 2026-06-09 — alignment handoff created; R4 ruling recorded; canonical contract + CTA map + calendar spec + build sequence; config + dry-run scaffold produced.
+- 2026-06-09 — RC1-RC4 locked; config role_map finalized (practitioner→`role:partner`), lifecycle/migration/calendar rulings recorded; status → rulings-locked.

--- a/thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md
+++ b/thoughts/shared/handoffs/general/2026-06-09_contained-cta-ghl-alignment.md
@@ -1,0 +1,144 @@
+---
+session: general
+date: 2026-06-09
+status: ready-for-build
+outcome: ALIGNMENT-SPEC
+owner: Ben (rulings + Tier 2/3 verbs) · session (doc + config + dry-run scaffold)
+relates_to:
+  - thoughts/shared/plans/2026-06-08-contained-adelaide-campaign-crm.md   # the durable campaign-CRM module plan (P0-P4) this extends
+  - thoughts/shared/plans/2026-06-08-whole-system-forms-tag-alignment.md  # the canonical contract + R1-R11 rulings (R4 = CONTAINED representation)
+  - thoughts/shared/handoffs/general/2026-06-08_contained-crm-p0-complete-build-handoff.yaml
+  - wiki/concepts/ghl-audience-comms-automation.md   # the 5-layer model + consent/community gates
+  - wiki/concepts/ghl-crm-taxonomy.md                # the canonical namespaces (§3)
+  - /Users/benknight/Code/JusticeHub/thoughts/shared/handoffs/contained-cta-ghl-inventory.md  # full 24-CTA audit (source evidence)
+  - /Users/benknight/Code/JusticeHub/output/contained-ghl-ui-build-spec.md  # the GHL UI build spec (to be re-based onto canonical)
+  - /Users/benknight/Code/JusticeHub/output/ghl-contained-adelaide-audit/eligibility-verification-2026-06-09.md  # 113 eligible / 2916 blocked
+produces:
+  - config/campaigns/contained-adelaide-2026.json   # canonical campaign config (P1 of the campaign-CRM plan)
+  - scripts/campaign-preflight.mjs                   # dry-run config validator/printer (no GHL calls)
+---
+
+# CONTAINED → GHL: full CTA / form / calendar alignment to the canonical contract
+
+> **What this is.** The cross-repo alignment between the CONTAINED website (JusticeHub: forms, CTAs, signup, calendar) and the durable GoHighLevel system being built here in act-global-infrastructure. It executes the campaign-CRM plan's P1 (campaign config) under one locked ruling, maps every CONTAINED CTA to the canonical contract, specs the self-serve booking calendar, and lists the build sequence to the 16 Jun go/no-go.
+>
+> **Tier discipline.** Everything in this handoff and the files it produces is Tier 1-2 (docs, config, dry-run code). **Zero live GHL writes.** The actual tag migration, the calendar creation, the pipeline build, and any send are Tier 3 / day-shift / human-in-loop, gated to the 16 Jun go/no-go. Never queue them AFK.
+
+## The decision that unblocks everything (Ben, 2026-06-09)
+
+CONTAINED carried **two incompatible tag vocabularies**:
+
+| | Live merged register route + GHL UI build spec | Canonical contract (forms-plan R4, locked 2026-06-08) |
+|---|---|---|
+| project | `project:contained` + `project:contained-adelaide-2026` | `project:act-jh` |
+| source | `source:form` | `source:event:contained-adelaide` |
+| interest | (none) | `interest:justice-reform` |
+| newsletter | `newsletter-stream:contained-adelaide-invite` (+ 5 more) | `comms:justicehub-newsletter` (consent-gated) |
+| state | `state:<x>` | `place:<x>` |
+| lifecycle | `engagement:<x>`, `cohort:<x>`, `campaign-stage:<x>` | segment layer (see below) |
+
+**RULING — Canonical R4 wins.** CONTAINED conforms to the one-account canonical contract. The register route, the GHL UI build spec, and the ~260 already-tagged live contacts migrate to canonical. No new top-level namespace for CONTAINED.
+
+Why this is the right call (and cheaper than it looks): `GHL_CANONICAL` already exists in JusticeHub `src/lib/ghl/client.ts` (added by PR #38), and **4 of the 5 GHL routes already emit canonical** (`signup`, `newsletter`, `contact`, nominations). Only `/api/ghl/register` (the CONTAINED branch) and two legacy routes (`reaction`, `tour-stories`) still emit off-contract tags. Today `project:` is split (register → `project:contained`; everything else → `project:act-jh`), so "all CONTAINED contacts" segmentation is already broken. R4 fixes the split at the root: the campaign is identified by `source:event:contained-adelaide` over a `project:act-jh` base.
+
+## The canonical CONTAINED contract (target)
+
+Layer model (from `ghl-audience-comms-automation.md`): **DESCRIBE** (identity, never triggers a send) · **SEGMENT** (smart-lists) · **ENROL** (`comms:`, consent-granted only) · **ACT** (workflows) · **GATE** (consent + community-line).
+
+**Every CONTAINED contact, regardless of which form they came through:**
+- `project:act-jh` (identity)
+- `source:event:contained-adelaide` (campaign membership = the "all CONTAINED contacts" segment key; use `source:event:contained-<city>` per stop)
+- `interest:justice-reform` (identity)
+- `role:<x>` (canonical role set, see role rulings below)
+- `place:<state>` (from `STATE_TO_PLACE`, not `state:<x>`)
+- `lane:community` + `role:storyteller` for lived-experience / youth voice (R3 OCAP: never auto-enrolled into `comms:*`; automation suppressed; explicit opt-in human-confirmed)
+
+**Newsletter / sends:** `comms:justicehub-newsletter` is the single enrolment tag, granted **only** with `newsletter_consent=Yes` captured at the form. The "6 CONTAINED streams" in the build spec are **NOT** six new `comms:` tags. They become **smart-list segments** inside justicehub-newsletter, keyed on canonical tags (see config `newsletter.segments`). A send to "media pack" = justicehub-newsletter recipients who also have `role:media`; "funder brief" = `role:funder`; "Adelaide invite" = `source:event:contained-adelaide` + `place:sa`; etc.
+
+**Campaign lifecycle (SEGMENT layer):** the build spec's `engagement:*` and `campaign-stage:*` are existing operational namespaces already on hundreds of live contacts. Keep them as the campaign lifecycle, keyed to CONTAINED by `source:event:contained-adelaide`. (`cohort:<x>` and `newsletter-stream:<x>` are dropped / migrated.) NOTE: whether `engagement:`/`campaign-stage:` are formal-taxonomy keepers or themselves migrate is an open item for the taxonomy worksheet; this config treats them as the lifecycle layer pending that ruling.
+
+## CTA → canonical mapping (all 24, from the JusticeHub inventory)
+
+Status: ✅ already canonical · 🔧 migrate to canonical · ➕ build (capture gap) · ⬜ out of scope / local-only.
+
+### Register / book
+- **#1 `/register` (CONTAINED branch)** 🔧 the one big migration. `project:contained`→`project:act-jh`; `source:form`→`source:event:contained-adelaide`; drop `project:contained-adelaide-2026`; `state:<x>`→`place:<x>`; add `interest:justice-reform`; `newsletter-stream:contained-adelaide-invite`→`comms:justicehub-newsletter` (consent-gated); align `role:<x>` to canonical; lived-experience→`lane:community`+`role:storyteller`+suppress. `cohort:<x>` → drop the tag, keep cohort in the `cohort` custom field for views.
+- **#2 `/adelaide`, #3 tour-stop CTAs** ✅ redirect into #1, inherit its (migrated) contract.
+- **#4 `/register-interest`** 🔧 rides `/api/ghl/signup` (already `project:act-jh`) but injects underscore tags `contained`, `contained_<role>` via customTags. Drop those; add `source:event:contained-adelaide` + `interest:justice-reform`.
+- **#5 `/join` signup** ✅ canonical via `/api/ghl/signup`; add `source:event:contained-adelaide` when the signup originates on a CONTAINED page.
+- **#6 `/enroll` (on-site device)** ⬜ anonymous device session by design (no contact). Product decision: offer a CRM opt-in at kiosk? (open item, low priority).
+
+### Experience (inside-container)
+- **#7 `/reaction`** 🔧 legacy `GHL_TAGS` (`Reacted`,`CONTAINED`,`contained_adelaide`,`public_visitor`,`youth_remand`). Migrate to `project:act-jh`+`source:event:contained-adelaide`+`interest:justice-reform`+`role:supporter`+`tier:curious`; reflection text → custom field; **no `comms:` without explicit consent**.
+- **#8 reflection widget, #9 story widget, #12 tour-stop story** ➕ rich first-party content to Supabase, **no GHL contact**. Build: when a name/email is attached, upsert a canonical contact (`source:event:contained-adelaide`, `role:storyteller`, `lane:community` if lived-experience, no `comms:`).
+- **#10 enrollment recommender** ⬜ recommendation engine, not a contact CTA.
+
+### Activate / share / nominate
+- **#11 `/share` story-form** 🔧 legacy `GHL_TAGS` on email; migrate as #7.
+- **#13 `/help`, #14 `/canberra`** ✅ canonical via `/api/contact` (already `project:act-jh`+`source:event:contained`); fix `source:event:contained`→`source:event:contained-adelaide` where city is known; keep `help_options` field.
+- **#15 tour newsletter footer** 🔧 canonical newsletter wiring but missing the campaign source; add `source:event:contained-adelaide` + `interest:justice-reform`.
+- **#16 "Nominate a Leader"** ➕ **biggest gap.** CTA links to an empty `<section id="nominate" />`; a working backend (`/api/projects/[slug]/nominations`) exists but nothing renders a form. Build: render the nomination form → canonical tags `project:act-jh`+`source:event:contained-adelaide`+`interest:justice-reform`+`nominated_person` field (R5: field not tag).
+
+### Host / fund
+- **#18 "Back the Tour", #21 "Host the Container"** ➕ anchor / static card, no capture. Build a host/backer form → `project:act-jh`+`source:event:contained-adelaide`+`role:partner` (host) / `role:supporter` (backer)+`interest:justice-reform`; host offers → opportunity in the campaign pipeline. (Host/sponsor pricing ladder $5K-$75K is conversation-led → opportunity → Xero ACT-CN, not e-commerce.)
+- **#20 funder/partner/media mailto** ➕ high-value outreach with **zero CRM capture**. Build: replace `mailto:` with a routed form (or a GHL form) that upserts `role:funder|partner|media` + opens an opportunity; reply-to stays `benjamin@act.place`.
+- **#19 Donate `/back-this`** ⬜ outside contained scope; verify GHL capture separately.
+- **#22 social kit, #23 passcode gates, #24 vip-dinner redirect** ⬜ not lead-capture.
+
+## Self-serve booking calendar (chosen 2026-06-09) — this un-defers the pipeline
+
+The campaign-CRM plan's **D1 deferred the GHL pipeline "until booking/open-viewing forms exist."** Choosing a self-serve calendar **creates that precondition**, so the "CONTAINED Adelaide 2026" pipeline moves from DEFERRED to scoped (still Tier-3 to build live).
+
+Spec:
+1. **GHL Calendar** "CONTAINED Adelaide Walkthroughs" (Tandanya, 24-25 Jun), slot length 30 min, capacity per slot, ops as owner. (Create in GHL UI/API = Tier 3, gated to go/no-go.)
+2. **Website CTA**: the "Book a walkthrough" CTA (today `/contained/register?cohort=...`) points to the GHL calendar booking URL after (or instead of) the register step. Keep register as the identity-capture; calendar as the slot-capture.
+3. **On booking confirmed** (GHL calendar event created): workflow sets `slot_confirmed` (date custom field, to be created) and moves the opportunity to **Booked**. This replaces the build spec's manual `engagement:booked` tag with a real booking signal.
+4. **No-show / cancel**: workflow handles re-offer; never auto-drips a community-line contact.
+5. **Consent**: the booking form captures `newsletter_consent` so a `comms:justicehub-newsletter` enrolment is lawful (Spam Act).
+
+## Pipeline (now scoped) — canonical triggers
+
+The build spec's 11 stages, re-based onto canonical triggers (replacing `project:contained-adelaide-2026` / `cohort:` / `engagement:booked` tag triggers):
+
+| # | Stage | Canonical entry signal |
+|---|-------|------------------------|
+| 1 | Captured | `source:event:contained-adelaide` added |
+| 2 | Needs enrichment | no `role:*` OR no org |
+| 3 | Warm - review | has `role:*` + inbound signal |
+| 4 | Personal invite | `role:funder` OR `role:media` OR VIP segment |
+| 5 | Booking link sent | calendar link sent |
+| 6 | Booked | calendar booking confirmed → `slot_confirmed` set |
+| 7 | Experienced | check-in (`engagement:experienced` or check-in field) |
+| 8 | Activated | journal / story / pledge captured |
+| 9 | Post-week nurture | +7d after activated |
+| 10 | Future city / partner | `source:event:contained-<next-city>` interest |
+| 11 | Closed / no contact | done or `lane:community` no-contact |
+
+Suppression guard (A8 in the build spec) is unchanged and must be built FIRST: DND / unsubscribe / `consent_status=No consent` / `lane:community` → strip from all `comms:*`.
+
+## Build sequence to 16 Jun go/no-go
+
+**Phase A — alignment (this handoff + config, Tier 1, done):** R4 ruling recorded; canonical contract defined; CTA map; config + dry-run validator scaffolded.
+
+**Phase B — JusticeHub code migration (Tier 1 code, Tier 2 push, Tier 3 deploy):** migrate `/register` CONTAINED branch + `reaction` + `share`/tour-stories to canonical; build the 3 capture gaps that are launch-relevant (nominate form #16, host/backer #18/#21, funder/partner form #20). Wire the self-serve calendar CTA. `npm run type-check`; branch + PR. (This is JusticeHub-repo work; spec lives here, code lands there.)
+
+**Phase C — GHL system (act-global, P1-P3 of the campaign-CRM plan):** finalize `config/campaigns/contained-adelaide-2026.json`; build the generalized dry-run preflight module (P2) on `GHLService`; derived `campaign_crm_segments` view + read-only command-center dashboard (P3, schema-verify first).
+
+**Phase D — gated live build (Tier 3, day-shift, 16 Jun go/no-go):** create the 2 missing custom fields (`cohort`, `slot_confirmed`); create the calendar; create the pipeline + 11 stages; build A1-A8 automations on canonical triggers; **run the off-contract → canonical tag migration on the ~260 contacts** (additive-then-strip, conflict-guarded, re-assert community-line guard after each bucket); resolve the 9 multi-way duplicate contacts in the GHL UI (Kristy Bloomfield = community line). First send of every stream = preview to Ben, then enable.
+
+## Open rulings (do not guess)
+
+- **RC1 — role mapping for CONTAINED's 12-role dropdown → 8 canonical roles.** Obvious: researcher/media/funder/community map 1:1; lived_experience→`lane:community`+`role:storyteller` (R3). **Needs ruling:** practitioner, service_org, student, policymaker, advocate, artist → which canonical `role:` / `interest:`? (Config encodes PROPOSED mappings, marked.)
+- **RC2 — `engagement:`/`campaign-stage:` keepers?** Are these formal-taxonomy namespaces or do they migrate in the taxonomy worksheet? The lifecycle layer depends on the answer.
+- **RC3 — the ~260 live `project:contained-adelaide-2026` contacts.** Strip the tag after adding canonical, or leave as a legacy campaign marker? (Recommend: add canonical, strip the off-contract tag in the gated migration.)
+- **RC4 — calendar location of record.** GHL native calendar vs an embedded booking form that writes the booking. (Spec assumes GHL native calendar.)
+
+## Decision + verification log
+
+- 2026-06-09 — **R4 wins (Ben, AskUserQuestion):** CONTAINED conforms to canonical; register route + build spec + ~260 contacts migrate. Self-serve calendar chosen (un-defers pipeline). All CTAs in scope.
+- 2026-06-09 VERIFIED (read-only, live GHL, loc `agzsSZWgovjwgpcoASWG`): custom fields present except `cohort`+`slot_confirmed` (to create); no "CONTAINED Adelaide 2026" pipeline yet; eligibility gate 113 eligible / 2916 blocked; `newsletter-stream:contained-adelaide-invite`=28; `project:contained-adelaide-2026`=260. Evidence: JusticeHub `eligibility-verification-2026-06-09.md`.
+- 2026-06-09 VERIFIED (read-only, JusticeHub): 24 CTAs mapped, 9 capture gaps, `GHL_CANONICAL` exists, 4/5 routes already canonical, `project:` split. Evidence: `contained-cta-ghl-inventory.md`.
+- 2026-06-09 FLAGGED: a colon→underscore `tag-normalize` dry-run artifact in JusticeHub `output/ghl-contained-adelaide-audit/` is wrong-direction (would orphan the register form's colon tags); do NOT apply it.
+
+## Changelog
+- 2026-06-09 — alignment handoff created; R4 ruling recorded; canonical contract + CTA map + calendar spec + build sequence; config + dry-run scaffold produced.

--- a/thoughts/shared/reviews/2026-06-09_phantom-consent-root-cause.md
+++ b/thoughts/shared/reviews/2026-06-09_phantom-consent-root-cause.md
@@ -1,0 +1,49 @@
+# Phantom consent — root-cause finding (2026-06-09)
+
+**What:** 106 of the 269 CONTAINED contacts (and likely others) carry GHL `Newsletter Consent = Yes` with
+**no `Consent Source` and no `Consent Timestamp`** = consent that was never actually given. A naive
+`Yes`-only send gate trusts it → Spam Act exposure. Detail + per-row: `2026-06-09_contained-consent-resolution-worklist.{md,csv}`.
+
+## Root cause: a manual GHL-UI import, NOT a script
+
+**The codebase is ruled out as the source** (verified by reading every consent-writer in both repos):
+
+| Script | Verdict |
+|---|---|
+| `scripts/goods-contact-hygiene.mjs` | `shouldConsent = false` — explicitly refuses to infer consent. Not it. |
+| `scripts/backfill-newsletter-consent.mjs` | writes all **three** consent fields *with* a real source; phantoms have **blank** source → didn't touch them. Not it. |
+| `scripts/ghl-taxonomy-migrate.mjs` | only **reads/gates** on the consent field (`hasNewsletterConsent`), never writes `Yes`. Not it. |
+| `scripts/sync-ghl-to-supabase.mjs` | GHL→mirror read only; consent is sticky-from-GHL. Not it. |
+
+No code path writes `Newsletter Consent = Yes` without a source/timestamp. The phantom signature
+therefore cannot have come from the scripts.
+
+**The records' own evidence (verified live):**
+- Created **2026-01-08**, GHL `source = "ACT Intelligence"` — a *research-prospect list* (orgs/funders ACT
+  identified: StreetSmart, AMP Foundation, Paul Ramsay Foundation, Red Dust, Julalikari), **not signups**.
+- `Newsletter Consent = Yes`; `Consent Source` + `Consent Timestamp` **blank**.
+- `dateUpdated = 2026-06-08T06:57` (all same minute) = the June-8 CONTAINED **tag** run — which did NOT set
+  the `Yes` (the CONTAINED import CSV labels them `Consent Status = "Needs consent check"`, never wrote Yes).
+
+**Conclusion — confidence levels (per verification.md):**
+- **Verified:** the codebase does not produce this signature (every consent-writer read and excluded).
+- **Strongly inferred:** the `Yes` was set by a **manual GHL-UI CSV import of the January "ACT Intelligence"
+  prospect list** that mapped/defaulted a "Newsletter Consent = Yes" column with no source/timestamp columns.
+  It is a UI action — which is exactly why there is no script or git commit for it.
+
+## Why it won't silently regrow — and the guards
+
+Because no automation writes phantom consent, **it only returns if a human re-imports a list with
+`Newsletter Consent = Yes` again.** Three guards close that:
+1. **Hardened send gate (done):** every Sendable Smart List now requires `Consent Source is not empty` —
+   phantom consent fails the gate by construction, even before cleanup. (`2026-06-09_move2-move3-smartlists-views-spec.md`.)
+2. **Standing import rule:** never map `Newsletter Consent = Yes` on a GHL import without a real
+   `Consent Source` + `Consent Timestamp` column. Pin in the comms-architecture / consent policy docs and
+   brief anyone who bulk-imports.
+3. **Recurring monitor:** `scripts/phantom-consent-guard.mjs` (dry-run = audit) flags any
+   `Yes ∧ Consent Source empty` — cron it; alert when count > 0. `--apply` revokes (held; explicit verb).
+
+## Remediation status
+- **Revoke the existing 106:** `phantom-consent-guard.mjs --apply` (sets `Newsletter Consent = No`, never Yes,
+  re-verifies live first). **HELD — needs explicit "revoke".**
+- The hardened gate already neutralises the live risk; revoke is hygiene, not an emergency.


### PR DESCRIPTION
Closes the 'find the 2026-01-08 source' investigation + delivers the standing guard. Read-only tooling — the revoke path is HELD (needs explicit verb).

## Root cause
The 106 phantom consents (Newsletter Consent=Yes, blank source/timestamp) come from a **manual GHL-UI import of the Jan-2026 'ACT Intelligence' prospect list** — NOT a script. Every codebase consent-writer was read and ruled out (goods-hygiene refuses to infer; backfill stamps a real source; taxonomy-migrate only gates). So it cannot silently regrow — only a human re-import would.

## Delivered
- `scripts/phantom-consent-guard.mjs` — one tool, two modes: **dry-run = AUDIT** (cron-able monitor for `Yes ∧ Consent Source empty`), **--apply = REVOKE** (sets Newsletter Consent=No, never Yes, re-verifies live first; HELD). Smoke-tested.
- `2026-06-09_phantom-consent-root-cause.md` — finding + 3 regrowth guards.

⚠️ Overlaps the active `codex/contained-cta-ghl-alignment` branch (CONTAINED area) — coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)