### PR TITLE
feat(whole-picture): FY26 R&D-basis sidecar (v1.5 phase 3, TDD, honest at-risk)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,5 +189,8 @@ thoughts/shared/drafts/funder-notes/[0-9]*.md
 # Two-account cash pipeline sidecar — live financial balances, regenerable, point-in-time (v1.5 phase 2)
 thoughts/shared/data/two-account-cash-latest.json
 
+# FY26 R&D-basis sidecar — sensitive R&D-tax financials, regenerable (v1.5 phase 3)
+thoughts/shared/data/rd-basis-latest.json
+
 # Meeting-sync cursor (machine state, like .xero-sync-state.json above)
 wiki/raw/.last-meeting-sync

--- a/scripts/build-rd-basis.mjs
+++ b/scripts/build-rd-basis.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * build-rd-basis.mjs — the honest FY26 R&D-basis sidecar (whole-picture v1.5 phase 3).
+ *
+ * Reports the FY26 R&D basis AS IT ACTUALLY STANDS for the 43.5% R&D Tax Incentive — not a
+ * confident number. Sources rd_eligible SPEND from xero_transactions, strips founder drawings via
+ * the TDD-pinned pure fn (lib/rd-basis-lib.mjs · test scripts/tests/rd-basis.test.mjs), and frames
+ * the result as an AT-RISK CEILING.
+ *
+ * READ-ONLY: queries xero_transactions, writes one JSON sidecar. No DB/Xero/GHL writes.
+ *
+ * The defensible basis is a CEILING, not bankable, for TWO documented reasons:
+ *   1. Nothing on paper — contemporaneous records 15078–81 absent from the mirror, R&D checklist
+ *      unchecked, decision log DRAFT (founders-OS plan 2026-06-10). 43.5% requires contemporaneous
+ *      records; without them the claim is uncured.
+ *   2. Standard Ledger review of the remaining (non-founder) rows can strip more ineligible spend —
+ *      the documented collapse-to-~$55K risk.
+ * Gate: bankable only when RD_BASIS_RECORDS_CURED=1 (set ONLY after records exist + SL confirms).
+ * Default OFF — the sidecar headlines the RISK, never a bankable figure.
+ *
+ * Output: thoughts/shared/data/rd-basis-latest.json (gitignored — sensitive R&D financials).
+ * Run:  node scripts/build-rd-basis.mjs            (writes sidecar + prints summary)
+ *       node scripts/build-rd-basis.mjs --dry-run  (prints only)
+ */
+import { createClient } from '@supabase/supabase-js';
+import { config as loadEnv } from 'dotenv';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { computeRdBasis } from './lib/rd-basis-lib.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+loadEnv({ path: path.resolve(ROOT, '.env.local') });
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const OUT = path.join(ROOT, 'thoughts/shared/data/rd-basis-latest.json');
+const FY = { start: '2025-07-01', end: '2026-06-30' };
+const money = (n) => '$' + Number(n || 0).toLocaleString('en-AU', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+// Documented "nothing on paper" gaps — from the founders-OS plan 2026-06-10 (not computed here).
+const PAPER_GAPS = [
+  'Contemporaneous records 15078-81 absent from the Xero mirror',
+  'R&D activity checklist unchecked',
+  'Decision log still DRAFT',
+];
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+  const sb = createClient(url, key);
+
+  // rd_eligible SPEND in FY26 (384 rows < PostgREST 1000 cap; guard the count anyway).
+  const { data, error, count } = await sb
+    .from('xero_transactions')
+    .select('contact_name, total', { count: 'exact' })
+    .eq('type', 'SPEND')
+    .eq('rd_eligible', true)
+    .gte('date', FY.start)
+    .lte('date', FY.end);
+  if (error) throw error;
+  if (count != null && data.length !== count) {
+    throw new Error(`TRUNCATION GUARD: fetched ${data.length} of ${count} rd_eligible rows — paginate`);
+  }
+
+  const rows = data.map((r) => ({ contact_name: r.contact_name, amount: Math.abs(Number(r.total) || 0) }));
+  const r = computeRdBasis(rows);
+
+  const cured = ['1', 'true', 'yes'].includes(String(process.env.RD_BASIS_RECORDS_CURED || '').toLowerCase());
+
+  const out = {
+    generated_at: new Date().toISOString(),
+    fy: 'FY26 (1 Jul 2025 - 30 Jun 2026)',
+    source: 'xero_transactions where rd_eligible AND type=SPEND',
+    rows_total: rows.length,
+    gross_flagged: r.grossFlagged,            // what is tagged R&D today
+    founder_drawings: r.founderDrawings,      // R&D-INELIGIBLE — must be stripped
+    founder_rows: r.founderRows,
+    founder_pct: Number(r.founderPct.toFixed(1)),
+    defensible_basis_ceiling: r.defensibleBasis, // CEILING after stripping obvious founder rows
+    offset_435_on_ceiling: r.offset435,          // 43.5% on the ceiling (illustrative, NOT bankable)
+    records_cured: cured,
+    bankable: cured,                             // never bankable until records cured
+    headline: cured
+      ? `FY26 R&D basis (records cured): up to ${money(r.defensibleBasis)} defensible; offset ~${money(r.offset435)}. SL-confirm final.`
+      : `AT RISK — flagged ${money(r.grossFlagged)} but ${money(r.founderDrawings)} (${r.founderPct.toFixed(0)}%) is founder drawings (ineligible). Defensible CEILING ${money(r.defensibleBasis)}; NOT bankable (nothing on paper + collapse-to-~$55K risk).`,
+    paper_gaps: PAPER_GAPS,
+    collapse_risk_note: 'Defensible basis is a ceiling; SL review of the remaining non-founder rows can push it lower (documented collapse-to-~$55K risk).',
+  };
+
+  console.log(`FY26 R&D basis ${DRY_RUN ? '(dry-run)' : ''}`);
+  console.log(`  flagged today:      ${money(r.grossFlagged)} (${rows.length} rows)`);
+  console.log(`  founder drawings:   ${money(r.founderDrawings)} (${r.founderRows} rows, ${r.founderPct.toFixed(0)}%) — R&D-INELIGIBLE, strip`);
+  console.log(`  defensible ceiling: ${money(r.defensibleBasis)}  ->  43.5% offset ${money(r.offset435)} (illustrative)`);
+  console.log(`  records cured: ${cured} -> bankable: ${cured}${cured ? '' : '  [AT RISK: ' + PAPER_GAPS.length + ' paper gaps + collapse-to-~$55K]'}`);
+
+  if (DRY_RUN) { console.log(`  (dry-run: ${path.relative(ROOT, OUT)} NOT written)`); return; }
+  mkdirSync(path.dirname(OUT), { recursive: true });
+  writeFileSync(OUT, JSON.stringify(out, null, 2));
+  console.log(`  wrote ${path.relative(ROOT, OUT)}`);
+}
+
+main().catch((e) => { console.error('build-rd-basis FAILED:', e.message); process.exit(1); });

