### PR TITLE
feat(whole-picture): two-account cash pipeline (v1.5 phase 2, TDD, display-gated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,8 @@ thoughts/shared/cockpit/xero-ghl-reconciler/[0-9]*.md
 thoughts/shared/cockpit/procurement-analyst/[0-9]*.md
 thoughts/shared/drafts/funder-notes/[0-9]*.md
 
+# Two-account cash pipeline sidecar — live financial balances, regenerable, point-in-time (v1.5 phase 2)
+thoughts/shared/data/two-account-cash-latest.json
+
 # Meeting-sync cursor (machine state, like .xero-sync-state.json above)
 wiki/raw/.last-meeting-sync

--- a/scripts/build-two-account-cash.mjs
+++ b/scripts/build-two-account-cash.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * build-two-account-cash.mjs — the trustworthy two-account cash pipeline (whole-picture v1.5 phase 2).
+ *
+ * Replaces the money snapshot's `.cash` field (which sums ALL non-archived xero_bank_accounts and
+ * renders -$152K/-$375K — see build-whole-picture.mjs header). Computes cash on hand from ONLY the
+ * two ACT operating accounts (NAB Visa #8815 + NJ Marchesi T/as ACT Everyday) via the TDD-pinned
+ * pure fn in lib/two-account-cash-lib.mjs (test: scripts/tests/two-account-cash.test.mjs).
+ *
+ * READ-ONLY: queries xero_bank_accounts, writes one JSON sidecar. No DB/Xero/GHL writes.
+ *
+ * TWO GATES guard the number before any surface shows it:
+ *   1. displayable = complete (both accounts, numeric) AND fresh (sync age <= 26h).
+ *   2. n3_decided  = the founders have declared the canonical money truth (N3). Default FALSE —
+ *      set WHOLE_PICTURE_MONEY_CANON=1 only AFTER the session declares canon. Until then the
+ *      surface keeps "withheld" even when displayable. `gated` = displayable && n3_decided.
+ *
+ * Output: thoughts/shared/data/two-account-cash-latest.json (gitignored — live, regenerable, sensitive).
+ * Run:  node scripts/build-two-account-cash.mjs            (writes sidecar + prints summary)
+ *       node scripts/build-two-account-cash.mjs --dry-run  (prints only, no file write)
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config as loadEnv } from 'dotenv';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeTwoAccountCash } from './lib/two-account-cash-lib.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+loadEnv({ path: path.resolve(ROOT, '.env.local') });
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const OUT = path.join(ROOT, 'thoughts/shared/data/two-account-cash-latest.json');
+const money = (n) => (n == null ? 'n/a' : '$' + Number(n).toLocaleString('en-AU', { minimumFractionDigits: 2, maximumFractionDigits: 2 }));
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  const sb = createClient(url, key);
+
+  const { data, error } = await sb
+    .from('xero_bank_accounts')
+    .select('name, status, current_balance, balance_updated_at');
+  if (error) throw error;
+
+  const r = computeTwoAccountCash(data, { nowMs: Date.now(), staleHours: 26 });
+
+  // N3 canon gate — orthogonal to displayable; OFF until the founders declare the money truth.
+  const n3Decided = ['1', 'true', 'yes'].includes(String(process.env.WHOLE_PICTURE_MONEY_CANON || '').toLowerCase());
+  const gated = r.displayable && n3Decided;
+  const withholdReason = gated
+    ? null
+    : !r.complete ? 'incomplete - an operating account balance is missing'
+      : r.stale ? `stale - oldest sync ${r.ageH == null ? '?' : r.ageH.toFixed(1)}h (>26h)`
+        : !n3Decided ? 'pending N3 - founders have not declared the canonical money truth'
+          : 'withheld';
+
+  const out = {
+    generated_at: new Date().toISOString(),
+    source: 'xero_bank_accounts (two-account rule: #8815 + Everyday only)',
+    cash: r.cash,
+    asOf: r.asOfMs == null ? null : new Date(r.asOfMs).toISOString(),
+    ageHours: r.ageH == null ? null : Number(r.ageH.toFixed(1)),
+    stale: r.stale,
+    complete: r.complete,
+    displayable: r.displayable,   // fresh + complete
+    n3_decided: n3Decided,        // founders declared canon?
+    gated,                        // displayable && n3_decided — surfaces may show ONLY when true
+    withhold_reason: withholdReason,
+    included: r.included,
+    excluded: r.excluded.map((e) => ({ name: e.name.trim(), reason: e.reason })),
+    card_caveat: r.cardCaveat,
+    note: r.note,
+  };
+
+  console.log(`two-account cash ${DRY_RUN ? '(dry-run)' : ''}`);
+  console.log(`  cash: ${money(r.cash)}  (included: ${r.included.map((a) => `${a.name.trim()} ${money(a.balance)}`).join(' + ')})`);
+  console.log(`  complete: ${r.complete} | fresh: ${!r.stale} (age ${r.ageH == null ? '?' : r.ageH.toFixed(1)}h) | displayable: ${r.displayable}`);
+  console.log(`  N3 canon decided: ${n3Decided} -> gated (surface may show): ${gated}${gated ? '' : `  [withheld: ${withholdReason}]`}`);
+  console.log(`  excluded: ${out.excluded.map((e) => e.name).join(', ')}`);
+
+  if (DRY_RUN) {
+    console.log(`  (dry-run: ${OUT} NOT written)`);
+    return;
+  }
+  mkdirSync(path.dirname(OUT), { recursive: true });
+  writeFileSync(OUT, JSON.stringify(out, null, 2));
+  console.log(`  wrote ${path.relative(ROOT, OUT)}`);
+}
+
+main().catch((e) => { console.error('build-two-account-cash FAILED:', e.message); process.exit(1); });

