### PR TITLE
fix(ghl): repoint contact lookup at working search endpoint (stop the dup engine)

### DIFF
--- a/scripts/build-ghl-merge-worklist-2026-06-09.mjs
+++ b/scripts/build-ghl-merge-worklist-2026-06-09.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Build a GHL contact-merge worklist (READ-ONLY).
+ *
+ * GHL has NO public contact-merge API (`POST /contacts/merge` always 403s —
+ * UI-only / Workflow-action). So this does NOT merge anything. It triages the
+ * email-duplicate groups in the `ghl_contacts` mirror into action buckets and
+ * emits a worklist Ben works through in the GHL UI.
+ *
+ * Buckets (per same-lower(email) group of >1 live row):
+ *   MERGE     — personal email, plausible human keeper → safe to merge in UI
+ *   REVIEW    — role/shared inbox (info@, contact@, jobs@ …) → same address can
+ *               be DIFFERENT people; do NOT merge without eyeballing
+ *   LOW_VALUE — every record has no tags, no consent and a garbage/empty name
+ *               → candidate to DELETE the dups, not merge
+ *
+ * Canonical keeper per group (the record to KEEP / merge others INTO):
+ *   1. has empathy_ledger_id      (linked to a storyteller record)
+ *   2. newsletter_consent = true  (keep the record that carries consent)
+ *   3. most tags
+ *   4. most recent updated_at
+ *   5. tiebreak: earliest created_at, then lowest ghl_id
+ *
+ * Output: thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.{md,csv}
+ *
+ * Usage: node scripts/build-ghl-merge-worklist-2026-06-09.mjs
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'node:fs';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const SOFT_DELETED = new Set(['gone-from-ghl', 'ghl-deleted']);
+
+// local-part values (and prefixes) that signal a shared / role inbox — same
+// address legitimately used by multiple distinct humans → never blind-merge.
+const ROLE_LOCALPARTS = new Set([
+  'info', 'admin', 'hi', 'hello', 'contact', 'office', 'team', 'jobs', 'careers',
+  'support', 'enquiries', 'enquiry', 'hq', 'mail', 'accounts', 'sales', 'marketing',
+  'media', 'press', 'hr', 'finance', 'reception', 'bookings', 'orders', 'noreply',
+  'no-reply', 'donate', 'donations', 'volunteer', 'volunteers', 'partnerships',
+  'general', 'help', 'service', 'services', 'ceo', 'admin1', 'all', 'people',
+]);
+
+function isRoleInbox(email) {
+  const local = (email.split('@')[0] || '').toLowerCase().trim();
+  if (ROLE_LOCALPARTS.has(local)) return true;
+  // info-au, contact-us, jobs.apply etc.
+  return /^(info|contact|admin|hello|hi|jobs|careers|support|enquir|office|team|accounts|donate|media|press)\b/.test(local.replace(/[._-]/g, ' '));
+}
+
+// Automation / system addresses — a tool generates a contact per run (e.g. the
+// GrantScope orchestrator on grantscope-triage@act.place). Not relationships;
+// delete / fix at source, never hand-merge.
+function isSystemGroup(email, recs) {
+  const local = (email.split('@')[0] || '').toLowerCase().trim();
+  if (/^(grantscope|triage|orchestrator|bot|automation|webhook|cron|daemon|noreply|no-reply|mailer|postmaster|system|test)\b/.test(local.replace(/[._-]/g, ' '))) return true;
+  // whole group is named like an automation artifact
+  return recs.every(r => /triage|orchestrator|\bbot\b|automation/i.test(displayName(r)));
+}
+
+// ACT ecosystem domains — funders, partners, community, team, key vendors.
+// A dup on one of these is a relationship worth fixing first.
+const ECOSYSTEM_DOMAINS = new Set([
+  'act.place', 'picc.com.au', 'oonchiumpa.com.au', 'anyinginyi.com.au',
+  'snowfoundation.org.au', 'minderoo.org', 'frrr.org.au', 'paulramsayfoundation.org.au',
+  'ianpotter.org.au', 'dusseldorp.org.au', 'philanthropy.org.au', 'queenslandgives.org.au',
+  'reddust.org.au', 'defydesign.org', 'socialimpacthub.org', 'orangesky.org.au',
+  'standardledger.co', 'streetsmartaustralia.org', 'wilyajanta.org', 'anat.org.au',
+  'redmovies.com.au', 'portable.com.au', 'kalianahoutdoors.com.au', 'brianmdavis.org.au',
+  'homelandschoolcompany.org.au',
+]);
+
+// NOT a person: test/placeholder/vendor-sender/place-record/scraped-spam. These
+// leaked into the email-dup set but must never be merged as a human contact.
+function isNotPeople(email) {
+  const [localRaw, domainRaw] = email.toLowerCase().split('@');
+  const local = (localRaw || '').trim();
+  const domain = (domainRaw || '').trim();
+  // test / placeholder / fake TLDs
+  if (/(^|\.)(example\.com|placeholder|local|invalid|test)$/.test(domain)) return true;
+  if (domain.endsWith('.placeholder') || domain.endsWith('.local') || domain.endsWith('.invalid')) return true;
+  if (/test/.test(local)) return true;
+  // Goods asset-tracker place records (communities, not people)
+  if (domain === 'goods.civicgraph.io') return true;
+  // automated / transactional sender local-parts
+  if (/^(news|updates?|welcome|voicemail|invoice|invoices|billing|receipts?|feedback|notifications?|noreply|no-reply|donotreply|mailer|notify|alerts?|statements?|accounting|wecare|hello-|reply|.*\.reply)$/.test(local)) return true;
+  if (local.includes('+')) return true; // plus-alias = almost always a system/sender address
+  // scraped-spam gmail/googlemail: many-dotted or digit-laden obfuscated local-parts
+  if ((domain === 'gmail.com' || domain === 'googlemail.com')) {
+    const dots = (local.match(/\./g) || []).length;
+    if (dots >= 4) return true;
+    if (dots >= 2 && /\d/.test(local) && local.replace(/[^a-z]/g, '').length <= 12) return true;
+  }
+  return false;
+}
+
+function domainOf(email) { return (email.split('@')[1] || '').toLowerCase().trim(); }
+
+// A name that looks scraped/garbage: single token, long, vowel-poor (no real
+// human name). Used only as a soft signal, never to auto-act.
+function looksGarbageName(name) {
+  if (!name) return true;
+  const n = name.trim();
+  if (!n) return true;
+  if (/\s/.test(n)) return false;            // has a space → treat as real
+  if (n.length >= 12 && !/[aeiou]{1}/i.test(n.slice(2, -2))) return true; // long consonant blob
+  if (/^[a-z]{14,}$/i.test(n)) return true;  // long single lowercase blob
+  return false;
+}
+
+async function fetchAllWithEmail() {
+  const all = [];
+  let offset = 0;
+  const page = 1000;
+  while (true) {
+    const { data, error } = await supabase
+      .from('ghl_contacts')
+      .select('id, ghl_id, email, full_name, first_name, last_name, tags, newsletter_consent, empathy_ledger_id, last_contact_date, created_at, updated_at, sync_status')
+      .not('email', 'is', null)
+      .neq('email', '')
+      .order('id')
+      .range(offset, offset + page - 1);
+    if (error) throw error;
+    if (!data?.length) break;
+    all.push(...data);
+    if (data.length < page) break;
+    offset += page;
+  }
+  return all;
+}
+
+function displayName(r) {
+  return (r.full_name && r.full_name.trim())
+    || [r.first_name, r.last_name].filter(Boolean).join(' ').trim()
+    || '(no name)';
+}
+
+function pickCanonical(rows) {
+  return [...rows].sort((a, b) => {
+    const el = (b.empathy_ledger_id ? 1 : 0) - (a.empathy_ledger_id ? 1 : 0);
+    if (el) return el;
+    const con = (b.newsletter_consent ? 1 : 0) - (a.newsletter_consent ? 1 : 0);
+    if (con) return con;
+    const tg = (b.tags?.length || 0) - (a.tags?.length || 0);
+    if (tg) return tg;
+    const up = new Date(b.updated_at || 0) - new Date(a.updated_at || 0);
+    if (up) return up;
+    const cr = new Date(a.created_at || 0) - new Date(b.created_at || 0); // earliest first
+    if (cr) return cr;
+    return String(a.ghl_id).localeCompare(String(b.ghl_id));
+  })[0];
+}
+
+const rows = await fetchAllWithEmail();
+const live = rows.filter(r => !SOFT_DELETED.has(r.sync_status || ''));
+
+const groups = new Map();
+for (const r of live) {
+  const k = r.email.toLowerCase().trim();
+  if (!groups.has(k)) groups.set(k, []);
+  groups.get(k).push(r);
+}
+
+const buckets = { MERGE: [], REVIEW: [], SYSTEM: [], NOT_PEOPLE: [], LOW_VALUE: [] };
+
+for (const [email, recs] of groups) {
+  if (recs.length < 2) continue;
+  const canonical = pickCanonical(recs);
+  const dups = recs.filter(r => r.id !== canonical.id);
+
+  const anyValue = recs.some(r => (r.tags?.length || 0) > 0 || r.newsletter_consent || r.empathy_ledger_id);
+  const allGarbage = recs.every(r => looksGarbageName(displayName(r)));
+
+  let bucket;
+  if (isSystemGroup(email, recs)) bucket = 'SYSTEM';
+  else if (isNotPeople(email)) bucket = 'NOT_PEOPLE';
+  else if (isRoleInbox(email)) bucket = 'REVIEW';
+  else if (!anyValue && allGarbage) bucket = 'LOW_VALUE';
+  else bucket = 'MERGE';
+
+  // importance (merge-these-first): an ecosystem relationship, or fragmented
+  // across 2+ duplicate records. Consent/EL alone is table-stakes, not priority.
+  const eco = ECOSYSTEM_DOMAINS.has(domainOf(email));
+  const important = bucket === 'MERGE' && (eco || dups.length >= 2);
+  buckets[bucket].push({ email, canonical, dups, recs, eco, important });
+}
+
+// MERGE sorted by importance: ecosystem first, then most dups, then most tags
+buckets.MERGE.sort((a, b) =>
+  (b.eco ? 1 : 0) - (a.eco ? 1 : 0)
+  || b.dups.length - a.dups.length
+  || (b.canonical.tags?.length || 0) - (a.canonical.tags?.length || 0));
+for (const k of ['REVIEW', 'SYSTEM', 'NOT_PEOPLE', 'LOW_VALUE']) {
+  buckets[k].sort((a, b) => b.dups.length - a.dups.length);
+}
+
+const dupCount = b => buckets[b].reduce((s, g) => s + g.dups.length, 0);
+const totalGroups = Object.values(buckets).reduce((s, l) => s + l.length, 0);
+const mergeDups = dupCount('MERGE');
+const reviewDups = dupCount('REVIEW');
+const systemDups = dupCount('SYSTEM');
+const notPeopleDups = dupCount('NOT_PEOPLE');
+const lowDups = dupCount('LOW_VALUE');
+const importantGroups = buckets.MERGE.filter(g => g.important);
+
+// ─── markdown ───
+const L = [];
+L.push('# GHL contact-merge worklist — 2026-06-09');
+L.push('');
+L.push('> **GHL has no merge API** (`POST /contacts/merge` → 403, UI-only). This worklist is');
+L.push('> read-only; do the merges in the GHL UI. For each group: open the **KEEP** contact,');
+L.push('> use Contact → Merge, and merge each **dup** into it. Verify the kept record still');
+L.push('> carries the consent + tags before saving.');
+L.push('');
+L.push(`**Source:** \`ghl_contacts\` mirror (${live.length} live rows w/ email, paginated). Re-run: \`node scripts/build-ghl-merge-worklist-2026-06-09.mjs\`.`);
+L.push('');
+L.push('| Bucket | Groups | Dup rows to clear |');
+L.push('|---|---:|---:|');
+L.push(`| ✅ MERGE — real people (⭐ ${importantGroups.length} important) | ${buckets.MERGE.length} | ${mergeDups} |`);
+L.push(`| ⚠️ REVIEW (role/shared inbox) | ${buckets.REVIEW.length} | ${reviewDups} |`);
+L.push(`| 🤖 SYSTEM (automation — delete/fix at source) | ${buckets.SYSTEM.length} | ${systemDups} |`);
+L.push(`| 🚫 NOT_PEOPLE (vendor/test/place/spam — skip or delete) | ${buckets.NOT_PEOPLE.length} | ${notPeopleDups} |`);
+L.push(`| 🗑️ LOW_VALUE (delete dups, don't merge) | ${buckets.LOW_VALUE.length} | ${lowDups} |`);
+L.push(`| **Total** | **${totalGroups}** | **${mergeDups + reviewDups + systemDups + notPeopleDups + lowDups}** |`);
+L.push('');
+L.push(`**Merge these ${importantGroups.length} first** (an ACT ecosystem relationship, or fragmented across 2+ duplicate records). The rest of MERGE is real but low-stakes — single low-value dups you can skip or batch later.`);
+L.push('');
+
+function recLine(r, isKeep) {
+  const tags = r.tags?.length || 0;
+  const flags = [
+    r.empathy_ledger_id ? 'EL' : null,
+    r.newsletter_consent ? 'consent' : null,
+    `${tags}t`,
+  ].filter(Boolean).join(' ');
+  const last = (r.last_contact_date || r.updated_at || '').toString().slice(0, 10);
+  return `   ${isKeep ? '**KEEP**' : 'merge← '} \`${r.ghl_id}\` ${displayName(r)} · ${flags} · ${last}`;
+}
+
+function section(title, list, note) {
+  L.push(`## ${title}`);
+  if (note) { L.push(''); L.push(note); }
+  L.push('');
+  if (!list.length) { L.push('_none_'); L.push(''); return; }
+  list.forEach((g, i) => {
+    const star = g.important ? '⭐ ' : '';
+    L.push(`### ${star}${i + 1}. ${g.email}  (${g.dups.length} dup${g.dups.length > 1 ? 's' : ''})`);
+    L.push(recLine(g.canonical, true));
+    g.dups.forEach(d => L.push(recLine(d, false)));
+    L.push('');
+  });
+}
+
+section('✅ MERGE — safe to merge in UI', buckets.MERGE,
+  'Personal addresses with a plausible human keeper. Merge each `merge←` row into the **KEEP** row.');
+section('⚠️ REVIEW — role / shared inbox', buckets.REVIEW,
+  'Same address, but a shared inbox can be **different people**. Confirm they are the same human before merging; otherwise re-email them and split.');
+section('🤖 SYSTEM — automation artifacts (delete / fix at source)', buckets.SYSTEM,
+  'A tool created a contact per run (e.g. the GrantScope orchestrator on `grantscope-triage@act.place`). **Do not hand-merge** — delete the extras and fix the source so it stops regrowing.');
+section('🚫 NOT_PEOPLE — vendor / test / place-record / scraped spam', buckets.NOT_PEOPLE,
+  'Not human relationships: example/placeholder domains, automated senders (`news@`, `invoice+…`), `goods.civicgraph.io` place-records, and dotted-gmail spam. **Skip when merging**; safe to bulk-delete.');
+section('🗑️ LOW_VALUE — delete the dups (don\'t merge)', buckets.LOW_VALUE,
+  'No tags, no consent, garbage/empty names — scrape artifacts. Safe to delete the `merge←` rows in UI rather than merge.');
+
+writeFileSync('thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.md', L.join('\n'));
+
+// ─── csv ───
+const C = ['bucket,important,email,action,ghl_id,name,tags,consent,empathy_ledger,last_seen'];
+const dupAction = bk => (bk === 'LOW_VALUE' || bk === 'SYSTEM' || bk === 'NOT_PEOPLE') ? 'DELETE'
+  : (bk === 'REVIEW' ? 'REVIEW' : 'MERGE_INTO_KEEP');
+for (const bk of ['MERGE', 'REVIEW', 'SYSTEM', 'NOT_PEOPLE', 'LOW_VALUE']) {
+  for (const g of buckets[bk]) {
+    const esc = s => `"${String(s ?? '').replace(/"/g, '""')}"`;
+    const row = (r, action) => C.push([
+      bk, g.important ? 'yes' : 'no', esc(g.email), action, r.ghl_id, esc(displayName(r)),
+      r.tags?.length || 0, r.newsletter_consent ? 'yes' : 'no',
+      r.empathy_ledger_id ? 'yes' : 'no',
+      (r.last_contact_date || r.updated_at || '').toString().slice(0, 10),
+    ].join(','));
+    row(g.canonical, 'KEEP');
+    g.dups.forEach(d => row(d, dupAction(bk)));
+  }
+}
+writeFileSync('thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.csv', C.join('\n'));
+
+console.log(`Groups: ${totalGroups}  | MERGE ${buckets.MERGE.length} (⭐${importantGroups.length} important, ${mergeDups} dups) · REVIEW ${buckets.REVIEW.length} (${reviewDups}) · SYSTEM ${buckets.SYSTEM.length} (${systemDups}) · NOT_PEOPLE ${buckets.NOT_PEOPLE.length} (${notPeopleDups}) · LOW_VALUE ${buckets.LOW_VALUE.length} (${lowDups})`);
+console.log('Wrote thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.{md,csv}');

