### PR TITLE
docs(finance): retract stale 328-G cutover recommendation (fails two-trust UEO test)

### DIFF
--- a/thoughts/shared/research/2026-06-01-cutover-tax-verification.md
+++ b/thoughts/shared/research/2026-06-01-cutover-tax-verification.md
@@ -46,6 +46,8 @@
 
 ### 2. Subdivision 328-G Small Business Restructure Rollover — SUPPORTED-WITH-CONDITIONS
 
+> ⚠️ **UPDATE (2026-06-19): the MEDIUM-risk condition this section flagged has resolved AGAINST 328-G.** The 2026-06-19 decision pack concludes 328-G FAILS: the s328-440 family-trust alternative needs every individual with ultimate economic ownership before and after to be in the *same* family group, but A Curious Tractor Pty Ltd is 50/50 across **two different family groups** (Knight FT + Marchesi FT) — a family trust election on both trusts cannot bridge them. Proposed path is now a market-value sale + 50% CGT discount + Div 152 + vendor loan. See `thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` §C1.
+
 **Primary source (Verified — ATO SBRR guidance page; conditions map to ss 328-430/435/440/445):** The rollover allows CGT-neutral (and trading-stock/depreciating-asset-neutral) transfer of **active assets** of a small business between entities, provided ALL of:
 
 1. **Genuine restructure of an ongoing business** (s328-430(1)(a)) — substance over form; the business continues to operate, not a step toward sale/winding-down. A **3-year safe-harbour** treats it as genuine if for 3 years post-rollover there's no change in ultimate economic ownership of significant assets, they're active assets, and there's no significant private use.

--- a/wiki/concepts/the-whole-picture-diagrams.md
+++ b/wiki/concepts/the-whole-picture-diagrams.md
@@ -43,7 +43,7 @@ flowchart LR
     MI["Mount Isa"]
     BEYOND["Future nodes + licensees<br/>not ACT's to control"]
   end
-  ST -->|"328-G cutover 30 Jun"| PTY
+  ST -->|"cutover 30 Jun (mechanism TBC)"| PTY
   PTY --- EL
   PTY --- JH
   PTY --- CG

--- a/wiki/finance/README.md
+++ b/wiki/finance/README.md
@@ -32,7 +32,7 @@ The brain's finance source-of-truth layer. Live operational data lives in the Co
 | File | What it holds |
 |---|---|
 | [act-money-thesis-discussion.md](./act-money-thesis-discussion.md) | Full discussion document — for Ben + Nic + Standard Ledger to walk through together. |
-| [act-money-thesis-rebuttal.md](./act-money-thesis-rebuttal.md) | Adversarial review of the founder-pay-and-rd thesis. Flags Subdiv 328-G, small business CGT, IPP JV, PSI/PSB, realistic R&D refund range. |
+| [act-money-thesis-rebuttal.md](./act-money-thesis-rebuttal.md) | Adversarial review of the founder-pay-and-rd thesis. Flags Subdiv 328-G (⚠️ **later RETRACTED 2026-06-19** — fails the two-trust UEO test; see the decision pack), small business CGT, IPP JV, PSI/PSB, realistic R&D refund range. |
 | [five-year-cashflow-model.md](./five-year-cashflow-model.md) | FY26 actuals + FY27-30 projections supporting the five-year plan (working draft). |
 
 ## Operational analysis

--- a/wiki/finance/act-money-framework.md
+++ b/wiki/finance/act-money-framework.md
@@ -337,6 +337,8 @@ Multi-year setup — start NOW so it lands by Y2.
 
 ### E3. Subdivision 328-G rollover for cutover asset transfer
 
+> ⚠️ **RETRACTED / SUPERSEDED (2026-06-19).** 328-G does NOT work here: A Curious Tractor Pty Ltd is owned 50/50 by two *different* family groups (Knight FT + Marchesi FT), so the no-change-in-ultimate-economic-ownership test fails, and the s328-440 family-trust alternative (single family group only) can't bridge them. Subdiv 122-A also fails (100%-of-shares-to-one-transferor). **Current proposed position: a market-value SALE + 50% CGT discount + Div 152 shelter + vendor loan — a FORK from the journal-entry model, pending Standard Ledger.** Source of truth: `thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` §C1. The 328-G eligibility check below — and the incidental 328-G references in the decision log and the §H1 checklist — are retained as the original 2026-05 reasoning but are superseded by this note.
+
 **Opportunity:** defer all asset-related tax events at cutover, including IP, equipment, depreciating assets, and trading stock — areas where Subdivision 122-A would leave gaps.
 
 **Action [V]:** instruct Standard Ledger to use **Subdivision 328-G** (small business restructure rollover), not 122-A. 328-G covers all asset types.
@@ -344,7 +346,7 @@ Multi-year setup — start NOW so it lands by Y2.
 **Eligibility check [V]:**
 - Both entities small business entities (aggregated turnover < $10M) — ✅ ACT well under
 - "Genuine restructure" of business — ✅ Nic's sole trader → Pty meets this