--- a/scripts/lib/two-account-cash-lib.mjs
+++ b/scripts/lib/two-account-cash-lib.mjs
@@ -1,0 +1,79 @@
+// Two-account cash pipeline — pure functions, no env, no network.
+//
+// ACT cash on hand is ONLY the two operating accounts (the two-account rule):
+//   NAB Visa ACT #8815 (credit card; negative = owing, nets cash DOWN) + NJ Marchesi T/as ACT Everyday.
+// EXCLUDE everything else — NM Personal (Nic's pre-cutover, -$388,937), the Maximiser savings,
+// and any ARCHIVED account. Source of truth for the names is ACCOUNTS.both in reconcile-sidecar-lib.
+//
+// This is the trustworthy replacement for the money snapshot's `.cash` field, which sums ALL
+// non-archived xero_bank_accounts (the bug that renders -$152K/-$375K). See
+// scripts/build-whole-picture.mjs header and thoughts/shared/plans/2026-06-16-whole-picture-v1.5.md.
+import { ACCOUNTS } from './reconcile-sidecar-lib.mjs';
+
+export const OPERATING_ACCOUNTS = ACCOUNTS.both.map((s) => s.trim());
+
+export const CARD_CAVEAT =
+  '#8815 (NAB Visa) carries unreconciled statement lines — its mirror balance is provisional; ' +
+  'verify against the card statement before treating cash as final.';
+
+/**
+ * Compute ACT two-account cash from xero_bank_accounts rows.
+ * @param {Array<{name,status,current_balance,balance_updated_at}>} accounts
+ * @param {{nowMs?:number, staleHours?:number, operating?:string[]}} opts
+ * @returns {{cash:number|null, asOfMs:number|null, ageH:number|null, stale:boolean,
+ *            complete:boolean, displayable:boolean, included:Array, excluded:Array,
+ *            cardCaveat:string, note:string}}
+ *
+ * `displayable` = complete AND fresh. The N3 "one money truth" canon gate is ORTHOGONAL and is
+ * applied by the consumer (the surface), NOT here — until N3 is declared the surface keeps the
+ * number withheld even when this returns displayable:true.
+ */
+export function computeTwoAccountCash(accounts, { nowMs = Date.now(), staleHours = 26, operating = OPERATING_ACCOUNTS } = {}) {
+  const opSet = new Set(operating.map((s) => String(s).trim()));
+  const included = [];
+  const excluded = [];
+
+  for (const a of accounts || []) {
+    const name = String(a?.name ?? '').trim();
+    const active = String(a?.status ?? '').toUpperCase() === 'ACTIVE';
+    if (opSet.has(name) && active) {
+      included.push({ name, balance: a.current_balance, balance_updated_at: a.balance_updated_at });
+    } else {
+      excluded.push({
+        name,
+        balance: a?.current_balance ?? null,
+        reason: !active ? `status ${a?.status}` : 'not an ACT operating account (two-account rule)',
+      });
+    }
+  }
+
+  // Complete only when every operating account is present AND has a numeric balance.
+  // A missing or null operating balance must NOT ship as a whole cash figure.
+  const foundNames = new Set(included.map((a) => a.name));
+  const allPresent = [...opSet].every((n) => foundNames.has(n));
+  const allNumeric = included.every((a) => typeof a.balance === 'number' && Number.isFinite(a.balance));
+  const complete = allPresent && allNumeric;
+
+  const cash = complete
+    ? Number(included.reduce((s, a) => s + a.balance, 0).toFixed(2))
+    : null;
+
+  // Freshness from the OLDEST operating-account sync (most conservative).
+  const stamps = included.map((a) => Date.parse(a.balance_updated_at)).filter((t) => !Number.isNaN(t));
+  const asOfMs = stamps.length ? Math.min(...stamps) : null;
+  const ageH = asOfMs == null ? null : (nowMs - asOfMs) / 3.6e6;
+  const stale = ageH == null ? true : ageH > staleHours;
+
+  const displayable = complete && !stale;
+
+  return {
+    cash, asOfMs, ageH, stale, complete, displayable,
+    included, excluded,
+    cardCaveat: CARD_CAVEAT,
+    note: !complete
+      ? 'Two-account cash INCOMPLETE — an operating account balance is missing; do not display.'
+      : stale
+        ? 'Two-account cash computed but STALE — withhold until a fresh sync.'
+        : 'Two-account mirror cash (fresh). Provisional on #8815 reconciliation; canon gate (N3) applied by the surface.',
+  };
+}