--- a/scripts/lib/ghl-api-service.mjs
+++ b/scripts/lib/ghl-api-service.mjs
@@ -209,14 +209,33 @@ export class GHLService {
    * @param {string} email - Email to lookup
    * @returns {Promise<Object|null>} Contact if found
    */
-  async lookupContactByEmail(email) {
-    try {
-      const data = await this.request(
-        `/contacts/lookup?locationId=${this.locationId}&email=${encodeURIComponent(email)}`
-      );
-      return data.contacts?.[0] || null;
-    } catch (err) {
-      return null;
+  async lookupContactByEmail(email, { retries = 1 } = {}) {
+    if (!email) return null;
+    const lower = String(email).toLowerCase();
+    for (let attempt = 0; ; attempt++) {
+      try {
+        // GHL's GET /contacts/lookup is broken — it reads "lookup" as a contact id and
+        // 4xx's, so this used to silently return null for EVERYONE. That meant
+        // upsertContact never found existing contacts and always created (the real
+        // engine of the duplicate pile, incl. grantscope-triage@). Use the working
+        // POST /contacts/search path with an exact-email match instead.
+        const matches = await this.searchContacts(email);
+        return matches.find(c => (c.email || '').toLowerCase() === lower) || null;
+      } catch (err) {
+        // A search "not found" is an empty 200, never an error — so any thrown error is
+        // a genuine failure. Returning null on a transient failure is exactly what lets
+        // upsertContact create a duplicate, so retry transients then THROW; never
+        // swallow to null.
+        const status = parseInt(
+          (String(err?.message).match(/GHL API Error \((\d+)\)/) || [])[1], 10
+        );
+        const transient = status === 429 || status >= 500 || Number.isNaN(status);
+        if (transient && attempt < retries) {
+          await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+          continue;
+        }
+        throw err; // fail loud — caller must NOT create-on-error
+      }
     }
   }
 
@@ -230,7 +249,19 @@ export class GHLService {
     const existing = await this.lookupContactByEmail(contactData.email);
 
     if (existing) {
-      const updated = await this.updateContact(existing.id, contactData);
+      // GHL's PUT /contacts/{id} REPLACES the tag array, so merge incoming tags onto the
+      // existing ones — otherwise an upsert carrying a handful of tags would wipe a
+      // contact's existing tags (including consent/comms tags). This update path only
+      // started firing for real once lookup was repointed at the working endpoint.
+      const updates = { ...contactData };
+      if (contactData.tags?.length) {
+        const have = new Set((existing.tags || []).map(t => String(t).toLowerCase()));
+        updates.tags = [
+          ...(existing.tags || []),
+          ...contactData.tags.filter(t => !have.has(String(t).toLowerCase())),
+        ];
+      }
+      const updated = await this.updateContact(existing.id, updates);
       return { contact: updated, created: false };
     } else {
       const created = await this.createContact(contactData);

--- a/scripts/seed-ghl-grants.mjs
+++ b/scripts/seed-ghl-grants.mjs
@@ -71,17 +71,37 @@ async function fetchTopGrants(limit) {
   return result;
 }
 
+const TRIAGE_EMAIL = 'grantscope-triage@act.place';
+
 async function ensureTriageContact() {
-  // GHL requires contactId on opportunity create. Use a single triage contact for grants
+  // GHL requires contactId on opportunity create. We use a single triage contact for grants
   // sourced via GrantScope sweeps — owners can re-link to a real funder contact later.
-  const upsert = await ghl.upsertContact({
-    email: 'grantscope-triage@act.place',
+  //
+  // Reuse a known id when configured. This avoids upserting a fixed email on EVERY run,
+  // which (with a flaky lookup) was spawning duplicate grantscope-triage@ contacts.
+  if (process.env.GHL_TRIAGE_CONTACT_ID) {
+    return process.env.GHL_TRIAGE_CONTACT_ID;
+  }
+
+  // Unconfigured: look up once, create only if truly absent. lookupContactByEmail now
+  // THROWS on a transient lookup failure (instead of returning null), so a flaky lookup
+  // can no longer fall through to a duplicate create here.
+  const existing = await ghl.lookupContactByEmail(TRIAGE_EMAIL);
+  if (existing) {
+    log(`Triage contact reuse ${existing.id} — set GHL_TRIAGE_CONTACT_ID=${existing.id} to skip lookup next run`);
+    return existing.id;
+  }
+
+  const created = await ghl.createContact({
+    email: TRIAGE_EMAIL,
     firstName: 'GrantScope',
     lastName: 'Triage',
     companyName: 'ACT — Foundation Research',
     tags: ['grantscope-source', 'auto-triage'],
   });
-  return upsert.contact.id || upsert.contact._id;
+  const id = created.id || created._id;
+  log(`Triage contact CREATED ${id} — set GHL_TRIAGE_CONTACT_ID=${id} to skip lookup next run`);
+  return id;
 }
 
 async function main() {

--- a/thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.csv
+++ b/thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.csv
@@ -1,0 +1,290 @@
+bucket,important,email,action,ghl_id,name,tags,consent,empathy_ledger,last_seen
+MERGE,yes,"benjamin@act.place",KEEP,7lzNuk9ykZbioseKyuVx,"benjamin knight",17,yes,yes,2026-06-08
+MERGE,yes,"benjamin@act.place",MERGE_INTO_KEEP,QarRbCphkMj7BFzOPlcT,"ben knight",3,no,yes,2026-06-08
+MERGE,yes,"benjamin@act.place",MERGE_INTO_KEEP,5MBKnM7ruUX8J7YT4XJE,"benjamin knight",3,no,yes,2026-06-08
+MERGE,yes,"benjamin@act.place",MERGE_INTO_KEEP,pRSrM0tnXQjYHfGeASAo,"benjamin test",13,no,yes,2026-03-26
+MERGE,yes,"benjamin@act.place",MERGE_INTO_KEEP,dQmMJj9xcPx51SY04W7B,"benjamin knight",6,no,yes,2026-05-31
+MERGE,yes,"benjamin@act.place",MERGE_INTO_KEEP,bkaZQuNkFw5qCcBGME5m,"benjamin knight",2,no,no,2026-05-26
+MERGE,yes,"sam@defydesign.org",KEEP,Vk0et07jw3qccBZsqBF8,"sam davies",14,yes,no,2026-04-15
+MERGE,yes,"sam@defydesign.org",MERGE_INTO_KEEP,7WXGBE5zD73ipAJfb5qE,"sam davies",13,no,no,2026-06-08
+MERGE,yes,"sam@defydesign.org",MERGE_INTO_KEEP,LfwjeSOvc2Mq3u4f2qm4,"sam davies",10,no,no,2026-06-08
+MERGE,yes,"sam@defydesign.org",MERGE_INTO_KEEP,B7vVWvvVhrUhP3QL3Dnl,"sam davies",10,no,no,2026-06-08
+MERGE,yes,"sam@defydesign.org",MERGE_INTO_KEEP,dMiQCeVDknPCK9Mhy5fg,"sam davies",17,no,no,2026-06-08
+MERGE,yes,"adam@streetsmartaustralia.org",KEEP,Oe2NBiLSraMozWjQtN7H,"adam robinson",12,no,no,2026-05-29
+MERGE,yes,"adam@streetsmartaustralia.org",MERGE_INTO_KEEP,wHstWIW6zo1ifWnWsayd,"adam robinson",8,no,no,2026-06-08
+MERGE,yes,"adam@streetsmartaustralia.org",MERGE_INTO_KEEP,Fe8nEezHRiBho7G6ev5V,"adam robinson",11,no,no,2026-06-08
+MERGE,yes,"adam@streetsmartaustralia.org",MERGE_INTO_KEEP,IgobH3bxpJMAMNxhUCVS,"adam robinson",9,no,no,2026-06-08
+MERGE,yes,"adam@streetsmartaustralia.org",MERGE_INTO_KEEP,Qtl5PgkHPMnNS1mjnGRO,"adam robinson",9,no,no,2026-03-28
+MERGE,yes,"sq@wilyajanta.org",KEEP,UJPGFZbcjcdslJC8jN6T,"wilya janta",12,yes,no,2025-12-10
+MERGE,yes,"sq@wilyajanta.org",MERGE_INTO_KEEP,601lLFL2WpQFwlcLmPBx,"dr. simon quilty",6,no,no,2026-06-08
+MERGE,yes,"sq@wilyajanta.org",MERGE_INTO_KEEP,4xqT9yHGyDBJKaUPf2lJ,"dr. simon quilty",6,no,no,2026-06-08
+MERGE,yes,"sq@wilyajanta.org",MERGE_INTO_KEEP,7ZKeS2H6Fyi1xDUTvING,"dr. simon quilty",8,no,no,2026-06-08
+MERGE,yes,"sq@wilyajanta.org",MERGE_INTO_KEEP,tNmXNxNzKf61yG3HmvNc,"dr. simon quilty",12,no,no,2026-06-08
+MERGE,yes,"kim@philanthropy.org.au",KEEP,O8F7kwyzHdWEbOjQ0Zob,"kim harland",11,no,no,2026-06-08
+MERGE,yes,"kim@philanthropy.org.au",MERGE_INTO_KEEP,qwvBT8hK74DMvrUPkIbd,"kim harland",5,no,no,2026-06-08
+MERGE,yes,"kim@philanthropy.org.au",MERGE_INTO_KEEP,wgEuHdAaGZnXGHBxKR1Q,"kim harland",4,no,no,2026-03-24
+MERGE,yes,"kim@philanthropy.org.au",MERGE_INTO_KEEP,YHR05hsHaxDiHO2gxo8f,"kim harland",9,no,no,2026-06-08
+MERGE,yes,"kim@philanthropy.org.au",MERGE_INTO_KEEP,KKLU6JUmRSSvACtvyPyT,"kim harland",6,no,no,2026-06-08
+MERGE,yes,"willhemina.wahlin@portable.com.au",KEEP,FlyntveGZxWzVeDmFwZ5,"willhemina wahlin",9,no,no,2026-06-08
+MERGE,yes,"willhemina.wahlin@portable.com.au",MERGE_INTO_KEEP,moxP9fCQ7a2pdibcxPDa,"willhemina wahlin",6,no,no,2026-06-08
+MERGE,yes,"willhemina.wahlin@portable.com.au",MERGE_INTO_KEEP,0w3yMTXm12bl74aKGce0,"willhemina wahlin",7,no,no,2026-01-20
+MERGE,yes,"willhemina.wahlin@portable.com.au",MERGE_INTO_KEEP,CjmW3zEgVVEYnrkw8tvq,"willhemina wahlin",7,no,no,2026-06-08
+MERGE,yes,"willhemina.wahlin@portable.com.au",MERGE_INTO_KEEP,WaTXyJ8P4oFUYeR5sXHT,"willhemina wahlin",7,no,no,2026-06-08
+MERGE,yes,"tara@queenslandgives.org.au",KEEP,xzRV6dT0WTQhJP5BCsHX,"tara castle",8,no,no,2026-06-08
+MERGE,yes,"tara@queenslandgives.org.au",MERGE_INTO_KEEP,GR0z6Lvl2N7gdUEqzMLk,"tara castle",6,no,no,2026-06-08
+MERGE,yes,"tara@queenslandgives.org.au",MERGE_INTO_KEEP,8QyHvajKpuyHyDmBfcCY,"tara castle",6,no,no,2025-12-11
+MERGE,yes,"tara@queenslandgives.org.au",MERGE_INTO_KEEP,1FJKzuyt1IpEFdjbJhjC,"tara castle",6,no,no,2026-06-08
+MERGE,yes,"tara@queenslandgives.org.au",MERGE_INTO_KEEP,qmFrCOsGrXQbLsIgjAzX,"tara castle",6,no,no,2026-06-08
+MERGE,yes,"nicholas@act.place",KEEP,rDUI85k0HWkfxvTyiNXK,"australian medical students association",22,yes,yes,2026-06-08
+MERGE,yes,"nicholas@act.place",MERGE_INTO_KEEP,yX006WjgWqAAoWEIkdtb,"nic",4,no,no,2026-06-08
+MERGE,yes,"nicholas@act.place",MERGE_INTO_KEEP,GWbymO5vTuzl0ELUsM0O,"nicholas marchesi oam",4,no,no,2026-06-08
+MERGE,yes,"nicholas@act.place",MERGE_INTO_KEEP,auto_d5f091cc,"Nicholas Marchesi",4,no,yes,2026-04-26
+MERGE,yes,"tobyg@kalianahoutdoors.com.au",KEEP,mTsZ14zvtIs3XaaTHHhX,"toby gowland",12,no,no,2026-06-08
+MERGE,yes,"tobyg@kalianahoutdoors.com.au",MERGE_INTO_KEEP,o0nVQWqVWIGTqXbg0zuG,"toby gowland",11,no,no,2026-06-08
+MERGE,yes,"tobyg@kalianahoutdoors.com.au",MERGE_INTO_KEEP,cnNzFM6zrQjRaMJ69NpE,"toby gowland",12,no,no,2026-06-08
+MERGE,yes,"tobyg@kalianahoutdoors.com.au",MERGE_INTO_KEEP,l1v8gPj5zXhURMeS0mCv,"toby gowland",12,no,no,2026-06-08
+MERGE,yes,"ratkinson@picc.com.au",KEEP,yZcX8GoQEqBYqcb5Uyjm,"palm island community company limited (picc)",11,yes,yes,2026-01-22
+MERGE,yes,"ratkinson@picc.com.au",MERGE_INTO_KEEP,j6S1E0B1NNfv4MZIp6AI,"rachel atkinson",10,no,yes,2026-06-08
+MERGE,yes,"ratkinson@picc.com.au",MERGE_INTO_KEEP,oVIfdPjlceNMZJB20RsO,"rachel atkinson",8,no,yes,2026-06-08
+MERGE,yes,"ratkinson@picc.com.au",MERGE_INTO_KEEP,VfEBYrMWswkt7jfYjmd0,"rachel atkinson",11,no,yes,2026-06-08
+MERGE,yes,"jay@socialimpacthub.org",KEEP,jWlB8bMHxQxWMNIZLIoD,"jay boolkin",7,no,no,2026-06-08
+MERGE,yes,"jay@socialimpacthub.org",MERGE_INTO_KEEP,d0zn6ZAai0BVwoB8PZnA,"jay boolkin",6,no,no,2026-06-08
+MERGE,yes,"jay@socialimpacthub.org",MERGE_INTO_KEEP,HRLfast9ci2Yq6XPoajQ,"jay boolkin",5,no,no,2026-06-08
+MERGE,yes,"jay@socialimpacthub.org",MERGE_INTO_KEEP,auto_90abca15,"Jay Boolkin",0,no,no,2026-04-01
+MERGE,yes,"jennifer.kitching@anyinginyi.com.au",KEEP,lXK8sKfCmHJQYLC9Din1,"jennifer kitching",5,no,no,2026-06-08
+MERGE,yes,"jennifer.kitching@anyinginyi.com.au",MERGE_INTO_KEEP,B8hHjzzwIuQNf9lOeGze,"jennifer kitching",5,no,no,2026-06-08
+MERGE,yes,"jennifer.kitching@anyinginyi.com.au",MERGE_INTO_KEEP,sbIeXVLqNf2kPWdiPle2,"jennifer kitching",5,no,no,2026-06-08
+MERGE,yes,"jennifer.kitching@anyinginyi.com.au",MERGE_INTO_KEEP,4tZeGvHPsy6bw0UDubdx,"jennifer kitching",5,no,no,2026-06-08
+MERGE,yes,"jodie@redmovies.com.au",KEEP,6itSyoLzsKS3R35a8mfs,"jodie davis",5,no,no,2026-06-08
+MERGE,yes,"jodie@redmovies.com.au",MERGE_INTO_KEEP,d1iSnUNRv78E1m43NmFv,"jodie davis",3,no,no,2026-03-27
+MERGE,yes,"jodie@redmovies.com.au",MERGE_INTO_KEEP,3DGTgCZt6R25rAYoODaW,"jodie davis",5,no,no,2026-06-08
+MERGE,yes,"jodie@redmovies.com.au",MERGE_INTO_KEEP,CabhyQwSVhdry4vNGIrt,"jodie davis",5,no,no,2026-06-08
+MERGE,yes,"millie@defydesign.org",KEEP,RMUL5qNtnclYhvsmvjBP,"millie shearer",5,no,no,2026-06-08
+MERGE,yes,"millie@defydesign.org",MERGE_INTO_KEEP,7K273hja6a0nEfYMsea1,"millie shearer",5,no,no,2026-06-08
+MERGE,yes,"millie@defydesign.org",MERGE_INTO_KEEP,MaE0EVXGdc8cOZpgkCGI,"millie shearer",3,no,no,2026-03-25
+MERGE,yes,"millie@defydesign.org",MERGE_INTO_KEEP,6dVAQFDuKNd4QHqPEO9s,"millie shearer",5,no,no,2026-06-08
+MERGE,yes,"s.grimsley-ballard@snowfoundation.org.au",KEEP,nZDW2c7bgNmKT62iOMP4,"sally grimsley-ballard",20,no,no,2026-06-08
+MERGE,yes,"s.grimsley-ballard@snowfoundation.org.au",MERGE_INTO_KEEP,tr5gXz8M27R7Y6PyZ3WD,"(no name)",2,no,no,2026-05-23
+MERGE,yes,"s.grimsley-ballard@snowfoundation.org.au",MERGE_INTO_KEEP,NSn2Ywjd0g0RIlWp66Fs,"sally grimsley-ballard",13,no,no,2026-06-08
+MERGE,yes,"s.pearson@frrr.org.au",KEEP,j7hi3rlHwmIuDKNSIdTs,"steph pearson",18,no,no,2026-03-31
+MERGE,yes,"s.pearson@frrr.org.au",MERGE_INTO_KEEP,MMrEpSBB5rbHzONLDirb,"steph pearson",6,no,no,2026-05-15
+MERGE,yes,"s.pearson@frrr.org.au",MERGE_INTO_KEEP,jatY7yhZL4h5OtexuCJ1,"steph pearson",11,no,no,2026-06-08
+MERGE,yes,"kristy.bloomfield@oonchiumpa.com.au",KEEP,0kEs9BJmkmi7ZUc5haEX,"kristy bloomfield",9,yes,yes,2026-03-23
+MERGE,yes,"kristy.bloomfield@oonchiumpa.com.au",MERGE_INTO_KEEP,yk4uK8rgDNGA87EUqNbu,"kristy bloomfield",9,no,yes,2026-06-08
+MERGE,yes,"kristy.bloomfield@oonchiumpa.com.au",MERGE_INTO_KEEP,gCok46nfL0BqYeYEeexd,"kristy bloomfield",7,no,no,2026-06-08
+MERGE,yes,"lstronach@minderoo.org",KEEP,yCiaPtyAOWYsEs9ITUGj,"lucy stronach",24,yes,no,2026-04-29
+MERGE,yes,"lstronach@minderoo.org",MERGE_INTO_KEEP,bkZQ6vDNekvTtUVV1TpI,"lucy stronach",5,no,no,2026-06-08
+MERGE,yes,"scarlettsteven@dusseldorp.org.au",KEEP,hlGY2sV3G9XUgJcBpM9O,"scarlett steven",22,yes,no,2026-03-20
+MERGE,yes,"scarlettsteven@dusseldorp.org.au",MERGE_INTO_KEEP,1AuVcj7COcol4udwL2Nw,"scarlett steven",5,no,no,2026-05-27
+MERGE,yes,"wfrazer@paulramsayfoundation.org.au",KEEP,WZQ7eABQAKf59F3Vyaow,"william frazer",15,yes,no,2026-03-24
+MERGE,yes,"wfrazer@paulramsayfoundation.org.au",MERGE_INTO_KEEP,86IotCHStn0fEHyhFtoF,"william frazer",5,no,no,2026-06-08
+MERGE,yes,"judith@orangesky.org.au",KEEP,Q4h5Aa8lRj8YDOZ0E8s2,"judith meiklejohn",13,no,no,2026-03-03
+MERGE,yes,"judith@orangesky.org.au",MERGE_INTO_KEEP,c7ieIClxZbohQeuihgyq,"judith meiklejohn",11,no,no,2026-06-08
+MERGE,yes,"todd@defydesign.org",KEEP,tiC3ISBpkDdmS54agG6P,"todd sidery",12,no,no,2026-03-31
+MERGE,yes,"todd@defydesign.org",MERGE_INTO_KEEP,Ktm6aDokztnOYsToBWrR,"todd sidery",10,no,no,2026-06-08
+MERGE,yes,"narelle@picc.com.au",KEEP,pXbha9a8lYxHuD9oAM8S,"narelle gleeson",11,no,yes,2026-06-08
+MERGE,yes,"narelle@picc.com.au",MERGE_INTO_KEEP,aZICs18JhTlYcCja2awk,"narelle gleeson",13,no,no,2026-04-23
+MERGE,yes,"matt.allen@socialimpacthub.org",KEEP,NVHZfqOTviJyw6Tw1old,"matt allen",7,no,no,2026-06-08
+MERGE,yes,"matt.allen@socialimpacthub.org",MERGE_INTO_KEEP,auto_66af5eed,"Matt Allen",0,no,no,2026-04-27
+MERGE,yes,"will@defydesign.org",KEEP,TFYAX2ABmlLTPnc91Xt5,"will thompson",7,no,no,2026-05-27
+MERGE,yes,"will@defydesign.org",MERGE_INTO_KEEP,reconcile_e94191a5,"Will Thompson",3,no,no,2026-03-26
+MERGE,yes,"slovett@picc.com.au",KEEP,tip2wTi3wWy0nwLFE2Vp,"sharon lovett",7,no,no,2026-05-27
+MERGE,yes,"slovett@picc.com.au",MERGE_INTO_KEEP,b52Teph3cCcL1FEWaTgN,"sharon lovett",0,no,no,2026-02-18
+MERGE,yes,"tony.miles@anyinginyi.com.au",KEEP,bJ0IHYKRVBtlwmyIydaQ,"tony miles",6,no,no,2026-06-08
+MERGE,yes,"tony.miles@anyinginyi.com.au",MERGE_INTO_KEEP,auto_35b4e62f,"Tony Miles",0,no,no,2026-03-13
+MERGE,yes,"carollyn@anat.org.au",KEEP,TF4i9w40DIGne1wPg5uN,"carollyn kavanagh",6,no,no,2026-04-15
+MERGE,yes,"carollyn@anat.org.au",MERGE_INTO_KEEP,dgQZ3xUzj3E6aZwbGrvG,"carollyn kavanagh",6,no,no,2026-06-08
+MERGE,yes,"bruce@redmovies.com.au",KEEP,47rRZh5KUga3AvHgxorp,"bruce redman",5,no,no,2026-03-27
+MERGE,yes,"bruce@redmovies.com.au",MERGE_INTO_KEEP,HI1vnNSzvmxk0q6Yhd4u,"bruce redman",5,no,no,2026-05-15
+MERGE,yes,"cosecau@standardledger.co",KEEP,rirjlbnB0qUPn8xujAAD,"vanessa ordonez",4,no,no,2026-06-08
+MERGE,yes,"cosecau@standardledger.co",MERGE_INTO_KEEP,auto_f2330b32,"cosecAU SL",0,no,no,2026-04-27
+MERGE,yes,"sarah.bartak@brianmdavis.org.au",KEEP,QdAmpE07Z361Rrx6ilS2,"sarah bartak",4,no,no,2026-06-08
+MERGE,yes,"sarah.bartak@brianmdavis.org.au",MERGE_INTO_KEEP,auto_e4724ba2,"Sarah Bartak",0,no,no,2026-04-30
+MERGE,yes,"g.byron@snowfoundation.org.au",KEEP,WKPGDlP6FyYg4hUTmQzd,"georgina byron",4,no,no,2026-06-08
+MERGE,yes,"g.byron@snowfoundation.org.au",MERGE_INTO_KEEP,7S6pSw0fIMpMMwxtSPCz,"Georgina Byron",3,no,no,2026-04-08
+MERGE,yes,"anita.hopkins@brianmdavis.org.au",KEEP,X9kE3G9rqvR51gUo0Bsx,"anita hopkins",4,no,no,2026-06-08
+MERGE,yes,"anita.hopkins@brianmdavis.org.au",MERGE_INTO_KEEP,auto_9d9c9423,"Anita Hopkins",0,no,no,2026-05-13
+MERGE,yes,"bridgit@reddust.org.au",KEEP,Q4fquuYzVh0z6NXLqrwU,"bridgit mcmullen",4,no,no,2026-06-08
+MERGE,yes,"bridgit@reddust.org.au",MERGE_INTO_KEEP,auto_f1706418,"Bridgit McMullen",0,no,no,2026-03-10
+MERGE,yes,"alberto.furlan@ianpotter.org.au",KEEP,PoPY4biO1VsofPFGdpv5,"alberto furlan",4,no,no,2026-06-08
+MERGE,yes,"alberto.furlan@ianpotter.org.au",MERGE_INTO_KEEP,n9c8Aeyckfw1Qa6nupYD,"Alberto Furlan",3,no,no,2026-05-29
+MERGE,yes,"jessica@socialimpacthub.org",KEEP,reconcile_6547cf18,"Jessica Mendoza-Roth",1,no,no,2026-02-28
+MERGE,yes,"jessica@socialimpacthub.org",MERGE_INTO_KEEP,CxTAADLcBEUIzXLGhp5W,"social impact hub foundation",0,no,no,2026-06-08
+MERGE,yes,"nic.sharah@homelandschoolcompany.org.au",KEEP,r8oUYf3j3L0HcnoBqVeX,"homeland school company",0,no,no,2026-06-08
+MERGE,yes,"nic.sharah@homelandschoolcompany.org.au",MERGE_INTO_KEEP,auto_67832921,"Nic Sharah",0,no,no,2026-05-06
+MERGE,yes,"jenn@anat.org.au",KEEP,FZ9kj33EShcYmQt8BN1X,"jenn brazier",0,no,no,2026-06-08
+MERGE,yes,"jenn@anat.org.au",MERGE_INTO_KEEP,manual_95185c8b-d183-444f-b08c-8239cc673c1f,"Jenn Brazier",0,no,no,2026-03-18
+MERGE,yes,"traceynewman008@gmail.com",KEEP,8Ysd4HscCutj53m0Oqzx,"tracey newman",13,no,no,2026-05-29
+MERGE,yes,"traceynewman008@gmail.com",MERGE_INTO_KEEP,D05Oa0eO8arILsSNjiPQ,"tracey newman",6,no,no,2026-06-08
+MERGE,yes,"traceynewman008@gmail.com",MERGE_INTO_KEEP,5Ef5iz76fJvyK1b5hI1Q,"tracey newman",6,no,no,2026-06-08
+MERGE,yes,"traceynewman008@gmail.com",MERGE_INTO_KEEP,pvZ53c6JlkL5sOPPFiTc,"tracey newman",6,no,no,2026-06-08
+MERGE,yes,"traceynewman008@gmail.com",MERGE_INTO_KEEP,hOn1vWuI9tNNhW0Mn1jl,"tracey newman",6,no,no,2026-06-08
+MERGE,yes,"pene.curtis@bigpond.com",KEEP,eyr6Cv6B9cf2VFUzJBQs,"pene curtis",20,no,no,2026-06-08
+MERGE,yes,"pene.curtis@bigpond.com",MERGE_INTO_KEEP,5EfSDhGNzQmIcgLz5LuH,"pene curtis",13,no,no,2026-06-08
+MERGE,yes,"pene.curtis@bigpond.com",MERGE_INTO_KEEP,zByIWtdKk4Z83B7b4uML,"pene curtis",5,no,no,2026-04-20
+MERGE,yes,"pene.curtis@bigpond.com",MERGE_INTO_KEEP,PRoijdTUvWTYv2D5B29s,"pene curtis",7,no,no,2026-05-27
+MERGE,yes,"mtaylor@envirobank.com.au",KEEP,IPzrkrahNKcSWL03d8Jq,"marty taylor",4,no,no,2026-06-08
+MERGE,yes,"mtaylor@envirobank.com.au",MERGE_INTO_KEEP,auto_1c29c2da,"Marty Taylor",0,no,no,2026-02-26
+MERGE,yes,"mtaylor@envirobank.com.au",MERGE_INTO_KEEP,ipZjeDDR9uwHMdXR7KV6,"marty taylor",3,no,no,2026-06-08
+MERGE,yes,"knighttss@gmail.com",KEEP,9uBnZcxMfiGZDLgS22vg,"benjamin knight",4,no,yes,2026-05-27
+MERGE,yes,"knighttss@gmail.com",MERGE_INTO_KEEP,PuuRHAkYciTlzUYl9a8R,"benjamin knight",4,no,no,2026-05-25
+MERGE,yes,"knighttss@gmail.com",MERGE_INTO_KEEP,0PrtdUUsyqYv5QklTNte,"benjamin knight",4,no,no,2026-06-08
+MERGE,no,"susyn.young@gmail.com",KEEP,sanAvi38DOOdCFdBlNqO,"susyn young",19,yes,no,2026-06-08
+MERGE,no,"susyn.young@gmail.com",MERGE_INTO_KEEP,auto_c86bbe63,"Susyn Young",0,no,no,2026-05-04
+MERGE,no,"amy.elson@nt.gov.au",KEEP,B1U3yW6G9UoDI5BsAV4c,"amy elson",14,no,no,2026-04-22
+MERGE,no,"amy.elson@nt.gov.au",MERGE_INTO_KEEP,6IijuIN8YUSD200siSc8,"amy elson",12,no,no,2026-06-08
+MERGE,no,"grantluff@gmail.com",KEEP,X4Md4sr73fZdL33BPmlz,"grant luff",12,no,no,2026-03-26
+MERGE,no,"grantluff@gmail.com",MERGE_INTO_KEEP,V8YinCOfEn8BdsujGzW0,"grant luff",10,no,no,2026-06-08
+MERGE,no,"lorana.bartels@anu.edu.au",KEEP,ozylqwJZShaQnAwcOJby,"(no name)",7,yes,no,2026-06-08
+MERGE,no,"lorana.bartels@anu.edu.au",MERGE_INTO_KEEP,lDdMkRI18W42NlvS7k05,"Lorana Bartels",0,no,no,2026-03-25
+MERGE,no,"c.jones@pgud.org",KEEP,VO6mL3LulO6PqMgvBM9X,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"c.jones@pgud.org",MERGE_INTO_KEEP,ejNcw4Ba1tAKeKy7jb2N,"kmpugwfgwtxmtlrmpsimjnmp",4,no,no,2026-06-08
+MERGE,no,"srubiamador@sjusd.org",KEEP,vARf3DDefHHMj8tI35j2,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"srubiamador@sjusd.org",MERGE_INTO_KEEP,lS6odMdzaEcGJ4eVIEQT,"lxammhzitmziufjzsqxi",3,no,no,2026-06-08
+MERGE,no,"ciscoub@yahoo.com",KEEP,zVpUoZng3rFI78abJ861,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"ciscoub@yahoo.com",MERGE_INTO_KEEP,gGYuKv43Vi2uUkLij3DU,"kbbzxlhazvflphckap",4,no,no,2026-06-08
+MERGE,no,"hawk_b51@yahoo.com",KEEP,DkpXtag9mbaAp6yCuSrA,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"hawk_b51@yahoo.com",MERGE_INTO_KEEP,M9Tk5QXVTWiwj0tmJrXU,"yvjnzgwshqirdfbocw",4,no,no,2026-06-08
+MERGE,no,"sbruzda@allianceppc.com",KEEP,2Z6qZKDEfTRqATZN1oVk,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"sbruzda@allianceppc.com",MERGE_INTO_KEEP,wH335AZ8O1hTQY0gRgXr,"deuycmrdpsouzrxudbrbfly",3,no,no,2026-06-08
+MERGE,no,"dj.polodavi.s@gmail.com",KEEP,k51xRq1kMPEslLIjHRPP,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"dj.polodavi.s@gmail.com",MERGE_INTO_KEEP,vUF0sWNma75NwkMMr0K4,"wtadfcuqyfabvnttrzkpds",4,no,no,2026-06-08
+MERGE,no,"cperry@qt-az.com",KEEP,OCbQ4FD8QZ6H1J6SHSpR,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"cperry@qt-az.com",MERGE_INTO_KEEP,dU8c2XwMQtu0UuMs8Onv,"ikjvutqbrwdapktj",3,no,no,2026-06-08
+MERGE,no,"l.fclaf.fee@gmail.com",KEEP,5tsFtKJV3S9QHVVKlXo2,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"l.fclaf.fee@gmail.com",MERGE_INTO_KEEP,r5cRnJzfYPzf76K7J4C5,"tkjoiieskigthxrpmmxyy",3,no,no,2026-06-08
+MERGE,no,"kathy@klempel.me",KEEP,qB0Mm6PlNg9zMhYqgzPc,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"kathy@klempel.me",MERGE_INTO_KEEP,dERu9XMHEJ866KKclssi,"ojszzfnkjvshsbuc",3,no,no,2026-06-08
+MERGE,no,"javi_tess92@outlook.com",KEEP,z0VG38J9E9VD1CgAMdd1,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"javi_tess92@outlook.com",MERGE_INTO_KEEP,gZ3GXY1hv6iIBKLvNIBN,"hqcgsykswtixcpflqzmz",4,no,no,2026-06-08
+MERGE,no,"ryazantsova@chameleongroup.co",KEEP,n0x9Jeq9U7gUcDTIHcKi,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"ryazantsova@chameleongroup.co",MERGE_INTO_KEEP,PoULIorUVo7iRlB6Su8w,"xwbklalwszjssprelrykawc",3,no,no,2026-06-08
+MERGE,no,"sgbox@wanadoo.fr",KEEP,qPX3grwbIxKMhi09dnA8,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"sgbox@wanadoo.fr",MERGE_INTO_KEEP,9iKuhg5ZeUjxkwEvA9jO,"qmsnjfvzunkazvkoouae",3,no,no,2026-06-08
+MERGE,no,"7202034285@tmomail.net",KEEP,AANmMV55PgMLFCEvML8T,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"7202034285@tmomail.net",MERGE_INTO_KEEP,00CsYRanDFMm9dyuudLY,"vmygatmsfubskwdxzdhqeunh",3,no,no,2026-06-08
+MERGE,no,"vr@chameleongroup.co",KEEP,Skq21DRy4vKLLhj3Xxhf,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"vr@chameleongroup.co",MERGE_INTO_KEEP,qHhpImxgkfJRqQjQAcWw,"cruqxdtsahepqhvdiw",3,no,no,2026-06-08
+MERGE,no,"sd.sas.hco@gmail.com",KEEP,1H8Og5lXJvRRRe0D01GK,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"sd.sas.hco@gmail.com",MERGE_INTO_KEEP,hizlzOUVPL5pIXyPw0D2,"mlkytwiwsdfebevw",3,no,no,2026-06-08
+MERGE,no,"ecoury8751@aol.com",KEEP,aW4jtrU1dyKR0VHmM20z,"(no name)",6,yes,no,2026-06-08
+MERGE,no,"ecoury8751@aol.com",MERGE_INTO_KEEP,c1bLRnL2j6iBtUXDAHk8,"wgsvtpdkmfduaycfon",3,no,no,2026-06-08
+MERGE,no,"realinnovationfund@dewr.gov.au",KEEP,MymJIeUEL8btnnIT7bJB,"real innovation fund",5,no,no,2026-06-08
+MERGE,no,"realinnovationfund@dewr.gov.au",MERGE_INTO_KEEP,auto_ff882964,"DEWR - REAL Innovation Fund",2,no,no,2026-03-18
+MERGE,no,"stp@uonbi.ac.ke",KEEP,rzwKLf3DXKs3C02dBpPH,"fablab nairobi",4,no,no,2026-05-27
+MERGE,no,"stp@uonbi.ac.ke",MERGE_INTO_KEEP,CwcOrXeWjmjWQNryceX1,"(no name)",2,no,no,2026-06-08
+MERGE,no,"jeremy@colemanprint.com.au",KEEP,iqk86FbdDvkyZvYrVkmu,"jeremy bigg",4,no,no,2026-06-08
+MERGE,no,"jeremy@colemanprint.com.au",MERGE_INTO_KEEP,auto_e3c10d00,"jeremy",0,no,no,2026-05-15
+MERGE,no,"maggiebea@gmail.com",KEEP,xGUd9CrDEHyTZhjffqVs,"maggie beale",3,no,no,2026-06-08
+MERGE,no,"maggiebea@gmail.com",MERGE_INTO_KEEP,auto_acb2a874,"maggiebea",0,no,no,2026-03-30
+MERGE,no,"cherring@blackbird.vc",KEEP,ku4kKGWrrMSsUgBNv8Pe,"blackbird",0,no,no,2026-06-08
+MERGE,no,"cherring@blackbird.vc",MERGE_INTO_KEEP,auto_dd7e2e75,"Blackbird",0,no,no,2026-06-01
+MERGE,no,"cassie@devpost.com",KEEP,H4mOTf5X4in943diSVLE,"cassie from devpost",0,no,no,2026-06-08
+MERGE,no,"cassie@devpost.com",MERGE_INTO_KEEP,FUkMewWYXlKvY4iQsFKB,"Cassie from Devpost",0,no,no,2026-03-14
+MERGE,no,"jane.stecyk@m.mightynetworks.com",KEEP,TFBZR9piKBsEHbR9LAIQ,"jane stecyk",0,no,no,2026-06-08
+MERGE,no,"jane.stecyk@m.mightynetworks.com",MERGE_INTO_KEEP,320n1jeQmcihesXZUmye,"jane stecyk",0,no,no,2026-03-31
+MERGE,no,"learn@send.zapier.com",KEEP,ZAGln0nOLO1Li5gTbnGU,"Zapier",0,no,no,2026-06-08
+MERGE,no,"learn@send.zapier.com",MERGE_INTO_KEEP,I7Cxyx67diOdRbXnsVyA,"zapier",0,no,no,2026-03-21
+MERGE,no,"nicholas@ffproductions.com.au",KEEP,XDIJiY5M5UpTq731i8Gp,"nic marchesi",0,no,no,2026-06-08
+MERGE,no,"nicholas@ffproductions.com.au",MERGE_INTO_KEEP,auto_dbe6e4df,"Nicholas Marchesi",0,no,no,2026-04-27
+REVIEW,no,"ceo@deadlyscience.org.au",KEEP,kMG435sXyNZ3g0ka2hzg,"cory tutt",4,yes,no,2026-03-06
+REVIEW,no,"ceo@deadlyscience.org.au",REVIEW,5LqgNvZQ2TGXHyJguHkB,"corey tutt",7,no,no,2026-06-08
+REVIEW,no,"ceo@deadlyscience.org.au",REVIEW,O5zWG2qnHYaeMPlYdK6z,"corey tutt",4,no,no,2026-05-15
+REVIEW,no,"ceo@deadlyscience.org.au",REVIEW,wFviTiFi7euS3VyRWwLn,"corey tutt",9,no,no,2026-06-08
+REVIEW,no,"ceo@deadlyscience.org.au",REVIEW,7i2onyZFqX12BKlx5uLY,"corey tutt",5,no,no,2026-06-08
+REVIEW,no,"ceo@deadlyscience.org.au",REVIEW,YveuSGaoTk1fk105ExPO,"corey tutt",5,no,no,2026-06-08
+REVIEW,no,"contact@cdsuganda.org",KEEP,H02uVZuut3krrt7J4iV2,"ogole oscar",4,no,no,2026-05-27
+REVIEW,no,"contact@cdsuganda.org",REVIEW,Vse75dT3to1FwGmQeCAi,"ogole oscar",2,no,no,2026-06-08
+REVIEW,no,"jobs@key-systems.net",KEEP,Ix0bCx8mbJoEmKePeTer,"(no name)",6,yes,no,2026-06-08
+REVIEW,no,"jobs@key-systems.net",REVIEW,TBueqicmPnv5MTfw6fa9,"uztvrdwpntxpceienltdfn",4,no,no,2026-06-08
+REVIEW,no,"accounts@julalikari.com.au",KEEP,manual_323669aa-9ad2-46ae-910b-c5e795b64227,"Julalikari Accounts",1,no,no,2026-01-30
+REVIEW,no,"accounts@julalikari.com.au",REVIEW,2McL6zmvblS37U0Q5XOm,"julalikari council aboriginal corporation",0,no,no,2026-06-08
+REVIEW,no,"support.dk@ezviz.com",KEEP,jvbsIAwJdPpADLphJN4q,"ezviz international",0,no,no,2026-06-08
+REVIEW,no,"support.dk@ezviz.com",REVIEW,Qu9mAYCYeKQ49oneprmv,"support dk",0,no,no,2026-03-02
+REVIEW,no,"hi@act.place",KEEP,x9ppRP5MZJnF6v01DgWj,"a kind tractor",9,no,yes,2026-01-23
+REVIEW,no,"hi@act.place",REVIEW,b5iTn4wqP0LsYuknFPnd,"act admin",4,no,no,2026-05-29
+REVIEW,no,"contact@good360.org.au",KEEP,jHSaeQO107ZNdPE2663T,"good360 australia",0,no,no,2026-06-08
+REVIEW,no,"contact@good360.org.au",REVIEW,FYqz6jN9upIH186oBLKN,"Good360 Australia",0,no,no,2026-04-24
+REVIEW,no,"info@flyhav.com",KEEP,g3mCmF64426by14k24uk,"hinterland aviation",3,no,no,2026-06-08
+REVIEW,no,"info@flyhav.com",REVIEW,auto_25d2d21d,"info",0,no,no,2026-03-31
+REVIEW,no,"orders@eprintonline.com.au",KEEP,tCqk03o9pwcnf4F2pYi0,"eprint online",4,no,no,2026-06-08
+REVIEW,no,"orders@eprintonline.com.au",REVIEW,auto_2c98c781,"orders",0,no,no,2026-03-23
+REVIEW,no,"support@rubimicrocafe.com",KEEP,iZjD7QCXmTntsvhxRQSP,"(no name)",6,yes,no,2026-06-08
+REVIEW,no,"support@rubimicrocafe.com",REVIEW,hfwq5NNmXUdw4oN0bpwV,"vsxigmlydfvrynioyvudbprj",3,no,no,2026-06-08
+REVIEW,no,"info@e.atlassian.com",KEEP,fO8yjuMpilWMD5JDzJZ6,"loom",0,no,no,2026-06-08
+REVIEW,no,"info@e.atlassian.com",REVIEW,auto_fec6131c,"Loom",0,no,no,2026-04-17
+REVIEW,no,"ceo@jvtrust.org.au",KEEP,Fhk0FK9FcN563lUcSKhT,"fiona maxwell",21,no,no,2026-04-29
+REVIEW,no,"ceo@jvtrust.org.au",REVIEW,hQdMEJd33LmL3jzONRGh,"fiona maxwell",14,no,no,2026-06-08
+REVIEW,no,"accounts@act.place",KEEP,vT1CWtY6zB0kckOlzk8D,"accounts act",5,no,yes,2026-06-08
+REVIEW,no,"accounts@act.place",REVIEW,Evf4J6yT8Z7U1AUl7X3T,"accounts act",3,no,yes,2026-06-08
+REVIEW,no,"team@mail.miro.com",KEEP,MUEZf7YBTER80g9iPBB9,"the miro team",0,no,no,2026-06-08
+REVIEW,no,"team@mail.miro.com",REVIEW,TQfNIpXv2oBvNs03d6Hz,"The Miro Team",0,no,no,2025-12-16
+REVIEW,no,"hello@super.so",KEEP,1cDDSoegD8YYnQA4FbGK,"super",0,no,no,2026-06-08
+REVIEW,no,"hello@super.so",REVIEW,auto_89084644,"Super",0,no,no,2026-05-25
+REVIEW,no,"team@mail.perplexity.ai",KEEP,tIcBE6bbyxiKmFYPF1Vx,"perplexity enterprise",0,no,no,2026-06-08
+REVIEW,no,"team@mail.perplexity.ai",REVIEW,auto_fe7bbe3d,"Perplexity",0,no,no,2026-04-11
+SYSTEM,no,"grantscope-triage@act.place",KEEP,BZvB3crwSpby8FfzmB19,"grantscope triage",4,no,no,2026-05-23
+SYSTEM,no,"grantscope-triage@act.place",DELETE,go1AwjMi8D1trk8WsbYj,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,8SlnzOgAHhpOyLwywOIW,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,kL3sN6xV9WpGXRSqMgKM,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,NCBUYk9TQ7fnYIqFCD32,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,uAsIUWBHez3DzVex8rtm,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,RXTJqT4K3IpMk6XjRaj5,"grantscope triage",2,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,rxBfwMhOd3vyfOFCkvYD,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,5cWKwQGai8jg00jq23MJ,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,ls4MMNgOdTI2gEROPeW6,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,5kvBkyiJiSIlEC8EG2CO,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,OS6cGHu8rn3ySuwj1MOP,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,eWuHmHaqJqmO6M0qv5ku,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,N066soQXQ4SEPFm8jvDs,"grantscope triage",1,no,no,2026-06-08
+SYSTEM,no,"grantscope-triage@act.place",DELETE,ShJqUOpYkOwoJuZb1NjF,"grantscope triage",2,no,no,2026-06-08
+NOT_PEOPLE,no,"stripe@example.com",KEEP,Uo2GntyRd9gElysyXadb,"jenny rosen",3,no,no,2026-06-08
+NOT_PEOPLE,no,"stripe@example.com",DELETE,quQ1IVDWSP9KI5ixj2pd,"jenny rosen",1,no,no,2026-06-08
+NOT_PEOPLE,no,"stripe@example.com",DELETE,2Arkb6HM8Kde2MtGif5S,"jenny rosen",1,no,no,2026-06-08
+NOT_PEOPLE,no,"stripe@example.com",DELETE,gR2puEwwcN78LNSm1feT,"jenny rosen",1,no,no,2026-06-08
+NOT_PEOPLE,no,"m.cnu.rl.in.s@gmail.com",KEEP,Nnz7iZwHdneXV4Jevi5E,"(no name)",6,yes,no,2026-06-08
+NOT_PEOPLE,no,"m.cnu.rl.in.s@gmail.com",DELETE,iMXVDwAhWo1di7wpozUl,"uaeinxuxmozivxufmgmnvw",4,no,no,2026-06-08
+NOT_PEOPLE,no,"j.a.j.ab.ell.e8.1@gmail.com",KEEP,gXTEPv647NO8ZWZxnBrx,"(no name)",6,yes,no,2026-06-08
+NOT_PEOPLE,no,"j.a.j.ab.ell.e8.1@gmail.com",DELETE,StEignH29EJfadvAaEvs,"nrzlqeyovwlydenv",3,no,no,2026-06-08
+NOT_PEOPLE,no,"voicemail@dialpad.com",KEEP,J9r6ZqJc5UAFGkguBC9w,"dialpad",0,no,no,2026-06-08
+NOT_PEOPLE,no,"voicemail@dialpad.com",DELETE,auto_1eb1bdb3,"Dialpad",0,no,no,2026-03-10
+NOT_PEOPLE,no,"final-check@example.com",KEEP,qSAr8aMM9bgCPXzuTL1R,"test",9,no,no,2026-06-08
+NOT_PEOPLE,no,"final-check@example.com",DELETE,RI1TytFSVn0qCj3OpxMQ,"test",7,no,no,2026-06-08
+NOT_PEOPLE,no,"welcome@openrouter.ai",KEEP,xFafMw0kPSHRqudXbxzS,"openrouter team",0,no,no,2026-06-08
+NOT_PEOPLE,no,"welcome@openrouter.ai",DELETE,auto_7b5386cb,"OpenRouter Team",0,no,no,2026-06-03
+NOT_PEOPLE,no,"news@send.zapier.com",KEEP,JISEYTvuvj4g0PNcJ2nJ,"zapier news",0,no,no,2026-06-08
+NOT_PEOPLE,no,"news@send.zapier.com",DELETE,auto_6acba82c,"Zapier News",0,no,no,2026-03-26
+NOT_PEOPLE,no,"mi.ke661.8.10@gmail.com",KEEP,Hdz88yGNh9cQgxwdIVnH,"(no name)",6,yes,no,2026-06-08
+NOT_PEOPLE,no,"mi.ke661.8.10@gmail.com",DELETE,8BkMmfmUWrmSUTo7WLaE,"tzubbsxdthlorakxno",4,no,no,2026-06-08
+NOT_PEOPLE,no,"invoice+statements@supabase.com",KEEP,msoQkyq035iy0p92ayPu,"supabase pte. ltd.",0,no,no,2026-06-08
+NOT_PEOPLE,no,"invoice+statements@supabase.com",DELETE,JLIYqnZRZDJ2d4Qf5MQw,"supabase pte. ltd.",0,no,no,2026-03-21
+NOT_PEOPLE,no,"jarlmadanka@goods.civicgraph.io",KEEP,L1kooixF2tOI61OSdbP8,"jarlmadanka wa",2,no,no,2026-06-08
+NOT_PEOPLE,no,"jarlmadanka@goods.civicgraph.io",DELETE,ac6FQdAwintboayVWUiM,"jarlmadanka wa",2,no,no,2026-05-15
+NOT_PEOPLE,no,"warruwi@goods.civicgraph.io",KEEP,i3odQcXuB5Ek7jjnayH6,"warruwi nt",3,no,no,2026-06-08
+NOT_PEOPLE,no,"warruwi@goods.civicgraph.io",DELETE,Kfftjz1kr7re0quOvxxn,"warruwi nt",2,no,no,2026-05-15
+NOT_PEOPLE,no,"feedback+customerio@warp.dev",KEEP,NEPhpv06ImtmacDOjfye,"eric from warp",0,no,no,2026-06-08
+NOT_PEOPLE,no,"feedback+customerio@warp.dev",DELETE,auto_55e7da84,"Warp Team",0,no,no,2026-03-06
+NOT_PEOPLE,no,"kintore@goods.civicgraph.io",KEEP,kTimXhFlc71LShGqSwGI,"kintore nt",3,no,no,2026-06-08
+NOT_PEOPLE,no,"kintore@goods.civicgraph.io",DELETE,iuVqVB3OrXIEcOEw5riw,"kintore nt",2,no,no,2026-05-15
+NOT_PEOPLE,no,"accounting@thriday.com.au",KEEP,w9sayHZwpD9yy0cmahAb,"thriday accounting",0,no,no,2026-06-08
+NOT_PEOPLE,no,"accounting@thriday.com.au",DELETE,auto_5c5ea3f2,"Sally Hurst (Thriday Accounting Support)",0,no,no,2026-03-26
+NOT_PEOPLE,no,"maureen.cummings@jcf.placeholder",KEEP,OKn95bkiAVRAWDKxeh2U,"maureen cummings",3,no,yes,2026-06-08
+NOT_PEOPLE,no,"maureen.cummings@jcf.placeholder",DELETE,P7hT9BCbMgpmw3MYA1ub,"maureen cummings",4,no,no,2026-05-29
+NOT_PEOPLE,no,"a.s.hleyd.uk.es.1.2@gmail.com",KEEP,1wK7zf7Ja4VRRtyUID47,"(no name)",6,yes,no,2026-06-08
+NOT_PEOPLE,no,"a.s.hleyd.uk.es.1.2@gmail.com",DELETE,egO4mKoiE3UQOdVs3Fra,"kkvawnbzzxrsrkqbpglvr",4,no,no,2026-06-08
+NOT_PEOPLE,no,"wecare@thriday.com.au",KEEP,b1uGSGDl6iBEXJdiRFkV,"thriday",0,no,no,2026-06-08
+NOT_PEOPLE,no,"wecare@thriday.com.au",DELETE,auto_7ab4ec28,"Thriday",0,no,no,2026-03-11
+NOT_PEOPLE,no,"pete.rh.aup.e.nthal1.4@gmail.com",KEEP,Eyc5IpyXhUbBU09JhoSd,"(no name)",6,yes,no,2026-06-08
+NOT_PEOPLE,no,"pete.rh.aup.e.nthal1.4@gmail.com",DELETE,xmxXCRJfjp1l2nfJVfVo,"oyrdeuhvyjpndvxv",3,no,no,2026-06-08
+NOT_PEOPLE,no,"w.i.n.at.aro23.4@gmail.com",KEEP,8iuHKXd1fc399wTjBAao,"(no name)",6,yes,no,2026-06-08
+NOT_PEOPLE,no,"w.i.n.at.aro23.4@gmail.com",DELETE,qojZDdJtW9tjp46Cdjc4,"fqxxztkhksrsgcprhdojjem",3,no,no,2026-06-08
+NOT_PEOPLE,no,"umbakumba@goods.civicgraph.io",KEEP,6bjo08S459GAjsCrJEa0,"umbakumba nt",3,no,no,2026-06-08
+NOT_PEOPLE,no,"umbakumba@goods.civicgraph.io",DELETE,cosG1FgL133xMtL2ewdy,"umbakumba nt",2,no,no,2026-05-15
+NOT_PEOPLE,no,"updates@product.exa.ai",KEEP,UaApxKCDKpy7a1wYtDhT,"will bryk",0,no,no,2026-06-08
+NOT_PEOPLE,no,"updates@product.exa.ai",DELETE,mwZOKNJrRt23YeZSluLD,"Exa Product Updates",0,no,no,2026-03-05
+NOT_PEOPLE,no,"ben+washtest1779856038@benjamink.com.au",KEEP,CWYLiCR10hR8wa3NTmLw,"wash test",5,no,no,2026-06-08
+NOT_PEOPLE,no,"ben+washtest1779856038@benjamink.com.au",DELETE,W8NvPYuxVs8ZA6rR2Fsi,"wash test",5,no,no,2026-06-08
+NOT_PEOPLE,no,"milingimbi@goods.civicgraph.io",KEEP,65oqqmNvJ056JG0Mp3pF,"milingimbi nt",3,no,no,2026-06-08
+NOT_PEOPLE,no,"milingimbi@goods.civicgraph.io",DELETE,pnKIc9CJvb4XmbcK8q74,"milingimbi nt",2,no,no,2026-05-15
+NOT_PEOPLE,no,"cole.reply@formspree.io",KEEP,DQqLmSsP4hxU1iIUF14Y,"cole",0,no,no,2026-06-08
+NOT_PEOPLE,no,"cole.reply@formspree.io",DELETE,WUiKS4b8hgp2ePnV7LoC,"Cole",0,no,no,2026-03-12

--- a/thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.md
+++ b/thoughts/shared/reviews/2026-06-09_ghl-merge-worklist.md
@@ -1,0 +1,554 @@
+# GHL contact-merge worklist — 2026-06-09
+
+> **GHL has no merge API** (`POST /contacts/merge` → 403, UI-only). This worklist is
+> read-only; do the merges in the GHL UI. For each group: open the **KEEP** contact,
+> use Contact → Merge, and merge each **dup** into it. Verify the kept record still
+> carries the consent + tags before saving.
+
+**Source:** `ghl_contacts` mirror (2479 live rows w/ email, paginated). Re-run: `node scripts/build-ghl-merge-worklist-2026-06-09.mjs`.
+
+| Bucket | Groups | Dup rows to clear |
+|---|---:|---:|
+| ✅ MERGE — real people (⭐ 42 important) | 71 | 117 |
+| ⚠️ REVIEW (role/shared inbox) | 16 | 20 |
+| 🤖 SYSTEM (automation — delete/fix at source) | 1 | 14 |
+| 🚫 NOT_PEOPLE (vendor/test/place/spam — skip or delete) | 24 | 26 |
+| 🗑️ LOW_VALUE (delete dups, don't merge) | 0 | 0 |
+| **Total** | **112** | **177** |
+
+**Merge these 42 first** (an ACT ecosystem relationship, or fragmented across 2+ duplicate records). The rest of MERGE is real but low-stakes — single low-value dups you can skip or batch later.
+
+## ✅ MERGE — safe to merge in UI
+
+Personal addresses with a plausible human keeper. Merge each `merge←` row into the **KEEP** row.
+
+### ⭐ 1. benjamin@act.place  (5 dups)
+   **KEEP** `7lzNuk9ykZbioseKyuVx` benjamin knight · EL consent 17t · 2026-06-08
+   merge←  `QarRbCphkMj7BFzOPlcT` ben knight · EL 3t · 2026-06-08
+   merge←  `5MBKnM7ruUX8J7YT4XJE` benjamin knight · EL 3t · 2026-06-08
+   merge←  `pRSrM0tnXQjYHfGeASAo` benjamin test · EL 13t · 2026-03-26
+   merge←  `dQmMJj9xcPx51SY04W7B` benjamin knight · EL 6t · 2026-05-31
+   merge←  `bkaZQuNkFw5qCcBGME5m` benjamin knight · 2t · 2026-05-26
+
+### ⭐ 2. sam@defydesign.org  (4 dups)
+   **KEEP** `Vk0et07jw3qccBZsqBF8` sam davies · consent 14t · 2026-04-15
+   merge←  `7WXGBE5zD73ipAJfb5qE` sam davies · 13t · 2026-06-08
+   merge←  `LfwjeSOvc2Mq3u4f2qm4` sam davies · 10t · 2026-06-08
+   merge←  `B7vVWvvVhrUhP3QL3Dnl` sam davies · 10t · 2026-06-08
+   merge←  `dMiQCeVDknPCK9Mhy5fg` sam davies · 17t · 2026-06-08
+
+### ⭐ 3. adam@streetsmartaustralia.org  (4 dups)
+   **KEEP** `Oe2NBiLSraMozWjQtN7H` adam robinson · 12t · 2026-05-29
+   merge←  `wHstWIW6zo1ifWnWsayd` adam robinson · 8t · 2026-06-08
+   merge←  `Fe8nEezHRiBho7G6ev5V` adam robinson · 11t · 2026-06-08
+   merge←  `IgobH3bxpJMAMNxhUCVS` adam robinson · 9t · 2026-06-08
+   merge←  `Qtl5PgkHPMnNS1mjnGRO` adam robinson · 9t · 2026-03-28
+
+### ⭐ 4. sq@wilyajanta.org  (4 dups)
+   **KEEP** `UJPGFZbcjcdslJC8jN6T` wilya janta · consent 12t · 2025-12-10
+   merge←  `601lLFL2WpQFwlcLmPBx` dr. simon quilty · 6t · 2026-06-08
+   merge←  `4xqT9yHGyDBJKaUPf2lJ` dr. simon quilty · 6t · 2026-06-08
+   merge←  `7ZKeS2H6Fyi1xDUTvING` dr. simon quilty · 8t · 2026-06-08
+   merge←  `tNmXNxNzKf61yG3HmvNc` dr. simon quilty · 12t · 2026-06-08
+
+### ⭐ 5. kim@philanthropy.org.au  (4 dups)
+   **KEEP** `O8F7kwyzHdWEbOjQ0Zob` kim harland · 11t · 2026-06-08
+   merge←  `qwvBT8hK74DMvrUPkIbd` kim harland · 5t · 2026-06-08
+   merge←  `wgEuHdAaGZnXGHBxKR1Q` kim harland · 4t · 2026-03-24
+   merge←  `YHR05hsHaxDiHO2gxo8f` kim harland · 9t · 2026-06-08
+   merge←  `KKLU6JUmRSSvACtvyPyT` kim harland · 6t · 2026-06-08
+
+### ⭐ 6. willhemina.wahlin@portable.com.au  (4 dups)
+   **KEEP** `FlyntveGZxWzVeDmFwZ5` willhemina wahlin · 9t · 2026-06-08
+   merge←  `moxP9fCQ7a2pdibcxPDa` willhemina wahlin · 6t · 2026-06-08
+   merge←  `0w3yMTXm12bl74aKGce0` willhemina wahlin · 7t · 2026-01-20
+   merge←  `CjmW3zEgVVEYnrkw8tvq` willhemina wahlin · 7t · 2026-06-08
+   merge←  `WaTXyJ8P4oFUYeR5sXHT` willhemina wahlin · 7t · 2026-06-08
+
+### ⭐ 7. tara@queenslandgives.org.au  (4 dups)
+   **KEEP** `xzRV6dT0WTQhJP5BCsHX` tara castle · 8t · 2026-06-08
+   merge←  `GR0z6Lvl2N7gdUEqzMLk` tara castle · 6t · 2026-06-08
+   merge←  `8QyHvajKpuyHyDmBfcCY` tara castle · 6t · 2025-12-11
+   merge←  `1FJKzuyt1IpEFdjbJhjC` tara castle · 6t · 2026-06-08
+   merge←  `qmFrCOsGrXQbLsIgjAzX` tara castle · 6t · 2026-06-08
+
+### ⭐ 8. nicholas@act.place  (3 dups)
+   **KEEP** `rDUI85k0HWkfxvTyiNXK` australian medical students association · EL consent 22t · 2026-06-08
+   merge←  `yX006WjgWqAAoWEIkdtb` nic · 4t · 2026-06-08
+   merge←  `GWbymO5vTuzl0ELUsM0O` nicholas marchesi oam · 4t · 2026-06-08
+   merge←  `auto_d5f091cc` Nicholas Marchesi · EL 4t · 2026-04-26
+
+### ⭐ 9. tobyg@kalianahoutdoors.com.au  (3 dups)
+   **KEEP** `mTsZ14zvtIs3XaaTHHhX` toby gowland · 12t · 2026-06-08
+   merge←  `o0nVQWqVWIGTqXbg0zuG` toby gowland · 11t · 2026-06-08
+   merge←  `cnNzFM6zrQjRaMJ69NpE` toby gowland · 12t · 2026-06-08
+   merge←  `l1v8gPj5zXhURMeS0mCv` toby gowland · 12t · 2026-06-08
+
+### ⭐ 10. ratkinson@picc.com.au  (3 dups)
+   **KEEP** `yZcX8GoQEqBYqcb5Uyjm` palm island community company limited (picc) · EL consent 11t · 2026-01-22
+   merge←  `j6S1E0B1NNfv4MZIp6AI` rachel atkinson · EL 10t · 2026-06-08
+   merge←  `oVIfdPjlceNMZJB20RsO` rachel atkinson · EL 8t · 2026-06-08
+   merge←  `VfEBYrMWswkt7jfYjmd0` rachel atkinson · EL 11t · 2026-06-08
+
+### ⭐ 11. jay@socialimpacthub.org  (3 dups)
+   **KEEP** `jWlB8bMHxQxWMNIZLIoD` jay boolkin · 7t · 2026-06-08
+   merge←  `d0zn6ZAai0BVwoB8PZnA` jay boolkin · 6t · 2026-06-08
+   merge←  `HRLfast9ci2Yq6XPoajQ` jay boolkin · 5t · 2026-06-08
+   merge←  `auto_90abca15` Jay Boolkin · 0t · 2026-04-01
+
+### ⭐ 12. jennifer.kitching@anyinginyi.com.au  (3 dups)
+   **KEEP** `lXK8sKfCmHJQYLC9Din1` jennifer kitching · 5t · 2026-06-08
+   merge←  `B8hHjzzwIuQNf9lOeGze` jennifer kitching · 5t · 2026-06-08
+   merge←  `sbIeXVLqNf2kPWdiPle2` jennifer kitching · 5t · 2026-06-08
+   merge←  `4tZeGvHPsy6bw0UDubdx` jennifer kitching · 5t · 2026-06-08
+
+### ⭐ 13. jodie@redmovies.com.au  (3 dups)
+   **KEEP** `6itSyoLzsKS3R35a8mfs` jodie davis · 5t · 2026-06-08
+   merge←  `d1iSnUNRv78E1m43NmFv` jodie davis · 3t · 2026-03-27
+   merge←  `3DGTgCZt6R25rAYoODaW` jodie davis · 5t · 2026-06-08
+   merge←  `CabhyQwSVhdry4vNGIrt` jodie davis · 5t · 2026-06-08
+
+### ⭐ 14. millie@defydesign.org  (3 dups)
+   **KEEP** `RMUL5qNtnclYhvsmvjBP` millie shearer · 5t · 2026-06-08
+   merge←  `7K273hja6a0nEfYMsea1` millie shearer · 5t · 2026-06-08
+   merge←  `MaE0EVXGdc8cOZpgkCGI` millie shearer · 3t · 2026-03-25
+   merge←  `6dVAQFDuKNd4QHqPEO9s` millie shearer · 5t · 2026-06-08
+
+### ⭐ 15. s.grimsley-ballard@snowfoundation.org.au  (2 dups)
+   **KEEP** `nZDW2c7bgNmKT62iOMP4` sally grimsley-ballard · 20t · 2026-06-08
+   merge←  `tr5gXz8M27R7Y6PyZ3WD` (no name) · 2t · 2026-05-23
+   merge←  `NSn2Ywjd0g0RIlWp66Fs` sally grimsley-ballard · 13t · 2026-06-08
+
+### ⭐ 16. s.pearson@frrr.org.au  (2 dups)
+   **KEEP** `j7hi3rlHwmIuDKNSIdTs` steph pearson · 18t · 2026-03-31
+   merge←  `MMrEpSBB5rbHzONLDirb` steph pearson · 6t · 2026-05-15
+   merge←  `jatY7yhZL4h5OtexuCJ1` steph pearson · 11t · 2026-06-08
+
+### ⭐ 17. kristy.bloomfield@oonchiumpa.com.au  (2 dups)
+   **KEEP** `0kEs9BJmkmi7ZUc5haEX` kristy bloomfield · EL consent 9t · 2026-03-23
+   merge←  `yk4uK8rgDNGA87EUqNbu` kristy bloomfield · EL 9t · 2026-06-08
+   merge←  `gCok46nfL0BqYeYEeexd` kristy bloomfield · 7t · 2026-06-08
+
+### ⭐ 18. lstronach@minderoo.org  (1 dup)
+   **KEEP** `yCiaPtyAOWYsEs9ITUGj` lucy stronach · consent 24t · 2026-04-29
+   merge←  `bkZQ6vDNekvTtUVV1TpI` lucy stronach · 5t · 2026-06-08
+
+### ⭐ 19. scarlettsteven@dusseldorp.org.au  (1 dup)
+   **KEEP** `hlGY2sV3G9XUgJcBpM9O` scarlett steven · consent 22t · 2026-03-20
+   merge←  `1AuVcj7COcol4udwL2Nw` scarlett steven · 5t · 2026-05-27
+
+### ⭐ 20. wfrazer@paulramsayfoundation.org.au  (1 dup)
+   **KEEP** `WZQ7eABQAKf59F3Vyaow` william frazer · consent 15t · 2026-03-24
+   merge←  `86IotCHStn0fEHyhFtoF` william frazer · 5t · 2026-06-08
+
+### ⭐ 21. judith@orangesky.org.au  (1 dup)
+   **KEEP** `Q4h5Aa8lRj8YDOZ0E8s2` judith meiklejohn · 13t · 2026-03-03
+   merge←  `c7ieIClxZbohQeuihgyq` judith meiklejohn · 11t · 2026-06-08
+
+### ⭐ 22. todd@defydesign.org  (1 dup)
+   **KEEP** `tiC3ISBpkDdmS54agG6P` todd sidery · 12t · 2026-03-31
+   merge←  `Ktm6aDokztnOYsToBWrR` todd sidery · 10t · 2026-06-08
+
+### ⭐ 23. narelle@picc.com.au  (1 dup)
+   **KEEP** `pXbha9a8lYxHuD9oAM8S` narelle gleeson · EL 11t · 2026-06-08
+   merge←  `aZICs18JhTlYcCja2awk` narelle gleeson · 13t · 2026-04-23
+
+### ⭐ 24. matt.allen@socialimpacthub.org  (1 dup)
+   **KEEP** `NVHZfqOTviJyw6Tw1old` matt allen · 7t · 2026-06-08
+   merge←  `auto_66af5eed` Matt Allen · 0t · 2026-04-27
+
+### ⭐ 25. will@defydesign.org  (1 dup)
+   **KEEP** `TFYAX2ABmlLTPnc91Xt5` will thompson · 7t · 2026-05-27
+   merge←  `reconcile_e94191a5` Will Thompson · 3t · 2026-03-26
+
+### ⭐ 26. slovett@picc.com.au  (1 dup)
+   **KEEP** `tip2wTi3wWy0nwLFE2Vp` sharon lovett · 7t · 2026-05-27
+   merge←  `b52Teph3cCcL1FEWaTgN` sharon lovett · 0t · 2026-02-18
+
+### ⭐ 27. tony.miles@anyinginyi.com.au  (1 dup)
+   **KEEP** `bJ0IHYKRVBtlwmyIydaQ` tony miles · 6t · 2026-06-08
+   merge←  `auto_35b4e62f` Tony Miles · 0t · 2026-03-13
+
+### ⭐ 28. carollyn@anat.org.au  (1 dup)
+   **KEEP** `TF4i9w40DIGne1wPg5uN` carollyn kavanagh · 6t · 2026-04-15
+   merge←  `dgQZ3xUzj3E6aZwbGrvG` carollyn kavanagh · 6t · 2026-06-08
+
+### ⭐ 29. bruce@redmovies.com.au  (1 dup)
+   **KEEP** `47rRZh5KUga3AvHgxorp` bruce redman · 5t · 2026-03-27
+   merge←  `HI1vnNSzvmxk0q6Yhd4u` bruce redman · 5t · 2026-05-15
+
+### ⭐ 30. cosecau@standardledger.co  (1 dup)
+   **KEEP** `rirjlbnB0qUPn8xujAAD` vanessa ordonez · 4t · 2026-06-08
+   merge←  `auto_f2330b32` cosecAU SL · 0t · 2026-04-27
+
+### ⭐ 31. sarah.bartak@brianmdavis.org.au  (1 dup)
+   **KEEP** `QdAmpE07Z361Rrx6ilS2` sarah bartak · 4t · 2026-06-08
+   merge←  `auto_e4724ba2` Sarah Bartak · 0t · 2026-04-30
+
+### ⭐ 32. g.byron@snowfoundation.org.au  (1 dup)
+   **KEEP** `WKPGDlP6FyYg4hUTmQzd` georgina byron · 4t · 2026-06-08
+   merge←  `7S6pSw0fIMpMMwxtSPCz` Georgina Byron · 3t · 2026-04-08
+
+### ⭐ 33. anita.hopkins@brianmdavis.org.au  (1 dup)
+   **KEEP** `X9kE3G9rqvR51gUo0Bsx` anita hopkins · 4t · 2026-06-08
+   merge←  `auto_9d9c9423` Anita Hopkins · 0t · 2026-05-13
+
+### ⭐ 34. bridgit@reddust.org.au  (1 dup)
+   **KEEP** `Q4fquuYzVh0z6NXLqrwU` bridgit mcmullen · 4t · 2026-06-08
+   merge←  `auto_f1706418` Bridgit McMullen · 0t · 2026-03-10
+
+### ⭐ 35. alberto.furlan@ianpotter.org.au  (1 dup)
+   **KEEP** `PoPY4biO1VsofPFGdpv5` alberto furlan · 4t · 2026-06-08
+   merge←  `n9c8Aeyckfw1Qa6nupYD` Alberto Furlan · 3t · 2026-05-29
+
+### ⭐ 36. jessica@socialimpacthub.org  (1 dup)
+   **KEEP** `reconcile_6547cf18` Jessica Mendoza-Roth · 1t · 2026-02-28
+   merge←  `CxTAADLcBEUIzXLGhp5W` social impact hub foundation · 0t · 2026-06-08
+
+### ⭐ 37. nic.sharah@homelandschoolcompany.org.au  (1 dup)
+   **KEEP** `r8oUYf3j3L0HcnoBqVeX` homeland school company · 0t · 2026-06-08
+   merge←  `auto_67832921` Nic Sharah · 0t · 2026-05-06
+
+### ⭐ 38. jenn@anat.org.au  (1 dup)
+   **KEEP** `FZ9kj33EShcYmQt8BN1X` jenn brazier · 0t · 2026-06-08
+   merge←  `manual_95185c8b-d183-444f-b08c-8239cc673c1f` Jenn Brazier · 0t · 2026-03-18
+
+### ⭐ 39. traceynewman008@gmail.com  (4 dups)
+   **KEEP** `8Ysd4HscCutj53m0Oqzx` tracey newman · 13t · 2026-05-29
+   merge←  `D05Oa0eO8arILsSNjiPQ` tracey newman · 6t · 2026-06-08
+   merge←  `5Ef5iz76fJvyK1b5hI1Q` tracey newman · 6t · 2026-06-08
+   merge←  `pvZ53c6JlkL5sOPPFiTc` tracey newman · 6t · 2026-06-08
+   merge←  `hOn1vWuI9tNNhW0Mn1jl` tracey newman · 6t · 2026-06-08
+
+### ⭐ 40. pene.curtis@bigpond.com  (3 dups)
+   **KEEP** `eyr6Cv6B9cf2VFUzJBQs` pene curtis · 20t · 2026-06-08
+   merge←  `5EfSDhGNzQmIcgLz5LuH` pene curtis · 13t · 2026-06-08
+   merge←  `zByIWtdKk4Z83B7b4uML` pene curtis · 5t · 2026-04-20
+   merge←  `PRoijdTUvWTYv2D5B29s` pene curtis · 7t · 2026-05-27
+
+### ⭐ 41. mtaylor@envirobank.com.au  (2 dups)
+   **KEEP** `IPzrkrahNKcSWL03d8Jq` marty taylor · 4t · 2026-06-08
+   merge←  `auto_1c29c2da` Marty Taylor · 0t · 2026-02-26
+   merge←  `ipZjeDDR9uwHMdXR7KV6` marty taylor · 3t · 2026-06-08
+
+### ⭐ 42. knighttss@gmail.com  (2 dups)
+   **KEEP** `9uBnZcxMfiGZDLgS22vg` benjamin knight · EL 4t · 2026-05-27
+   merge←  `PuuRHAkYciTlzUYl9a8R` benjamin knight · 4t · 2026-05-25
+   merge←  `0PrtdUUsyqYv5QklTNte` benjamin knight · 4t · 2026-06-08
+
+### 43. susyn.young@gmail.com  (1 dup)
+   **KEEP** `sanAvi38DOOdCFdBlNqO` susyn young · consent 19t · 2026-06-08
+   merge←  `auto_c86bbe63` Susyn Young · 0t · 2026-05-04
+
+### 44. amy.elson@nt.gov.au  (1 dup)
+   **KEEP** `B1U3yW6G9UoDI5BsAV4c` amy elson · 14t · 2026-04-22
+   merge←  `6IijuIN8YUSD200siSc8` amy elson · 12t · 2026-06-08
+
+### 45. grantluff@gmail.com  (1 dup)
+   **KEEP** `X4Md4sr73fZdL33BPmlz` grant luff · 12t · 2026-03-26
+   merge←  `V8YinCOfEn8BdsujGzW0` grant luff · 10t · 2026-06-08
+
+### 46. lorana.bartels@anu.edu.au  (1 dup)
+   **KEEP** `ozylqwJZShaQnAwcOJby` (no name) · consent 7t · 2026-06-08
+   merge←  `lDdMkRI18W42NlvS7k05` Lorana Bartels · 0t · 2026-03-25
+
+### 47. c.jones@pgud.org  (1 dup)
+   **KEEP** `VO6mL3LulO6PqMgvBM9X` (no name) · consent 6t · 2026-06-08
+   merge←  `ejNcw4Ba1tAKeKy7jb2N` kmpugwfgwtxmtlrmpsimjnmp · 4t · 2026-06-08
+
+### 48. srubiamador@sjusd.org  (1 dup)
+   **KEEP** `vARf3DDefHHMj8tI35j2` (no name) · consent 6t · 2026-06-08
+   merge←  `lS6odMdzaEcGJ4eVIEQT` lxammhzitmziufjzsqxi · 3t · 2026-06-08
+
+### 49. ciscoub@yahoo.com  (1 dup)
+   **KEEP** `zVpUoZng3rFI78abJ861` (no name) · consent 6t · 2026-06-08
+   merge←  `gGYuKv43Vi2uUkLij3DU` kbbzxlhazvflphckap · 4t · 2026-06-08
+
+### 50. hawk_b51@yahoo.com  (1 dup)
+   **KEEP** `DkpXtag9mbaAp6yCuSrA` (no name) · consent 6t · 2026-06-08
+   merge←  `M9Tk5QXVTWiwj0tmJrXU` yvjnzgwshqirdfbocw · 4t · 2026-06-08
+
+### 51. sbruzda@allianceppc.com  (1 dup)
+   **KEEP** `2Z6qZKDEfTRqATZN1oVk` (no name) · consent 6t · 2026-06-08
+   merge←  `wH335AZ8O1hTQY0gRgXr` deuycmrdpsouzrxudbrbfly · 3t · 2026-06-08
+
+### 52. dj.polodavi.s@gmail.com  (1 dup)
+   **KEEP** `k51xRq1kMPEslLIjHRPP` (no name) · consent 6t · 2026-06-08
+   merge←  `vUF0sWNma75NwkMMr0K4` wtadfcuqyfabvnttrzkpds · 4t · 2026-06-08
+
+### 53. cperry@qt-az.com  (1 dup)
+   **KEEP** `OCbQ4FD8QZ6H1J6SHSpR` (no name) · consent 6t · 2026-06-08
+   merge←  `dU8c2XwMQtu0UuMs8Onv` ikjvutqbrwdapktj · 3t · 2026-06-08
+
+### 54. l.fclaf.fee@gmail.com  (1 dup)
+   **KEEP** `5tsFtKJV3S9QHVVKlXo2` (no name) · consent 6t · 2026-06-08
+   merge←  `r5cRnJzfYPzf76K7J4C5` tkjoiieskigthxrpmmxyy · 3t · 2026-06-08
+
+### 55. kathy@klempel.me  (1 dup)
+   **KEEP** `qB0Mm6PlNg9zMhYqgzPc` (no name) · consent 6t · 2026-06-08
+   merge←  `dERu9XMHEJ866KKclssi` ojszzfnkjvshsbuc · 3t · 2026-06-08
+
+### 56. javi_tess92@outlook.com  (1 dup)
+   **KEEP** `z0VG38J9E9VD1CgAMdd1` (no name) · consent 6t · 2026-06-08
+   merge←  `gZ3GXY1hv6iIBKLvNIBN` hqcgsykswtixcpflqzmz · 4t · 2026-06-08
+
+### 57. ryazantsova@chameleongroup.co  (1 dup)
+   **KEEP** `n0x9Jeq9U7gUcDTIHcKi` (no name) · consent 6t · 2026-06-08
+   merge←  `PoULIorUVo7iRlB6Su8w` xwbklalwszjssprelrykawc · 3t · 2026-06-08
+
+### 58. sgbox@wanadoo.fr  (1 dup)
+   **KEEP** `qPX3grwbIxKMhi09dnA8` (no name) · consent 6t · 2026-06-08
+   merge←  `9iKuhg5ZeUjxkwEvA9jO` qmsnjfvzunkazvkoouae · 3t · 2026-06-08
+
+### 59. 7202034285@tmomail.net  (1 dup)
+   **KEEP** `AANmMV55PgMLFCEvML8T` (no name) · consent 6t · 2026-06-08
+   merge←  `00CsYRanDFMm9dyuudLY` vmygatmsfubskwdxzdhqeunh · 3t · 2026-06-08
+
+### 60. vr@chameleongroup.co  (1 dup)
+   **KEEP** `Skq21DRy4vKLLhj3Xxhf` (no name) · consent 6t · 2026-06-08
+   merge←  `qHhpImxgkfJRqQjQAcWw` cruqxdtsahepqhvdiw · 3t · 2026-06-08
+
+### 61. sd.sas.hco@gmail.com  (1 dup)
+   **KEEP** `1H8Og5lXJvRRRe0D01GK` (no name) · consent 6t · 2026-06-08
+   merge←  `hizlzOUVPL5pIXyPw0D2` mlkytwiwsdfebevw · 3t · 2026-06-08
+
+### 62. ecoury8751@aol.com  (1 dup)
+   **KEEP** `aW4jtrU1dyKR0VHmM20z` (no name) · consent 6t · 2026-06-08
+   merge←  `c1bLRnL2j6iBtUXDAHk8` wgsvtpdkmfduaycfon · 3t · 2026-06-08
+
+### 63. realinnovationfund@dewr.gov.au  (1 dup)
+   **KEEP** `MymJIeUEL8btnnIT7bJB` real innovation fund · 5t · 2026-06-08
+   merge←  `auto_ff882964` DEWR - REAL Innovation Fund · 2t · 2026-03-18
+
+### 64. stp@uonbi.ac.ke  (1 dup)
+   **KEEP** `rzwKLf3DXKs3C02dBpPH` fablab nairobi · 4t · 2026-05-27
+   merge←  `CwcOrXeWjmjWQNryceX1` (no name) · 2t · 2026-06-08
+
+### 65. jeremy@colemanprint.com.au  (1 dup)
+   **KEEP** `iqk86FbdDvkyZvYrVkmu` jeremy bigg · 4t · 2026-06-08
+   merge←  `auto_e3c10d00` jeremy · 0t · 2026-05-15
+
+### 66. maggiebea@gmail.com  (1 dup)
+   **KEEP** `xGUd9CrDEHyTZhjffqVs` maggie beale · 3t · 2026-06-08
+   merge←  `auto_acb2a874` maggiebea · 0t · 2026-03-30
+
+### 67. cherring@blackbird.vc  (1 dup)
+   **KEEP** `ku4kKGWrrMSsUgBNv8Pe` blackbird · 0t · 2026-06-08
+   merge←  `auto_dd7e2e75` Blackbird · 0t · 2026-06-01
+
+### 68. cassie@devpost.com  (1 dup)
+   **KEEP** `H4mOTf5X4in943diSVLE` cassie from devpost · 0t · 2026-06-08
+   merge←  `FUkMewWYXlKvY4iQsFKB` Cassie from Devpost · 0t · 2026-03-14
+
+### 69. jane.stecyk@m.mightynetworks.com  (1 dup)
+   **KEEP** `TFBZR9piKBsEHbR9LAIQ` jane stecyk · 0t · 2026-06-08
+   merge←  `320n1jeQmcihesXZUmye` jane stecyk · 0t · 2026-03-31
+
+### 70. learn@send.zapier.com  (1 dup)
+   **KEEP** `ZAGln0nOLO1Li5gTbnGU` Zapier · 0t · 2026-06-08
+   merge←  `I7Cxyx67diOdRbXnsVyA` zapier · 0t · 2026-03-21
+
+### 71. nicholas@ffproductions.com.au  (1 dup)
+   **KEEP** `XDIJiY5M5UpTq731i8Gp` nic marchesi · 0t · 2026-06-08
+   merge←  `auto_dbe6e4df` Nicholas Marchesi · 0t · 2026-04-27
+
+## ⚠️ REVIEW — role / shared inbox
+
+Same address, but a shared inbox can be **different people**. Confirm they are the same human before merging; otherwise re-email them and split.
+
+### 1. ceo@deadlyscience.org.au  (5 dups)
+   **KEEP** `kMG435sXyNZ3g0ka2hzg` cory tutt · consent 4t · 2026-03-06
+   merge←  `5LqgNvZQ2TGXHyJguHkB` corey tutt · 7t · 2026-06-08
+   merge←  `O5zWG2qnHYaeMPlYdK6z` corey tutt · 4t · 2026-05-15
+   merge←  `wFviTiFi7euS3VyRWwLn` corey tutt · 9t · 2026-06-08
+   merge←  `7i2onyZFqX12BKlx5uLY` corey tutt · 5t · 2026-06-08
+   merge←  `YveuSGaoTk1fk105ExPO` corey tutt · 5t · 2026-06-08
+
+### 2. contact@cdsuganda.org  (1 dup)
+   **KEEP** `H02uVZuut3krrt7J4iV2` ogole oscar · 4t · 2026-05-27
+   merge←  `Vse75dT3to1FwGmQeCAi` ogole oscar · 2t · 2026-06-08
+
+### 3. jobs@key-systems.net  (1 dup)
+   **KEEP** `Ix0bCx8mbJoEmKePeTer` (no name) · consent 6t · 2026-06-08
+   merge←  `TBueqicmPnv5MTfw6fa9` uztvrdwpntxpceienltdfn · 4t · 2026-06-08
+
+### 4. accounts@julalikari.com.au  (1 dup)
+   **KEEP** `manual_323669aa-9ad2-46ae-910b-c5e795b64227` Julalikari Accounts · 1t · 2026-01-30
+   merge←  `2McL6zmvblS37U0Q5XOm` julalikari council aboriginal corporation · 0t · 2026-06-08
+
+### 5. support.dk@ezviz.com  (1 dup)
+   **KEEP** `jvbsIAwJdPpADLphJN4q` ezviz international · 0t · 2026-06-08
+   merge←  `Qu9mAYCYeKQ49oneprmv` support dk · 0t · 2026-03-02
+
+### 6. hi@act.place  (1 dup)
+   **KEEP** `x9ppRP5MZJnF6v01DgWj` a kind tractor · EL 9t · 2026-01-23
+   merge←  `b5iTn4wqP0LsYuknFPnd` act admin · 4t · 2026-05-29
+
+### 7. contact@good360.org.au  (1 dup)
+   **KEEP** `jHSaeQO107ZNdPE2663T` good360 australia · 0t · 2026-06-08
+   merge←  `FYqz6jN9upIH186oBLKN` Good360 Australia · 0t · 2026-04-24
+
+### 8. info@flyhav.com  (1 dup)
+   **KEEP** `g3mCmF64426by14k24uk` hinterland aviation · 3t · 2026-06-08
+   merge←  `auto_25d2d21d` info · 0t · 2026-03-31
+
+### 9. orders@eprintonline.com.au  (1 dup)
+   **KEEP** `tCqk03o9pwcnf4F2pYi0` eprint online · 4t · 2026-06-08
+   merge←  `auto_2c98c781` orders · 0t · 2026-03-23
+
+### 10. support@rubimicrocafe.com  (1 dup)
+   **KEEP** `iZjD7QCXmTntsvhxRQSP` (no name) · consent 6t · 2026-06-08
+   merge←  `hfwq5NNmXUdw4oN0bpwV` vsxigmlydfvrynioyvudbprj · 3t · 2026-06-08
+
+### 11. info@e.atlassian.com  (1 dup)
+   **KEEP** `fO8yjuMpilWMD5JDzJZ6` loom · 0t · 2026-06-08
+   merge←  `auto_fec6131c` Loom · 0t · 2026-04-17
+
+### 12. ceo@jvtrust.org.au  (1 dup)
+   **KEEP** `Fhk0FK9FcN563lUcSKhT` fiona maxwell · 21t · 2026-04-29
+   merge←  `hQdMEJd33LmL3jzONRGh` fiona maxwell · 14t · 2026-06-08
+
+### 13. accounts@act.place  (1 dup)
+   **KEEP** `vT1CWtY6zB0kckOlzk8D` accounts act · EL 5t · 2026-06-08
+   merge←  `Evf4J6yT8Z7U1AUl7X3T` accounts act · EL 3t · 2026-06-08
+
+### 14. team@mail.miro.com  (1 dup)
+   **KEEP** `MUEZf7YBTER80g9iPBB9` the miro team · 0t · 2026-06-08
+   merge←  `TQfNIpXv2oBvNs03d6Hz` The Miro Team · 0t · 2025-12-16
+
+### 15. hello@super.so  (1 dup)
+   **KEEP** `1cDDSoegD8YYnQA4FbGK` super · 0t · 2026-06-08
+   merge←  `auto_89084644` Super · 0t · 2026-05-25
+
+### 16. team@mail.perplexity.ai  (1 dup)
+   **KEEP** `tIcBE6bbyxiKmFYPF1Vx` perplexity enterprise · 0t · 2026-06-08
+   merge←  `auto_fe7bbe3d` Perplexity · 0t · 2026-04-11
+
+## 🤖 SYSTEM — automation artifacts (delete / fix at source)
+
+A tool created a contact per run (e.g. the GrantScope orchestrator on `grantscope-triage@act.place`). **Do not hand-merge** — delete the extras and fix the source so it stops regrowing.
+
+### 1. grantscope-triage@act.place  (14 dups)
+   **KEEP** `BZvB3crwSpby8FfzmB19` grantscope triage · 4t · 2026-05-23
+   merge←  `go1AwjMi8D1trk8WsbYj` grantscope triage · 1t · 2026-06-08
+   merge←  `8SlnzOgAHhpOyLwywOIW` grantscope triage · 1t · 2026-06-08
+   merge←  `kL3sN6xV9WpGXRSqMgKM` grantscope triage · 1t · 2026-06-08
+   merge←  `NCBUYk9TQ7fnYIqFCD32` grantscope triage · 1t · 2026-06-08
+   merge←  `uAsIUWBHez3DzVex8rtm` grantscope triage · 1t · 2026-06-08
+   merge←  `RXTJqT4K3IpMk6XjRaj5` grantscope triage · 2t · 2026-06-08
+   merge←  `rxBfwMhOd3vyfOFCkvYD` grantscope triage · 1t · 2026-06-08
+   merge←  `5cWKwQGai8jg00jq23MJ` grantscope triage · 1t · 2026-06-08
+   merge←  `ls4MMNgOdTI2gEROPeW6` grantscope triage · 1t · 2026-06-08
+   merge←  `5kvBkyiJiSIlEC8EG2CO` grantscope triage · 1t · 2026-06-08
+   merge←  `OS6cGHu8rn3ySuwj1MOP` grantscope triage · 1t · 2026-06-08
+   merge←  `eWuHmHaqJqmO6M0qv5ku` grantscope triage · 1t · 2026-06-08
+   merge←  `N066soQXQ4SEPFm8jvDs` grantscope triage · 1t · 2026-06-08
+   merge←  `ShJqUOpYkOwoJuZb1NjF` grantscope triage · 2t · 2026-06-08
+
+## 🚫 NOT_PEOPLE — vendor / test / place-record / scraped spam
+
+Not human relationships: example/placeholder domains, automated senders (`news@`, `invoice+…`), `goods.civicgraph.io` place-records, and dotted-gmail spam. **Skip when merging**; safe to bulk-delete.
+
+### 1. stripe@example.com  (3 dups)
+   **KEEP** `Uo2GntyRd9gElysyXadb` jenny rosen · 3t · 2026-06-08
+   merge←  `quQ1IVDWSP9KI5ixj2pd` jenny rosen · 1t · 2026-06-08
+   merge←  `2Arkb6HM8Kde2MtGif5S` jenny rosen · 1t · 2026-06-08
+   merge←  `gR2puEwwcN78LNSm1feT` jenny rosen · 1t · 2026-06-08
+
+### 2. m.cnu.rl.in.s@gmail.com  (1 dup)
+   **KEEP** `Nnz7iZwHdneXV4Jevi5E` (no name) · consent 6t · 2026-06-08
+   merge←  `iMXVDwAhWo1di7wpozUl` uaeinxuxmozivxufmgmnvw · 4t · 2026-06-08
+
+### 3. j.a.j.ab.ell.e8.1@gmail.com  (1 dup)
+   **KEEP** `gXTEPv647NO8ZWZxnBrx` (no name) · consent 6t · 2026-06-08
+   merge←  `StEignH29EJfadvAaEvs` nrzlqeyovwlydenv · 3t · 2026-06-08
+
+### 4. voicemail@dialpad.com  (1 dup)
+   **KEEP** `J9r6ZqJc5UAFGkguBC9w` dialpad · 0t · 2026-06-08
+   merge←  `auto_1eb1bdb3` Dialpad · 0t · 2026-03-10
+
+### 5. final-check@example.com  (1 dup)
+   **KEEP** `qSAr8aMM9bgCPXzuTL1R` test · 9t · 2026-06-08
+   merge←  `RI1TytFSVn0qCj3OpxMQ` test · 7t · 2026-06-08
+
+### 6. welcome@openrouter.ai  (1 dup)
+   **KEEP** `xFafMw0kPSHRqudXbxzS` openrouter team · 0t · 2026-06-08
+   merge←  `auto_7b5386cb` OpenRouter Team · 0t · 2026-06-03
+
+### 7. news@send.zapier.com  (1 dup)
+   **KEEP** `JISEYTvuvj4g0PNcJ2nJ` zapier news · 0t · 2026-06-08
+   merge←  `auto_6acba82c` Zapier News · 0t · 2026-03-26
+
+### 8. mi.ke661.8.10@gmail.com  (1 dup)
+   **KEEP** `Hdz88yGNh9cQgxwdIVnH` (no name) · consent 6t · 2026-06-08
+   merge←  `8BkMmfmUWrmSUTo7WLaE` tzubbsxdthlorakxno · 4t · 2026-06-08
+
+### 9. invoice+statements@supabase.com  (1 dup)
+   **KEEP** `msoQkyq035iy0p92ayPu` supabase pte. ltd. · 0t · 2026-06-08
+   merge←  `JLIYqnZRZDJ2d4Qf5MQw` supabase pte. ltd. · 0t · 2026-03-21
+
+### 10. jarlmadanka@goods.civicgraph.io  (1 dup)
+   **KEEP** `L1kooixF2tOI61OSdbP8` jarlmadanka wa · 2t · 2026-06-08
+   merge←  `ac6FQdAwintboayVWUiM` jarlmadanka wa · 2t · 2026-05-15
+
+### 11. warruwi@goods.civicgraph.io  (1 dup)
+   **KEEP** `i3odQcXuB5Ek7jjnayH6` warruwi nt · 3t · 2026-06-08
+   merge←  `Kfftjz1kr7re0quOvxxn` warruwi nt · 2t · 2026-05-15
+
+### 12. feedback+customerio@warp.dev  (1 dup)
+   **KEEP** `NEPhpv06ImtmacDOjfye` eric from warp · 0t · 2026-06-08
+   merge←  `auto_55e7da84` Warp Team · 0t · 2026-03-06
+
+### 13. kintore@goods.civicgraph.io  (1 dup)
+   **KEEP** `kTimXhFlc71LShGqSwGI` kintore nt · 3t · 2026-06-08
+   merge←  `iuVqVB3OrXIEcOEw5riw` kintore nt · 2t · 2026-05-15
+
+### 14. accounting@thriday.com.au  (1 dup)
+   **KEEP** `w9sayHZwpD9yy0cmahAb` thriday accounting · 0t · 2026-06-08
+   merge←  `auto_5c5ea3f2` Sally Hurst (Thriday Accounting Support) · 0t · 2026-03-26
+
+### 15. maureen.cummings@jcf.placeholder  (1 dup)
+   **KEEP** `OKn95bkiAVRAWDKxeh2U` maureen cummings · EL 3t · 2026-06-08
+   merge←  `P7hT9BCbMgpmw3MYA1ub` maureen cummings · 4t · 2026-05-29
+
+### 16. a.s.hleyd.uk.es.1.2@gmail.com  (1 dup)
+   **KEEP** `1wK7zf7Ja4VRRtyUID47` (no name) · consent 6t · 2026-06-08
+   merge←  `egO4mKoiE3UQOdVs3Fra` kkvawnbzzxrsrkqbpglvr · 4t · 2026-06-08
+
+### 17. wecare@thriday.com.au  (1 dup)
+   **KEEP** `b1uGSGDl6iBEXJdiRFkV` thriday · 0t · 2026-06-08
+   merge←  `auto_7ab4ec28` Thriday · 0t · 2026-03-11
+
+### 18. pete.rh.aup.e.nthal1.4@gmail.com  (1 dup)
+   **KEEP** `Eyc5IpyXhUbBU09JhoSd` (no name) · consent 6t · 2026-06-08
+   merge←  `xmxXCRJfjp1l2nfJVfVo` oyrdeuhvyjpndvxv · 3t · 2026-06-08
+
+### 19. w.i.n.at.aro23.4@gmail.com  (1 dup)
+   **KEEP** `8iuHKXd1fc399wTjBAao` (no name) · consent 6t · 2026-06-08
+   merge←  `qojZDdJtW9tjp46Cdjc4` fqxxztkhksrsgcprhdojjem · 3t · 2026-06-08
+
+### 20. umbakumba@goods.civicgraph.io  (1 dup)
+   **KEEP** `6bjo08S459GAjsCrJEa0` umbakumba nt · 3t · 2026-06-08
+   merge←  `cosG1FgL133xMtL2ewdy` umbakumba nt · 2t · 2026-05-15
+
+### 21. updates@product.exa.ai  (1 dup)
+   **KEEP** `UaApxKCDKpy7a1wYtDhT` will bryk · 0t · 2026-06-08
+   merge←  `mwZOKNJrRt23YeZSluLD` Exa Product Updates · 0t · 2026-03-05
+
+### 22. ben+washtest1779856038@benjamink.com.au  (1 dup)
+   **KEEP** `CWYLiCR10hR8wa3NTmLw` wash test · 5t · 2026-06-08
+   merge←  `W8NvPYuxVs8ZA6rR2Fsi` wash test · 5t · 2026-06-08
+
+### 23. milingimbi@goods.civicgraph.io  (1 dup)
+   **KEEP** `65oqqmNvJ056JG0Mp3pF` milingimbi nt · 3t · 2026-06-08
+   merge←  `pnKIc9CJvb4XmbcK8q74` milingimbi nt · 2t · 2026-05-15
+
+### 24. cole.reply@formspree.io  (1 dup)
+   **KEEP** `DQqLmSsP4hxU1iIUF14Y` cole · 0t · 2026-06-08
+   merge←  `WUiKS4b8hgp2ePnV7LoC` Cole · 0t · 2026-03-12
+
+## 🗑️ LOW_VALUE — delete the dups (don't merge)
+
+No tags, no consent, garbage/empty names — scrape artifacts. Safe to delete the `merge←` rows in UI rather than merge.
+
+_none_


### PR DESCRIPTION
## Why

GHL contact duplicates were regrowing. Root cause (verified live this session): **`lookupContactByEmail` was on a broken endpoint.** It called `GET /contacts/lookup`, which GHL reads as a contact-id in the path → always 4xx → the `catch` swallowed it to `null`. So `upsertContact` **never found existing contacts and always created** — the primary engine of the duplicate pile across *every* upsert caller (`push-prospects`, `seed-grants`, `world-tour`, `storytellers`, `contact-manager`), not just `grantscope-triage@`.

Probe (read-only): `lookupContactByEmail('sam@defydesign.org')` returned `null` despite sam having 5 records; `searchContacts(...)` found the exact match.

## Changes

**`scripts/lib/ghl-api-service.mjs`**
- `lookupContactByEmail` → uses the working `POST /contacts/search` + exact-email match. Transient errors (429/5xx/network) retry once then **THROW** instead of returning `null` (returning null on a transient failure is what lets upsert recreate a dup). Genuine not-found is a clean empty 200 → `null`, preserving the create path.
- `upsertContact` → **merges** incoming tags onto the existing record. GHL's `PUT /contacts/{id}` *replaces* the tag array; since updates only fire now that lookup works, without this an upsert carrying a few tags would wipe a contact's existing consent/comms tags.

**`scripts/seed-ghl-grants.mjs`**
- `ensureTriageContact` honors `GHL_TRIAGE_CONTACT_ID` to skip the per-run upsert of the fixed `grantscope-triage@act.place` holding contact; else lookup-once-then-create-if-absent.

**`scripts/build-ghl-merge-worklist-2026-06-09.mjs`** (+ output) — read-only triage of existing email-dup groups into MERGE / REVIEW / SYSTEM / NOT_PEOPLE for UI cleanup (no merge API exists).

## Verification
- ✅ **Live (read-only):** lookup now finds `sam@defydesign.org` (17 tags); a genuine miss returns clean `null`. `node --check` passes both files.
- ⚠️ **Not exercised live:** the write half (upsert → update with merged tags). Logic is sound but unrun against the API — **please review before this runs in the Monday cron.**

## Review focus
This is the **shared GHL write path**. Confirm: (1) the search→exact-email match is correct, (2) the tag-merge can't drop tags, (3) throw-on-transient is handled by callers (sync scripts wrap in try/catch + skip).

## Companion manual steps (not in this PR)
- GHL Settings → **"Allow Duplicate Contact" = OFF** (server-side belt).
- Clear the ~42 existing dups via the worklist, then set `GHL_TRIAGE_CONTACT_ID` to the surviving triage contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)