-- Same ultimate economic ownership before and after — ✅ Nic remains beneficial owner via Marchesi Trust
+- Same ultimate economic ownership before and after — ❌ **FAILS** — the Pty is 50/50 Knight FT + Marchesi FT (two family groups), not 100% Nic; this introduces a new ultimate economic owner. See the 2026-06-19 retraction above.
 - Australian residents — ✅
 - Election made by both parties before/at cutover — needs to be done formally
 

--- a/wiki/finance/act-money-thesis-rebuttal.md
+++ b/wiki/finance/act-money-thesis-rebuttal.md
@@ -17,7 +17,9 @@ tags:
 
 > **Why this doc exists.** I wrote a thesis (`act-money-thesis-discussion.md`) without fully reading the wiki's five-year plan, Goods/CivicGraph commercial detail, or current Australian tax-rule fine-print. This doc is the adversarial review of that thesis. It validates what's right, calls out what's under-played, surfaces opportunities I missed, and proposes a rebalanced strategy. Read this AFTER the main thesis, then synthesise with Nic.
 >
-> **Bottom line:** the thesis is right in shape (Knight Photography invoicing, Path C, Pty payroll, trusts as passive shareholders) but **wrong in scale (revenue is bigger than I projected), wrong in mechanism (should use Subdiv 328-G not 122-A for cutover), and missing a $4-10M lever (CivicGraph exit + small business CGT concessions)**.
+> **Bottom line:** the thesis is right in shape (Knight Photography invoicing, Path C, Pty payroll, trusts as passive shareholders) but **wrong in scale (revenue is bigger than I projected)** and **missing a $4-10M lever (CivicGraph exit + small business CGT concessions)**. ⚠️ The original "use Subdiv 328-G not 122-A" mechanism call is **RETRACTED** — see the correction below.
+>
+> ⚠️ **CORRECTION (2026-06-19) — the 328-G recommendation in §2.3 and §3.3 is WRONG and retracted.** 328-G fails the no-change-in-ultimate-economic-ownership test because A Curious Tractor Pty Ltd is owned 50/50 by **two different family groups** (Knight Family Trust + Marchesi Family Trust): pre-transfer Nic has 100% UEO of the sole trader; post-transfer the Knight side is a new ~50% owner = UEO changes. The s328-440 discretionary-trust alternative does **not** rescue it — it needs every individual with UEO before and after to be in the **same** family group, and this spans two. Subdiv 122-A also fails (needs 100% of shares to one transferor). **Current proposed position: a market-value SALE sheltered by the 50% CGT discount + Div 152, with the price left as a vendor loan (tax-free founder drawdown) — a FORK from the journal-entry model, pending Standard Ledger.** Source of truth: `thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` §C1 (and `thoughts/shared/research/2026-06-01-cutover-tax-verification.md`, which already flagged the two-trust family-group condition as the risk). **Also updated 2026-06-19:** *Bendel* is now settled for taxpayers (High Court, 10 Jun 2026) — a UPE to a corporate beneficiary is **not** a Div 7A loan (s100A is the gate); and a **30% minimum tax on discretionary-trust distributions** is announced from 1 Jul 2028 (not yet law) — both reinforce the salary-first posture.
 
 ---
 
@@ -79,7 +81,7 @@ My thesis collapsed all this into "ACT Pty earns commercial revenue". That hides
 - **Empathy Ledger bespoke** needs scope-management and annual-renewal workflow.
 - **Ground** needs operational accounting separate from R&D-heavy ACT-IN.
 
-### 2.3 I used Subdivision 122-A logic when 328-G is probably better
+### 2.3 I used Subdivision 122-A logic when 328-G is probably better — ⚠️ RETRACTED 2026-06-19 (NEITHER fits the 50/50 two-trust cap table; see the correction at the top of this doc)
 
 **What I wrote:** "Equipment / hardware → Transfer at market value via journal entry. Triggers minor CGT event."
 
@@ -255,7 +257,7 @@ If KP **passes** at least one → KP is treated as a regular business, income re
 
 This is a multi-year setup but the opportunity scale is large enough to warrant Standard Ledger + lawyer time NOW.
 
-### 3.3 Subdiv 328-G rollover for cutover asset transfer
+### 3.3 Subdiv 328-G rollover for cutover asset transfer — ⚠️ RETRACTED 2026-06-19 (328-G fails the two-family UEO test; see the correction at the top of this doc)
 
 **Opportunity:** Defer all asset-related CGT events at cutover, including for IP and equipment.
 
@@ -264,7 +266,7 @@ This is a multi-year setup but the opportunity scale is large enough to warrant 
 **Eligibility check:**
 - Both entities small business entities (aggregated turnover <$10M) — ✅ ACT well under
 - "Genuine restructure" of business — ✅ sole trader → Pty meets this
-- Same ultimate economic ownership before and after — ✅ Ben + Nic via trusts
+- Same ultimate economic ownership before and after — ❌ **FAILS** — the Pty is 50/50 across two different family groups (Knight FT + Marchesi FT); Nic had 100% UEO pre-transfer, so the Knight side is a new owner. s328-440 can't bridge two families. (Retracted 2026-06-19 — see correction at top.)
 - Australian residents — ✅
 - Election made by both parties — needs to be done formally
 