--- a/scripts/tests/two-account-cash.test.mjs
+++ b/scripts/tests/two-account-cash.test.mjs
@@ -1,0 +1,85 @@
+// Fixture tests for the two-account cash pipeline pure functions. No env, no network.
+// Run: node --test scripts/tests/two-account-cash.test.mjs
+//
+// The class of bug this pins (CLAUDE.md money-math rule): wrong account scoping.
+// ACT cash on hand is ONLY NAB Visa ACT #8815 + NJ Marchesi T/as ACT Everyday.
+// If NM Personal (-$388,937) or the Maximiser savings ever leak in, cash is wildly wrong
+// (the snapshot .cash bug renders -$152K/-$375K). A manual glance won't catch it; this test does.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeTwoAccountCash } from '../lib/two-account-cash-lib.mjs';
+
+const round2 = (n) => Number(Number(n).toFixed(2));
+
+// --- Fixture A: the live mirror as queried 2026-06-15 (ground truth) ---
+const LIVE_0615 = [
+  { name: 'NAB Visa ACT #8815', status: 'ACTIVE', current_balance: 64869.99, balance_updated_at: '2026-06-15T20:06:19Z' },
+  { name: 'NJ Marchesi T/as ACT Everyday', status: 'ACTIVE', current_balance: 56821.48, balance_updated_at: '2026-06-15T20:06:19Z' },
+  { name: 'NJ Marchesi T/as ACT Maximiser', status: 'ACTIVE', current_balance: null, balance_updated_at: '2026-06-15T20:06:19Z' },
+  { name: 'NM Personal ', status: 'ACTIVE', current_balance: -388937.60, balance_updated_at: '2026-06-15T20:06:19Z' }, // trailing space on purpose
+  { name: 'Heritage Visa CC ', status: 'ARCHIVED', current_balance: null, balance_updated_at: '2026-06-15T20:06:19Z' },
+];
+// 7.5h after the 06-15 20:06Z sync
+const NOW_FRESH = Date.parse('2026-06-16T03:36:19Z');
+
+test('two-account cash = #8815 + Everyday ONLY (current mirror = $121,691.47)', () => {
+  const r = computeTwoAccountCash(LIVE_0615, { nowMs: NOW_FRESH });
+  assert.equal(round2(r.cash), 121691.47);
+  assert.deepEqual(r.included.map((a) => a.name).sort(), ['NAB Visa ACT #8815', 'NJ Marchesi T/as ACT Everyday']);
+  assert.equal(r.complete, true);
+});
+
+test('NM Personal (-$388,937) NEVER leaks into cash (the bug this guards)', () => {
+  const r = computeTwoAccountCash(LIVE_0615, { nowMs: NOW_FRESH });
+  assert.ok(r.cash > 0, 'cash must be positive, not dragged negative by NM Personal');
+  const excludedNames = r.excluded.map((a) => a.name.trim());
+  assert.ok(excludedNames.includes('NM Personal'), 'NM Personal must be excluded');
+  assert.ok(excludedNames.includes('NJ Marchesi T/as ACT Maximiser'), 'Maximiser savings excluded');
+  assert.ok(excludedNames.includes('Heritage Visa CC'), 'archived account excluded');
+  assert.ok(!r.included.some((a) => a.name.trim() === 'NM Personal'));
+});
+
+// --- Fixture B: the founders-OS plan canonical figure (2026-06-10), regression anchor ---
+// $223,761.05 = Everyday +$288,981.73 + #8815 -$65,220.68 (proves negative-CC netting).
+const MIRROR_0610 = [
+  { name: 'NJ Marchesi T/as ACT Everyday', status: 'ACTIVE', current_balance: 288981.73, balance_updated_at: '2026-06-05T00:00:00Z' },
+  { name: 'NAB Visa ACT #8815', status: 'ACTIVE', current_balance: -65220.68, balance_updated_at: '2026-06-05T00:00:00Z' },
+  { name: 'NM Personal ', status: 'ACTIVE', current_balance: -375991.57, balance_updated_at: '2026-06-05T00:00:00Z' },
+];
+
+test('regression: 2026-06-10 founders-OS canonical cash = $223,761.05 (negative CC nets down)', () => {
+  const r = computeTwoAccountCash(MIRROR_0610, { nowMs: Date.parse('2026-06-10T00:00:00Z'), staleHours: 24 * 30 });
+  assert.equal(round2(r.cash), 223761.05);
+});
+
+// --- Freshness gate: never present a stale number as current ---
+test('freshness gate: fresh under threshold, stale over it', () => {
+  const fresh = computeTwoAccountCash(LIVE_0615, { nowMs: NOW_FRESH, staleHours: 26 });
+  assert.equal(fresh.stale, false);
+  const stale = computeTwoAccountCash(LIVE_0615, { nowMs: NOW_FRESH + 30 * 3.6e6, staleHours: 26 });
+  assert.equal(stale.stale, true);
+  // displayable requires fresh AND complete (the N3 canon gate is applied by the consumer, not here)
+  assert.equal(fresh.displayable, true);
+  assert.equal(stale.displayable, false);
+});
+
+// --- Completeness: a missing or null operating balance must not ship as a whole number ---
+test('completeness: missing #8815 => incomplete, not a partial cash figure', () => {
+  const onlyEveryday = LIVE_0615.filter((a) => a.name !== 'NAB Visa ACT #8815');
+  const r = computeTwoAccountCash(onlyEveryday, { nowMs: NOW_FRESH });
+  assert.equal(r.complete, false);
+  assert.equal(r.displayable, false);
+});
+
+test('completeness: a null operating balance => incomplete', () => {
+  const nullVisa = LIVE_0615.map((a) =>
+    a.name === 'NAB Visa ACT #8815' ? { ...a, current_balance: null } : a);
+  const r = computeTwoAccountCash(nullVisa, { nowMs: NOW_FRESH });
+  assert.equal(r.complete, false);
+});
+
+// --- The #8815 provisional caveat is always carried (unreconciled lines) ---
+test('card caveat present: #8815 balance is mirror-provisional', () => {
+  const r = computeTwoAccountCash(LIVE_0615, { nowMs: NOW_FRESH });
+  assert.match(r.cardCaveat, /#8815/);
+});


### PR DESCRIPTION
Phase 2 of Whole-Picture v1.5 (plan: `thoughts/shared/plans/2026-06-16-whole-picture-v1.5.md`). The trustworthy cash pipeline that replaces the money snapshot's `.cash` field (which sums ALL non-archived accounts and renders −$152K/−$375K).

## Money math — TDD-first
- **`lib/two-account-cash-lib.mjs`** — pure `computeTwoAccountCash()`. ACT cash = ONLY NAB Visa #8815 + NJ Marchesi T/as ACT Everyday (reuses `ACCOUNTS.both` as the single source of truth). Excludes NM Personal (−$388,937), Maximiser savings, archived accounts. Handles trailing-space names, null balances, negative-CC netting, freshness + completeness.
- **`tests/two-account-cash.test.mjs`** (written first, RED→GREEN) pins:
  - the failure mode — **NM Personal must never leak into cash**;
  - **current mirror cash $121,691.47** (verified live);
  - **the founders-OS canonical $223,761.05** (2026-06-10) as a regression anchor (proves negative-CC netting);
  - freshness + completeness gates.
  - 7/7 green; full suite **171/171**.

## Display gating — never ship a false/premature number
**`build-two-account-cash.mjs`** → JSON sidecar (gitignored: live balances, sensitive). **Two gates** before any surface shows the figure:
1. `displayable` = complete (both accounts, numeric) AND fresh (≤26h);
2. `n3_decided` = the founders declared the canonical money truth (**N3**) — default **OFF** (`WHOLE_PICTURE_MONEY_CANON`).

`gated = displayable && n3_decided`. Verified live: cash $121,691.47, displayable, **gated=false → withheld "pending N3"**. READ-ONLY.

## Follow-ups (not in this PR)
Phase 3 R&D-basis sidecar · wire the surfaces (session-kit / whole-picture) to consume this gated cash · the N3 decision itself is the founders' (flip `WHOLE_PICTURE_MONEY_CANON` after the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)