--- a/scripts/lib/rd-basis-lib.mjs
+++ b/scripts/lib/rd-basis-lib.mjs
@@ -1,0 +1,40 @@
+// FY26 R&D-basis pure functions — no env, no network.
+//
+// Founder DRAWINGS are R&D-INELIGIBLE (they sit in equity), yet ~$238K of the FY26 rd_eligible flag
+// is founder payments. The defensible basis STRIPS them; the 43.5% offset is computed on the
+// defensible basis ONLY, never the gross flag.
+//
+// isFounder mirrors the classifier in scripts/reconciliation-worklist.mjs — keep the two in sync.
+//
+// IMPORTANT: defensibleBasis is a CEILING, not a bankable figure. Standard Ledger review of the
+// remaining rows AND the "nothing on paper" gap (contemporaneous records 15078–81 absent, checklist
+// unchecked, decision log DRAFT) can push it lower — the documented collapse-to-~$55K risk. The
+// loader (build-rd-basis.mjs) carries those caveats and the display gate; this fn just does the math.
+
+const FOUNDER_RE = /marchesi|^nicholas|^nic\b/i;
+
+export function isFounder(contactName) {
+  return FOUNDER_RE.test(String(contactName || ''));
+}
+
+const R_AND_D_OFFSET_RATE = 0.435; // 43.5% refundable R&D Tax Incentive
+
+export function computeRdBasis(rows) {
+  let grossFlagged = 0;
+  let founderDrawings = 0;
+  let founderRows = 0;
+  for (const r of rows || []) {
+    const amt = Number(r?.amount) || 0;
+    grossFlagged += amt;
+    if (isFounder(r?.contact_name)) {
+      founderDrawings += amt;
+      founderRows += 1;
+    }
+  }
+  grossFlagged = Number(grossFlagged.toFixed(2));
+  founderDrawings = Number(founderDrawings.toFixed(2));
+  const defensibleBasis = Number((grossFlagged - founderDrawings).toFixed(2));
+  const founderPct = grossFlagged > 0 ? (founderDrawings / grossFlagged) * 100 : 0;
+  const offset435 = Number((defensibleBasis * R_AND_D_OFFSET_RATE).toFixed(2));
+  return { grossFlagged, founderDrawings, founderRows, defensibleBasis, founderPct, offset435 };
+}