--- a/wiki/finance/fy26-27-money-philosophy-and-plan.md
+++ b/wiki/finance/fy26-27-money-philosophy-and-plan.md
@@ -85,7 +85,7 @@ Five rules to never break:
 | Send Snow Foundation INV-0321 chase ($132K) | Nic | When 30d |
 | Make Standard Ledger appointment | Ben | This week |
 | Bring forward FY27 R&D-eligible spend | Ben + Nic | Next 4 weeks (per rebuttal §3.5) |
-| 328-G election forms drafted | Standard Ledger | Mid-May |
+| ~~328-G election forms drafted~~ ⚠️ **RETRACTED 2026-06-19** — transfer mechanism is now a market-value sale + Div 152, not 328-G (decision pack §C1) | Standard Ledger | — |
 | R&D consultant engaged | Standard Ledger refers | Mid-May |
 | Trust deeds reviewed for streaming permissions | Standard Ledger | Mid-May |
 
@@ -94,7 +94,7 @@ Five rules to never break:
 | Date | Action |
 |---|---|
 | 1-15 Jun | Final pre-cutover spend window — bring forward equipment/contractor/travel that's R&D-eligible |
-| 15-25 Jun | Sign Subdiv 328-G election forms (Nic's ST → ACT Pty), asset transfer scheduled |
+| 15-25 Jun | ⚠️ **328-G election RETRACTED 2026-06-19** — 328-G fails the two-trust UEO test; proposed path is a market-value sale + 50% discount + Div 152 + vendor loan. See `thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` §C1 |
 | 25-29 Jun | Final invoice push from Nic's ST (catch any outstanding) |
 | **30 Jun** | **CUTOVER.** Nic's ST closes (not deregistered yet — wait Y2). ACT Pty starts trading 1 Jul. |
 | 30 Jun | Trust distribution resolutions signed — wait, this is FY27 first cycle, see July |
@@ -381,7 +381,7 @@ Three GHL pipelines that need attention this CY:
 These go on the Money Sync Page for ongoing capture:
 
 ### Standard Ledger questions
-1. Confirm 328-G election treatment for Nic's sole trader → ACT Pty, including exact list of assets transferred.
+1. ⚠️ **328-G RETRACTED 2026-06-19** — confirm the transfer MECHANISM with Standard Ledger (328-G *and* 122-A both fail on the 50/50 two-trust cap table; proposed: market-value sale + Div 152 + vendor loan), including the exact list of assets transferred. See `thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` §C1.
 2. Confirm Path C R&D registration mechanic for FY26 (Pty as registrant for activities pre-incorporation).
 3. Trust deed permissions: does the Knight Family Trust deed allow streaming franked dividends and capital gains? If not, what's the cost to amend?
 4. Cameron + Pollyanna distribution treatment under s100A — what evidence do we need to maintain?


### PR DESCRIPTION
## What this is

Doc-rot fix flagged by the 2026-06-19 decision pack: several finance docs still recommended **Subdiv 328-G** for the sole-trader → Pty cutover and asserted **"ultimate economic ownership satisfied ✅"** — both wrong on the locked cap table.

## Why it's wrong

A Curious Tractor Pty Ltd is owned **50/50 by two different family groups** (Knight FT + Marchesi FT). Pre-transfer Nic has 100% UEO of the sole trader; post-transfer the Knight side is a new ~50% owner → UEO changes → **328-G fails** the no-change-in-UEO test. The s328-440 family-trust alternative needs a *single* family group, so it can't bridge two. Subdiv 122-A also fails (100%-of-shares-to-one-transferor). Proposed path is now a **market-value sale + 50% CGT discount + Div 152 + vendor loan** (a fork, pending Standard Ledger) — see `thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` §C1.

## Changes (annotate, don't delete — these are durable evidence docs)

- **act-money-thesis-rebuttal.md** — dated correction banner; retract the 328-G call in the bottom line + §2.3 + §3.3; fix the false `✅ UEO Ben + Nic via trusts` → `❌ FAILS`. Banner also carries the **Bendel** (settled for taxpayers, HCA 10 Jun 2026) + announced **30% trust-distribution tax** update as current-rules context.
- **act-money-framework.md** — RETRACTED/SUPERSEDED note at §E3; fix the false `✅ UEO Nic via Marchesi Trust` → `❌ FAILS`.
- **fy26-27-money-philosophy-and-plan.md** — retract the 328-G election-form actions.
- **README.md**, **the-whole-picture-diagrams.md** — flag/soften the 328-G references.
- **2026-06-01-cutover-tax-verification.md** — append the resolved conclusion (this research doc had already correctly flagged the two-trust family-group condition as the MEDIUM risk).

## Note

No actual "Bendel" / "TD 2022/11" stale text existed in the wiki to retract — the earlier claim that it did was an over-reach; the Bendel update is folded in as forward context, not a retraction. Pure documentation; no code, no schema, no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