--- a/scripts/tests/rd-basis.test.mjs
+++ b/scripts/tests/rd-basis.test.mjs
@@ -1,0 +1,61 @@
+// Fixture tests for the FY26 R&D-basis pure functions. No env, no network.
+// Run: node --test scripts/tests/rd-basis.test.mjs
+//
+// The class of bug this pins: founder DRAWINGS counted as R&D. Drawings sit in equity and are
+// R&D-INELIGIBLE; if they survive into the basis the 43.5% claim is overstated and collapses on
+// ATO/SL review. isFounder mirrors scripts/reconciliation-worklist.mjs (/marchesi|^nicholas|^nic\b/i)
+// — keep the two in sync. Live FY26 ground truth (2026-06-16): gross $325,947.23 (384 rows),
+// founder drawings $238,653.88 (11 rows), defensible ceiling $87,293.35.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isFounder, computeRdBasis } from '../lib/rd-basis-lib.mjs';
+
+const round2 = (n) => Number(Number(n).toFixed(2));
+
+// Fixture reproducing the live aggregate (founder 238,653.88 / defensible 87,293.35 / gross 325,947.23)
+const RD_FIXTURE = [
+  { contact_name: 'Nicholas Marchesi', amount: 200000.00 }, // founder drawing
+  { contact_name: 'Nic Marchesi', amount: 38653.88 },       // founder drawing
+  { contact_name: 'Anthropic', amount: 50000.00 },          // defensible R&D spend
+  { contact_name: 'Cursor AI', amount: 37293.35 },          // defensible R&D spend
+];
+
+test('isFounder catches the founder, not look-alikes', () => {
+  assert.equal(isFounder('Nicholas Marchesi'), true);
+  assert.equal(isFounder('Nic Marchesi'), true);
+  assert.equal(isFounder('NICHOLAS MARCHESI'), true);   // case-insensitive
+  assert.equal(isFounder('Marchesi Family Trust'), true); // contains marchesi
+  assert.equal(isFounder('Nicola Roxon'), false);        // 'nic' with no word boundary -> NOT founder
+  assert.equal(isFounder('Anthropic'), false);
+  assert.equal(isFounder(''), false);
+  assert.equal(isFounder(null), false);
+});
+
+test('R&D basis strips founder drawings: defensible = gross - founder', () => {
+  const r = computeRdBasis(RD_FIXTURE);
+  assert.equal(round2(r.grossFlagged), 325947.23);
+  assert.equal(round2(r.founderDrawings), 238653.88);
+  assert.equal(r.founderRows, 2);
+  assert.equal(round2(r.defensibleBasis), 87293.35);
+});
+
+test('defensible basis NEVER includes a founder row (the bug this guards)', () => {
+  const r = computeRdBasis(RD_FIXTURE);
+  // founder drawings are the majority here; defensible must be far below gross
+  assert.ok(r.defensibleBasis < r.grossFlagged);
+  assert.ok(r.founderDrawings > r.defensibleBasis, 'founder portion dominates — basis must exclude it');
+  // 43.5% offset is computed on the DEFENSIBLE basis only, never the gross flag
+  assert.equal(round2(r.offset435), round2(87293.35 * 0.435));
+});
+
+test('founder share is reported (drives the collapse-risk read)', () => {
+  const r = computeRdBasis(RD_FIXTURE);
+  assert.equal(Math.round(r.founderPct), 73); // 238653.88 / 325947.23 = 73.2%
+});
+
+test('empty input is safe (zeros, not NaN)', () => {
+  const r = computeRdBasis([]);
+  assert.equal(r.grossFlagged, 0);
+  assert.equal(r.defensibleBasis, 0);
+  assert.equal(r.founderPct, 0);
+});


### PR DESCRIPTION
Phase 3 of Whole-Picture v1.5. Reports the FY26 R&D basis **as it actually stands** for the 43.5% R&D Tax Incentive — an at-risk picture, not a confident number.

## Sourced live (memory was wrong — sourced, not assumed)
| | rows | $ |
|---|---|---|
| Gross rd_eligible flagged | 384 | $325,947.23 |
| **Founder drawings (R&D-ineligible — strip)** | 11 | $238,653.88 (73%) |
| **Defensible basis CEILING** | 373 | $87,293.35 |
| 43.5% offset on ceiling (illustrative) | | ~$37,972.61 |

Memory had claimed "$238,654 = the flag → ~$55K basis"; live truth: $238,654 is the *founder portion*, gross is $325,947, ceiling is $87,293, and ~$55K is the *further* collapse risk.

## TDD-first + honest gating
- **`lib/rd-basis-lib.mjs`** — pure `isFounder` (mirrors `reconciliation-worklist.mjs`) + `computeRdBasis`.
- **`tests/rd-basis.test.mjs`** (written first) pins: founder drawings **never** enter the basis, 43.5% computed on the defensible only, isFounder look-alike guard (`Nicola` ≠ `Nic`), empty-safe. 5/5; full suite **176/176**.
- **`build-rd-basis.mjs`** → truncation-guarded loader → gated sidecar. **NOT bankable** until `RD_BASIS_RECORDS_CURED=1`; headlines the risk: nothing on paper (15078–81 absent, checklist unchecked, decision log DRAFT) + collapse-to-~$55K on SL review. READ-ONLY; sidecar gitignored. Verified live: reproduces the SQL aggregate to the cent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)