### PR TITLE
docs(eofy): The Answered Case — every SL question answered as the expert

### DIFF
--- a/thoughts/shared/plans/2026-06-20-eofy-answered-case.md
+++ b/thoughts/shared/plans/2026-06-20-eofy-answered-case.md
@@ -1,0 +1,650 @@
+# EOFY 2026 — The Answered Case
+
+> Every question from the Standard Ledger email, **answered** — expert technical analysis built across 4 research rounds + an adversarial skeptic pass. For each: **the answer · why · the numbers · the one thing SL still needs from you · plain English (what it means for you)**.
+>
+> **How to use this:** SL is the registered tax agent and formally ratifies + lodges (legally required) — but the analysis is built out here so you *understand* each answer and can confirm it or push back, not wait blind. Not lodged advice. Today 20 Jun 2026; EOFY 30 Jun.
+
+---
+
+## ⚠️ Read this first — corrections + how sure each answer is
+
+An adversarial skeptic checked every answer. Most are **sound and web-verified** (the R&D "must be paid in cash" rule, the franking-debit reality, the Div 7A direction, the GST going-concern, the QLD duty scale, Bendel, the Div 293 math). Three things to hold in mind:
+
+1. **Two number-fixes are applied below:** (a) super catch-up reaches back to **2020-21, not 2018-19** (~$112.5K max, not $150K+); (b) the CGT-shelter example — for under-55 founders the **retirement-exemption slice must go INTO super**, so it isn't all drawable as a loan.
+2. **Three answers open with "GO/YES" but are genuinely *contingent* — they are Standard Ledger's calls to formally make, not settled facts:** (i) **selling the business** (vs the documented journal-entry model) is a recommended *fork* SL must re-open; (ii) the **tax-free vendor-loan drawdown** works in direction but is **Part-IVA-exposed** and depends on the sale fork + a real valuation + the CGT shelter holding; (iii) the **Path C R&D** re-framing is novel in the ATO's most-audited area — treat a **private ruling as near-essential**.
+3. **Everything here is for SL to ratify + lodge** (legally required of a registered agent). The value is that you *understand* each answer and can confirm it or push back.
+
+---
+
+## 1. Super + the pre-30-June tax moves (the time-critical ones)
+
+> Scope: the super and pre-30-June-spend cluster of the EOFY pack. This is expert technical analysis built to the standard Standard Ledger (SL) would — SL is the registered tax agent and formally ratifies + lodges (legally required), but each answer is built out fully here so Ben understands it and can confirm or challenge, not act blind. Every rate/threshold is verified against ato.gov.au for FY2025-26 (cited inline). Australian FY = Jul–Jun; today 20 Jun 2026; EOFY 30 Jun 2026. Nothing here is lodged or definitive personal tax advice.
+
+### Q: Should Nic put up to $30K into super before 30 June — and is it actually worth it?
+
+**The answer:** GO — make a personal deductible contribution up to the **$30,000** FY26 concessional cap, provided he has the cash and we've run the Division 293 check (next question). It is worth it: every dollar moves from being taxed in his hands at ~47% to 15% inside super — a ~32c saving per dollar, ~30c even if Div 293 applies.
+
+**Why:** Nic is a sole trader with no employer paying Super Guarantee for him, so the **entire $30K concessional cap is his to use** — nothing is pre-consumed. A personal contribution he claims as a deduction reduces his FY26 taxable income dollar-for-dollar, then is taxed only 15% as a "taxable contribution" inside the fund. The general concessional cap for FY2025-26 is **$30,000** (confirmed: from 1 Jul 2024 to 30 Jun 2026 the cap is $30,000; it rises to $32,500 from 1 Jul 2026 — [ATO concessional contributions cap](https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/growing-and-keeping-track-of-your-super/caps-limits-and-tax-on-super-contributions/concessional-contributions-cap)). On a top-bracket dollar (45% + 2% Medicare = 47%), the arbitrage is 47% − 15% = **32 percentage points**. The mechanism only works if he also lodges the notice of intent (see the timing question) — the deduction is not automatic.
+
+**The numbers:** A $30K contribution saves roughly **$9,600** in net tax at the top marginal rate (47% − 15% = 32% × $30K), reducing to about **$9,000** if Div 293 catches the contribution (32% becomes a 30% net benefit on the caught dollars — math below). The contribution itself is $30K of cash that stays his (now locked in super), so this is a ~$9-9.6K tax saving, not a cost — the only "cost" is preservation (he can't touch it until a condition of release).
+
+**The ONE thing SL still needs:** Nic's **actual FY26 net business profit** (not the ~$238K of drawings, which are not taxable income) and whether any concessional contribution has already been made this year — to confirm he's genuinely in the top bracket and the full $30K cap is unused.
+
+**Plain English — what this means for you:** Tell Nic: put $30K into super before 30 June and claim it. He saves roughly $9–9.6K in tax he'd otherwise pay, and the money is still his (just locked in super). The only catch is he can't spend it now.
+
+### Q: Division 293 — do his drawings + any recharacterised salary + a $30K contribution push him over $250K, and is the contribution still worth it if it does?
+
+**The answer:** He very likely crosses $250K, so Div 293 will probably apply — but the contribution is **still worth it**. Even when caught, the contribution is taxed at 30% total inside super versus 47% drawn in his hands, so it still saves ~17c per dollar relative to taking the cash, and ~30c relative to leaving it as fully-taxed income.
+
+**Why:** Division 293 adds an **extra 15%** tax on concessional contributions for individuals whose "income for Div 293 purposes" (taxable income + reportable fringe benefits + net investment losses + the concessional contributions themselves) exceeds **$250,000**. It's charged at 15% of the *lesser* of (the excess over $250K) or (the taxable super contributions) — [ATO Division 293 tax](https://www.ato.gov.au/individuals-and-families/super-for-individuals-and-families/super/growing-and-keeping-track-of-your-super/caps-limits-and-tax-on-super-contributions/division-293-tax-on-concessional-contributions-by-high-income-earners). Critically, **drawings are not income** — Nic's ~$238K is money he withdrew, not his taxable profit, so whether he actually crosses $250K depends on his *real net business profit* plus the $30K contribution itself (the contribution counts toward the $250K test). The key point: Div 293 only lifts the contribution's tax from 15% to **30%** — still 17 points below the 47% he'd pay holding the cash personally. It never makes the contribution a loser; it just trims the win.
+
+**The numbers:** If, say, his real income + the $30K contribution lands at ~$255K, then $30K is "caught" (the excess over $250K, $5K, is the lesser — wait: lesser of $5K excess vs $30K contributions = $5K caught). So only the amount *over* $250K is hit: on that slice, +15% Div 293. Worst case (well over $250K, all $30K caught): Div 293 costs an extra $4,500 (15% × $30K), so net super tax is $9,000 (30% × $30K) instead of $4,500 — but versus $14,100 if drawn (47% × $30K), he's still **~$5,100 ahead**. Versus leaving it as taxed income he keeps, he saves ~$9,000 (47% − 30% × $30K). Bottom line: **depends on his final income, but the saving is roughly $5–9.6K and never negative.**
+
+**The ONE thing SL still needs:** Nic's **final FY26 taxable income** (net business profit + any reportable fringe benefits / net investment losses) — that single figure decides exactly how much of the $30K is caught by Div 293 and pins the precise saving.
+
+**Plain English — what this means for you:** Even if Nic's income is high enough to trigger the extra "high-earner" super tax, the $30K contribution still wins — it's taxed 30% inside super versus 47% if he just took the cash. Don't let "Div 293" scare you off it.
+
+### Q: Carry-forward "catch-up" super — can he (or Ben) put in MORE than $30K, and why is it data-gated?
+
+**The answer:** Possibly yes — if his **Total Super Balance (TSB) was under $500,000 at 30 June 2025**, he can add unused concessional cap from up to the previous 5 years — **for an FY26 contribution that means 2020-21 to 2024-25; earlier years (2018-19, 2019-20) have already expired** — on top of this year's $30K, potentially **up to ~$112.5K** in one hit. But **HOLD at $30K until myGov confirms both the TSB and the exact unused amount** — we cannot assume it.
+
+**Why:** The carry-forward (catch-up) rule lets you use unused concessional cap from up to **5 prior financial years**, but only if your **TSB was below $500,000 at 30 June of the previous year** (i.e. 30 Jun 2025 for an FY26 contribution) — confirmed: "you're eligible if you have both a total super balance of less than $500,000 at 30 June of the previous financial year and unused concessional contributions cap amounts from up to 5 previous years" ([ATO contributions caps](https://www.ato.gov.au/tax-rates-and-codes/key-superannuation-rates-and-thresholds/contributions-caps)). Oldest unused amounts are used first and each expires after 5 years. This is **data-gated** because both inputs — the 30 Jun 2025 TSB and the precise unused-cap figure — live only in each founder's myGov / ATO online (Super → Carry forward concessional contributions). Guessing risks an excess-contributions assessment. For founders early in their super journey, a sub-$500K TSB is plausible, which is exactly why the door is worth checking — and why it **shuts** once the FY27 salary ramp + 12% SG starts filling the cap and pushing the TSB up. This is a use-it-or-lose-it window.
+
+**The numbers:** For an FY26 contribution the reachable years are **2020-21 ($25K) + 2021-22, 2022-23, 2023-24 ($27.5K each) + 2024-25 ($30K)** — so a founder who contributed nothing in those years could have **up to ~$112.5K** of catch-up room on top of the current $30K (2018-19 and 2019-20 have expired). At the top rate the extra arbitrage is ~32c/dollar (less Div 293), i.e. potentially **$7.5K–$22K+ of additional tax saved per founder** in a catch-up year — but only if cash is available to fund it. Illustrative until myGov is pulled.
+
+**The ONE thing SL still needs:** From each founder's **myGov → ATO → Super: the exact TSB at 30 Jun 2025 and the exact available carry-forward (unused concessional) balance.** Only the founders can pull this; SL then models whether to exceed $30K.
+
+**Plain English — what this means for you:** You and Nic might be allowed to put in much more than $30K this year if your super balances are still under $500K — which could save thousands more. But don't put a cent over $30K until each of you logs into myGov and reads off the exact "carry forward" number. We can't guess it.
+
+### Q: The hard timing — the fund must RECEIVE the money before 30 June, and the NAT 71121 step.
+
+**The answer:** Send the contribution so the **fund's bank account receives it on or before 30 June** — practically that means initiating the transfer by about **24–26 June** (allow for clearing; some funds publish a cut-off a few business days before EOFY). Then lodge the **notice of intent to claim (NAT 71121)** with the fund and get its **written acknowledgement back before lodging his tax return** — no deduction is valid without it.
+
+**Why:** A contribution counts in FY26 only when it is **received by the fund** by 30 June, not when Nic sends it — an in-transit payment over the weekend of 30 June misses the year. BPAY/EFT can take 1–3 business days, so a buffer is essential; 30 June 2026 is a Tuesday, so a send by Wed–Fri 24–26 June is the safe window (confirm the fund's own published EOFY cut-off, which is often earlier). Separately, the deduction is only allowable if Nic gives the fund a valid **NAT 71121 notice of intent** by the earlier of (a) the day he lodges his return, or (b) the end of the following income year — **and** the fund sends a **written acknowledgement**, which he must hold **before** claiming the deduction ([ATO notice of intent](https://www.ato.gov.au/forms-and-instructions/superannuation-personal-contributions-notice-of-intent-to-claim-or-vary-a-deduction)). Trap: if he rolls the money to another fund, starts a pension, or withdraws before lodging the notice, the notice can be invalidated — so **lodge the NAT 71121 first, get the acknowledgement, then do anything else.**
+
+**The numbers:** No dollar variable here — it's binary. Miss the 30 June receipt and the entire ~$9.6K saving slips to FY27 (still usable, but against the smaller FY27 win and the FY27 $32.5K cap). Miss the NAT 71121 acknowledgement and the deduction is **disallowed entirely** — the $30K becomes a non-deductible (non-concessional) contribution with zero tax benefit.
+
+**The ONE thing SL still needs:** **Nic's super fund and its published EOFY contribution cut-off date** — that sets the real send-by date. (The NAT 71121 itself Nic lodges with the fund; SL just needs to see the acknowledgement before lodging the return.)
+
+**Plain English — what this means for you:** Get the $30K into Nic's super fund's account by about 24–26 June at the latest — don't leave it to the 30th, because "sent" isn't "received." Then fill in the one-page notice (NAT 71121) to the fund and wait for their written "got it" reply before doing the tax return. Skip that form and the whole tax deduction vanishes.
+
+### Q: Ben's equivalent via Knight Photography.
+
+**The answer:** GO on the same mechanism for Ben, sized to his income — make a personal deductible contribution up to his available cap (the $30K FY26 cap, plus any carry-forward if his TSB is under $500K). Same NAT 71121 + 30 June receipt steps. He **likely avoids Div 293** because his income is lower, so his saving per dollar is cleaner.
+
+**Why:** Ben's income flows through Knight Photography (KP), his sole-trader contractor vehicle. As a sole trader with no employer SG, the same logic holds: a personal deductible contribution shifts income from his marginal rate to 15% in super, claimed via NAT 71121. Because his personal-services income is materially below $250K, **Div 293 probably doesn't bite** — so his arbitrage stays the full marginal-rate-minus-15%. The exact size depends on his FY26 income and whether KP has paid him any SG already (it shouldn't have, as a sole trader). Note: if KP is later run through a company/trust this changes — but for FY26 as a sole trader the personal-contribution route is identical to Nic's. The contribution is **Ben's personal deduction**, not a KP business deduction (he claims it in his individual return, D12 label).
+
+**The numbers:** At Ben's likely marginal rate, a $30K contribution saves roughly **$6,900–$9,600** (depending on whether he's in the 37% or 45% bracket — 37% + 2% = 39%, so 24c–32c per dollar), with **no Div 293 haircut** if he stays under $250K. Carry-forward could lift the contributable amount well above $30K if his TSB is under $500K.
+
+**The ONE thing SL still needs:** **Ben's FY26 income through KP** (to set his marginal rate and confirm he's under the $250K Div 293 line) and **his myGov TSB + carry-forward** (to size any contribution above $30K). Plus his super fund's EOFY cut-off for the send-by date.
+
+**Plain English — what this means for you:** Do the same move yourself, Ben — put money into your own super before 30 June and claim it. Because you earn less than Nic, you almost certainly dodge the high-earner extra tax, so it's a clean win. Same one-page form, same "money must land by ~24–26 June" rule.
+
+### Q: Pre-30-June deductible spend (instant asset write-off, prepaid expenses) — worth it given the 47%-vs-25% rate gap, and the catch when gear moves to the Pty?
+
+**The answer:** Worth it for **genuine, needed FY26 sole-trader spend** — a deduction in Nic's hands this year is worth ~47c per dollar, versus only ~25c if the same deduction lands in the Pty next year. But **do NOT buy equipment just to write it off**, because that equipment becomes assessable income when it transfers to the Pty at the cutover (a balancing charge at market value), which largely claws the benefit back. Prepaying genuine expenses is the cleaner lever; new asset purchases are a trap here.
+
+**Why:** Two distinct moves. **(1) Instant asset write-off:** a small business (<$10M aggregated turnover, which Nic is) can immediately deduct the full cost of an eligible asset costing **under $20,000** per asset, if first used or installed ready for use between 1 Jul 2025 and 30 Jun 2026 — confirmed, extended for FY2025-26 by the Treasury Laws Amendment (Strengthening Financial Systems and Other Measures) Act 2025 ([ATO $20,000 instant asset write-off 2025–26](https://www.ato.gov.au/businesses-and-organisations/small-business-newsroom/20000-instant-asset-write-off-for-2025-26)). **(2) Prepaid expenses:** a small business can deduct prepayments for services covering a period ≤12 months ending in the next income year (the 12-month prepayment rule). The rate-gap logic is real and large — a deduction taken now reduces income taxed at ~47% (Nic, top bracket), whereas the same deduction inside ACT Pty next year only offsets income taxed at the 25% base-rate-entity rate. So front-loading deductible spend into the high-rate sole-trader year is genuinely tax-efficient. **The catch (this is the important nuance for asset purchases):** when Nic's equipment transfers to the Pty at the 30 June cutover, it's a disposal to an associate at market value. Round 2 of this pack (and s40-285/300) confirms this is a **Division 40 balancing charge — ordinary income at deemed market value in Nic's FY26 return, no 50% CGT discount, no Div 152 shelter** (the Subdiv 328-D pool rollover fails on the same two-family cap-table issue that kills the other rollovers). So writing off a freshly-bought asset, then transferring it weeks later, drags most of that deduction straight back as assessable income. The write-off is only a real win on gear Nic **keeps** or genuinely consumes pre-cutover; for assets going to the Pty it's close to a wash (and the *timing* of the deduction vs the balancing charge can even leave him worse off). Prepaying genuine FY27 costs (insurance, subscriptions, rent) doesn't have this problem and is the safer rate-arbitrage play.
+
+**The numbers:** On a genuine **prepaid expense** of, say, $20K, Nic saves ~$9,400 (47%) this year versus ~$5,000 (25%) if the same cost fell in the Pty — a ~$4,400 timing/rate gain. On a **new asset bought to write off** and then transferred: the ~47% deduction is largely offset by ~47% assessable income on the balancing charge at market value, so net benefit is roughly **zero to slightly negative** — depends entirely on the WDV-vs-market-value gap on each item. Equipment in scope is the ~$30–50K plant noted across the pack.
+
+**The ONE thing SL still needs:** **A schedule of any planned pre-30-June purchases vs the equipment-transfer (balancing-charge) list** — SL prices the WDV-vs-market-value balancing charge per asset to confirm which spend is a genuine win and which just claws back. (For prepayments, SL confirms each falls within the 12-month prepayment rule.)
+
+**Plain English — what this means for you:** Bringing genuine business costs forward into this year (paying next year's insurance/subscriptions now) saves you real tax, because your sole-trader rate is ~47% and the company's is only 25%. But don't go buying equipment just to get the deduction — when that gear moves into the Pty on 1 July it counts as income to Nic and cancels most of the benefit. Prepay genuine bills, yes; panic-buy assets, no.
+
+---
+
+**Cross-cutting note for SL (the through-line on this cluster):** the two super contributions (Nic + Ben, up to $30K each, more if carry-forward confirmed) are **strong, ratify-and-execute** calls gated only on real income figures + myGov balances + the fund cut-off dates — the law is settled and verified. The pre-30-June-spend lever is real for **prepayments** but a **trap for asset purchases** that will transfer to the Pty (the balancing charge claws it back). Nothing here is aggressive or Part-IVA-exposed — these are mainstream, ATO-blessed EOFY moves; the only discipline required is the **timing** (fund must *receive* by 30 June; NAT 71121 acknowledgement before lodgement).
+
+---
+
+## 2. Moving the business into the company (the #1 decision)
+
+> Expert technical analysis built to the standard Standard Ledger (SL) would, so you understand each answer and can confirm or challenge it — not "go do this blindly." SL, as the registered tax agent, formally ratifies and lodges (legally required); the case is built here. Australian FY = Jul–Jun. Today 20 Jun 2026; EOFY 30 Jun 2026. Every rate/threshold below is web-verified against ATO/QRO 2025-26 sources and cited. Anything genuinely aggressive (Part IVA) is flagged plainly.
+
+**The through-line for the whole cluster (read this once):** Nic's sole trader (100% his) is going into a company that is *already issued* 50% to the Knight family trust and 50% to the Marchesi family trust — **two different families.** That single fact — a new, unrelated economic owner appearing on day one — is what breaks both cheap rollovers, and it forces a real sale instead of a free transfer. The good news: a real sale is *better* for you, because the price you don't get paid in cash becomes a tax-free loan the company owes you.
+
+---
+
+### Q: How does the business legally move from Nic's sole trader into the company, when the company is owned 50/50 by two different families' trusts?
+
+**The answer:** Not by a free "rollover" and not by the documented journal-entry model — it moves by a **market-value SALE** of the business (goodwill + IP + plant) from Nic to A Curious Tractor Pty Ltd, with the capital gain sheltered down to near-zero by the **50% general CGT discount + the Division 152 small-business concessions**, and the purchase price left **owing to Nic as a "vendor loan"** rather than paid in cash. This is a deliberate fork away from ACT's currently-documented "journal-entry / sole trader operated on behalf of the Pty" model, and it is the better path because it manufactures the tax-free founder loan (next question).
+
+**Why:** The two tax-free rollovers people normally use to incorporate a sole trader both fail here, and it's worth being precise about *why*, because the failure is structural, not fixable by paperwork:
+
+- **Subdivision 122-A (incorporation rollover) fails.** 122-A only works where the transferor receives **100% of the shares** in the company as the sole consideration (web-verified: "they must own 100% of the shares in the company immediately following the transfer"). The cap table is already split Knight FT 50 / Marchesi FT 50 — Nic cannot receive 100%. Dead on the facts.
+- **Subdivision 328-G (small business restructure rollover) fails.** 328-G requires **no change in "ultimate economic ownership"** of the asset, and ultimate economic ownership "can only be held by natural persons" (web-verified, ATO/Webb Martin). The day the business lands in a company half-owned by the Knight trust, **Ben becomes a new ultimate economic owner of ~50%** — a material change. The discretionary-trust safe harbour (s328-440) that *can* preserve UEO works **only where every individual before and after is a member of the same family group** (verified). Knight FT and Marchesi FT are two *separate* families — there is no single family group spanning them, so the safe harbour can't bridge them. Dead on the facts. (⚠ This **retracts** the earlier `act-money-thesis-rebuttal.md` guidance that recommended 328-G and asserted UEO was satisfied — that was wrong on these facts.)
+
+With both rollovers gone, what remains is an ordinary **CGT event A1 disposal at market value** (a sale), deliberately *not* rolled over. You then shelter the gain with the stack that *survives*: the **50% general discount** (held >12 months) stacks on the **50% active-asset reduction** (Subdiv 152-C), and the **$500K lifetime retirement exemption** (Subdiv 152-D) mops up the rest — verified all four Div 152 concessions are preserved by the 2026 Budget and the general 50% discount remains in full for any asset *sold before 1 July 2027*. The reason this is *better* than the journal-entry model: a sale creates a debt the company owes the vendor, and repaying a genuine debt is tax-free (next question). A journal entry creates nothing you can draw on tax-free.
+
+**The numbers:** No income tax on the sale if the Div 152 stack holds. Worked illustration on, say, $300K of goodwill, all gain: 50% discount → $150K; 50% active-asset reduction → $75K; the **retirement exemption** can absorb the remaining $75K → **$0 CGT** — BUT because Nic and Ben are **under 55, that $75K must be paid INTO super** to use the exemption, so it is locked away, not free cash. Net: ~$0 CGT, and the vendor loan is the full $300K sale price but ~$75K of it must be routed to super (≈ **$225K freely drawable + $75K parked in super**), not $300K all in-pocket. (Alternative: skip the retirement exemption and pay ~$35K CGT on the $75K to keep it as free cash — SL models which is better.) The shelter's adequacy depends entirely on the valuation and the $6M MNAV test holding — **treat the shelter as unconfirmed until SL runs the MNAV calc** (founder-personal-exertion goodwill can be thin, which would shrink the loan but also the duty).
+
+**The ONE thing SL still needs:** Nic's **maximum-net-asset-value calculation** (the $6M test across Nic + connected entities + affiliates, measured just before the sale) plus his DOB and any prior use of the $500K retirement cap — these are the only inputs that decide whether the Div 152 shelter fully holds, and SL must formally rule the sale-vs-journal-entry fork (re-opening the documented model) and confirm the disposal is dated before 1 July 2027.
+
+**Plain English — what this means for you:** You're not "transferring" the business for free — you're *selling* it to your own company at a fair price, paying roughly no tax on the sale because of small-business concessions, and the company ends up *owing Nic* the price. That IOU is the gold: it's money you can pull out later tax-free. This is a change from the plan on paper, so SL has to formally sign off on switching to it.
+
+---
+
+### Q: Does that sale create a tax-free loan the founders can draw down?
+
+**The answer:** **Yes — in direction it works.** Because the company *owes* the vendor (Nic, and Ben to the extent he owns any IP being sold) for the business it bought, every dollar the company later pays back is **tax-free repayment of a genuine debt**, completely outside Division 7A. Division 7A only taxes loans that run the *other* way — company → shareholder. A debt the company owes its vendor is the opposite direction and Div 7A simply doesn't reach it. **The caveat:** this is tax-free *only* if the price is genuinely arm's-length and Part IVA doesn't recharacterise the whole thing as disguised income.
+
+**Why:** Div 7A (s109D) is engaged by a *private company lending to, or forgiving a debt of, a shareholder or associate*. Here the cash flow is the reverse — the company is **repaying** Nic for assets it bought. Repaying a real liability is a return of capital, not assessable income, and is not a "loan" within Div 7A's reach. Two hard rules keep it clean: (1) the consideration must be a **real debt with real terms** documented as genuine vendor finance, not a sham (this is the one genuineness watch-point); (2) the repayments must be capital repayments of the loan, **not disguised salary or dividends**. The Part IVA exposure is real because the founders are associates of the shareholding trusts and the arrangement's *principal effect* is tax-free extraction — that combination is exactly what the general anti-avoidance rule scrutinises. This is why a **private ruling (PBR) is recommended if the loan balance is material**: it buys certainty that the ATO won't recharacterise the drawdowns. Also: do **not** double-count — roughly 81% of the FY26 ~$238,654 of "R&D-eligible" spend is *already-withdrawn founder drawings*; those reduce the opening loan balance, they don't get drawn again.
+
+**The numbers:** The loan equals the **independently-valued sale price** (goodwill + IP + plant) — on a $300K–$500K business the loan equals the price — but for **under-55 founders the retirement-exemption slice used to zero the CGT must be paid into super**, so the *freely-drawable* portion is the price minus that slice (the rest is sheltered in super, not your pocket). Still a large **tax-free drawdown facility** the founders pull on over time. Net tax on drawing it down: **$0** (vs ~47% if the same money came out as salary). Reduce the opening balance by FY26 drawings already taken.
+
+**The ONE thing SL still needs:** The **agreed arm's-length market-value consideration** (this sets the opening loan balance) and SL's call on whether to seek a Part IVA private ruling given the balance — only a registered agent can sign the vendor-finance characterisation and run the drawings reconciliation.
+
+**Plain English — what this means for you:** The company owes you the purchase price. As cash comes in, the company pays you back — and because it's paying back a real debt, you pay **no tax** on that money. It's the cleanest way to get cash out of the company. The only catch: the price has to be a genuine, properly-documented number, and because this saves a lot of tax, it's worth getting the ATO to bless it in writing if the amount is large.
+
+---
+
+### Q: What's the QLD stamp duty on that sale — the real number?
+
+**The answer:** Roughly **$3,700–$17,300**, charged at the ~2–3.2% effective band on **goodwill + the business name only** — **IP and plant on their own are NOT dutiable** (s37 Duties Act 2001), and the "5.75%" rate everyone quotes only starts **above $1M of dutiable value**, which this sale won't reach. It is **not self-assessable** — it must be lodged with the Queensland Revenue Office (QRO).
+
+**Why:** Web-verified QRO 2025-26 transfer-duty scale:
+
+| Dutiable value | Duty |
+|---|---|
+| up to $5,000 | nil |
+| $5,000–$75,000 | $1.50 per $100 over $5,000 |
+| $75,000–$540,000 | **$1,050 + $3.50 per $100 over $75,000** |
+| $540,000–$1,000,000 | $17,325 + $4.50 per $100 over $540,000 |
+| above $1,000,000 | $38,025 + **$5.75** per $100 over $1,000,000 |
+
+So the 5.75% marginal rate is irrelevant here — it only bites past $1M. The effective rate in the realistic band is ~1.9% at $100K rising to ~3.2% at $540K. Crucially, under the Duties Act 2001 (Qld) **a transaction *solely* for IP and/or plant is not dutiable (s37)** — IP and plant only become dutiable by being *aggregated* with a dutiable business asset (goodwill or the business name). So the duty hinge is the **goodwill + business name figure, apportioned to QLD for nexus** (s36/DA035) — and because ACT serves a largely interstate/overseas base, the goodwill apportions *down*, lowering the duty. There's a **consistency trap**: pushing goodwill *down* to cut duty also shrinks the CGT shelter and the vendor loan — so the goodwill figure must be set **once**, consistently, across both the duty return and the CGT calc. The small-business-restructure duty exemption (Part 1A Ch 10, ss413F–413I) **likely fails or gives only partial relief** — it requires ownership continuity (the same two-family problem that kills 328-G) and a transferee that **hasn't already traded** (the Pty registered 24 Apr 2026 — if it has already traded, that's a binary kill-switch even on Nic's half). This needs a QLD duties specialist; lodge Form D2.2 / exemption 58 with QRO.
+
+**The numbers:** At $150K goodwill → **~$3,675**; at $300K → **~$8,925**; at $540K → **~$17,325**. (IP and plant excluded standing alone.) The earlier "5.75% on goodwill+plant" line in older docs is **wrong** for this deal size.
+
+**The ONE thing SL still needs:** A **QLD duties specialist to lodge the duty return with QRO** and rule on whether the Pty has "already traded" (the restructure-exemption kill-switch) and the QLD goodwill apportionment — duty here is assessed by QRO, not self-assessed, so this is a formal lodgement only a specialist can make.
+
+**Plain English — what this means for you:** Stamp duty on selling the business to the company is real but modest — think **a few thousand to maybe $17K**, not the scary 5.75% number, and only on the goodwill/brand part (your code and equipment aren't taxed on their own). You can't just pay it yourself online — a Queensland duties specialist has to lodge it with the state revenue office.
+
+---
+
+### Q: Can we avoid GST on the transfer?
+
+**The answer:** **Yes — structure the sale as a GST-free "going concern" under s38-325** so no GST is charged on the transfer. The vendor-loan price is fine; consideration doesn't have to be cash. The only thing you must get exactly right is the timing and the paperwork.
+
+**Why:** Web-verified s38-325 has two mandatory limbs: (1) the supply is **for consideration**, the **recipient (ACT Pty) is GST-registered on the day of supply**, and there is a **written agreement** that the supply is of a going concern; (2) the supplier supplies **all things necessary** for the enterprise to keep operating, and **carries on the enterprise until the day of supply** (GSTR 2002/5, para 141 — all activities active and operating on the supply day). A **vendor/director loan satisfies "for consideration"** (GSTR 2001/6), so leaving the price owing doesn't break it. Retaining the cash, bank and trade debtors does **not** break limb 2 — those are run-off assets, not "things necessary to operate." The edge-case kills to avoid: Pty **not registered on the day**; the written agreement made **after** the day (cannot be retrofitted); the business **winding down** before the supply day; or a necessary contract/licence (a grant, the EL licence) not novated by the transfer day. **Fallback if it fails:** because Nic and the Pty are **associates**, **Div 72 imposes GST on full market value even if the stated price is nominal/deferred** — so "sell for $1 + a loan" does *not* dodge GST. That's why you get the clause right rather than relying on a low price. Note GST grouping is **unavailable** (needs a 90%-owned group; two trusts at the top don't satisfy it — ATO ID 2002/492), so inter-entity charges later will carry GST.
+
+**The numbers:** Avoids a GST timing/cashflow hit of roughly **$7K–$27K** on the transfer (the 1/11th that would otherwise sit on the consideration until ACT reclaimed it). Clause cost ≈ nil. Getting it wrong risks the supplier (Nic) owing 1/11th of the consideration to the ATO.
+
+**The ONE thing SL still needs:** Confirmation that **ACT Pty's GST registration is effective on or before the supply day** and that the **written going-concern clause is signed on/before that day** — the registration effective date and the executed clause are formal steps only SL/the lawyer can put in place, and they cannot be backdated.
+
+**Plain English — what this means for you:** Done right, there's **no GST to fund** on the transfer — you just need the company registered for GST before the sale day and a one-line "this is a going concern" clause signed on or before that day. Skip either and you create a GST bill out of thin air, even if you sell for a dollar.
+
+---
+
+### Q: How do we value the business?
+
+**The answer:** Commission **one independent, arm's-length valuation** that values goodwill by **capitalised future maintainable earnings**, IP by an income approach with a cost cross-check, and plant at market/written-down value — then apportion the total **per asset class** in the sale agreement. That single figure must drive **both** the QLD duty return and the CGT/Div 152 calc, because they pull against each other.
+
+**Why:** The valuation is the keystone — it sets the CGT gain (and whether the Div 152 shelter is adequate), the size of the tax-free vendor loan, the QLD duty base, and the equipment GST adjustment. It has to be **independent and defensible** precisely because the vendor and buyer are related parties and the price drives a tax-free extraction — a self-set or inflated number is the soft spot Part IVA and QRO both probe. **Capitalised maintainable earnings** is the standard method for goodwill (a multiple on normalised FY24–26 earnings); IP gets an income approach (royalty-relief / DCF) cross-checked against development cost; plant at WDV/market. The **tension to manage explicitly**: a *low* goodwill figure cuts duty but thins the CGT shelter and shrinks the vendor loan; a *high* figure does the reverse. You can't run two different numbers — pick one defensible figure and use it consistently everywhere. Apportioning per asset class in the contract also matters because **IP and plant alone aren't dutiable** (s37) — the split is what lets the duty fall only on goodwill+business name.
+
+**The numbers:** Cost = the valuer's fee (typically low-single-thousands for a business this size). It then drives every downstream figure: the CGT gain, the loan balance, the **~$3.7K–$17.3K** duty, and the equipment GST adjustment. No reliable dollar output without it — **this is the single biggest data gap; everything downstream waits on it.**
+
+**The ONE thing SL still needs:** The **independent valuer's report** with the goodwill/IP/plant apportionment — SL coordinates so the goodwill figure is identical across the CGT calc and the duty return, but only a commissioned valuer can produce the defensible number.
+
+**Plain English — what this means for you:** Pay an independent valuer once to put a fair price on the business, split between brand/goodwill, your software/IP, and equipment. That one number then feeds everything — the tax, the size of your tax-free loan, and the stamp duty — so it has to be solid and used consistently. Don't guess it yourself.
+
+---
+
+### Q: When do we flip the switch — 30 June or 1 July?
+
+**The answer:** **Operate from the company starting 1 July 2026** (clean financial-year boundary), but **date the CGT sale of the business itself whenever SL prefers — as long as it's before 1 July 2027** to keep the 50% CGT discount. And if the documents (valuation, going-concern clause, GST registration) genuinely aren't ready by 1 July, **do not fake the date** — run an honest split-year and cut over when ready.
+
+**Why:** Splitting the *operational* cutover on the FY boundary (last sole-trader invoice 30 Jun, first Pty payroll 1 Jul) keeps the books clean — one entity per financial year, no mid-year apportionment headache. The *CGT disposal date* is governed by the **sale contract date**, which is also what governs the 50% discount window: web-verified, the 2026 Budget removes the 50% general discount from **1 July 2027**, but **assets bought and sold before 1 July 2027 keep the full discount** — so an FY26 (or any pre-1-Jul-2027) disposal is safe, and Div 152 is untouched regardless of date. So there's no need to rush the sale paperwork to 30 June for discount reasons — you have a full year of runway. The **honest-delay rule** matters: the going-concern GST exemption *cannot be backdated* (the written agreement must exist on/before the supply day, and the enterprise must genuinely operate to that day). If you backdate to hit 1 July when the business actually wound down earlier or the clause was signed later, you **break the GST exemption and invite a sham finding**. Far cheaper to run a documented split-year: sole trader keeps collecting and funding payroll into Q1 FY27 (also the cheapest cash bridge), and cut over on a single dated arrangement when everything is in place.
+
+**The numbers:** No dollar cost to the date choice itself. The only hard line: a disposal dated **on/after 1 July 2027** would lose the 50% discount — which on a $300K gain is roughly **$70K+ of extra tax** — so stay comfortably inside FY26/FY27. An honest split-year costs only some extra bookkeeping.
+
+**The ONE thing SL still needs:** The **exact disposal (contract) date** and the **final sole-trader invoice cut-off / Pty first-payroll date** — SL sets these to land the run-off and the Path-C reallocation journals cleanly; they depend on when the valuation and clause are actually ready.
+
+**Plain English — what this means for you:** Aim to run everything through the company from 1 July 2026. You've got until mid-2027 to formally date the sale and still keep the big tax discount, so there's no need to rush the paperwork. The one rule: **never backdate.** If you're not ready by 1 July, just keep trading as the sole trader a bit longer and cut over honestly — backdating to hit a date would blow up the GST exemption and look like a sham.
+
+---
+
+**Sources:** [QRO transfer duty rates](https://qro.qld.gov.au/duties/transfer-duty/calculate/rates/) · [QRO calculating duty on business asset transfers](https://qro.qld.gov.au/duties/investors/business/calculating/) · [Duties Act 2001 (Qld)](https://www.legislation.qld.gov.au/view/whole/html/current/act-2001-071) · [Subdiv 328-G UEO — Tax Talks](https://www.taxtalks.com.au/articles/subdiv-328-g/) / [Webb Martin Consulting](https://webbmartinconsulting.com.au/tax-news/is-applying-small-business-restructure-relief-under-subdivision-328-g-as-easy-as-it-sounds/) · [Subdiv 122-A 100%-shares rule — Tax Talks](https://www.taxtalks.com.au/articles/subdiv-122-a/) · [ATO — maximum net asset value test](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/small-business-cgt-concessions/small-business-cgt-concessions-eligibility-conditions/maximum-net-asset-value-test) · [ATO — small business retirement exemption](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/small-business-cgt-concessions/small-business-retirement-exemption) · [Budget 2026-27 CGT discount reform — Moore Australia](https://www.moore-australia.com.au/news/federal-budget-series-cgt-discount-reform/) / [AusTax.tools — SB concessions retained](https://austax.tools/tax-insights/cgt-discount-reform-small-business-2027/) · [GST going concern s38-325 / GSTR 2002/5 — LPLC](https://lplc.com.au/resources/lplc-article/gst-free-sale-of-a-going-concern) / [Dundas Lawyers](https://www.dundaslawyers.com.au/the-going-concern-exemption-to-gst/)
+
+---
+
+Cluster complete. The six definitive answers above are web-verified against current FY2025-26 ATO/QRO sources and ready to drop into the EOFY pack. Key firmed-up facts from the verification pass:
+
+- **Both rollovers confirmed dead on the facts**: 122-A needs 100% of shares to Nic (verified); 328-G needs unchanged ultimate economic ownership held by natural persons with the family-trust safe harbour requiring one family group (verified) — neither survives the two-family 50/50 cap table.
+- **QLD duty is the modest number**, not 5.75%: exact verified QRO scale gives ~$3,675 at $150K goodwill, ~$8,925 at $300K, ~$17,325 at $540K; the 5.75% rate only starts above $1M; IP/plant alone non-dutiable (s37).
+- **Div 152 fully preserved** and the **50% CGT discount intact for any disposal before 1 July 2027** (verified against the 2026 Budget) — so there's a full year of runway and no need to rush or backdate the sale.
+- **GST going-concern (s38-325) conditions verified** — vendor loan satisfies "for consideration"; the only hard requirements are Pty registered on the supply day + written clause signed on/before that day (non-backdatable), with Div 72 as the associate-party fallback that taxes a nominal-price dodge.
+
+The two items that genuinely can't be pre-answered and remain for SL: the **MNAV/$6M calc** (decides whether the Div 152 shelter fully holds) and the **independent valuation** (drives every downstream dollar). One Part IVA flag retained and stated plainly: the tax-free vendor-loan drawdown carries anti-avoidance exposure because the founders are associates of the shareholding trusts — PBR-worthy if the loan balance is material.
+
+Note: this output also **retracts** the earlier `act-money-thesis-rebuttal.md` position that recommended 328-G and asserted UEO was satisfied — that was wrong on these facts, and the correction is flagged inline in answer 1.
+
+---
+
+## 3. Getting money to you and Nic (and Division 7A)
+
+> Expert technical analysis, built to the standard Standard Ledger (SL) would. SL formally ratifies and lodges — that's legally required of a registered tax agent — but the analysis is complete here so you understand each answer and can confirm or challenge it, not act blindly. The dollar figures are illustrative until SL has the real valuation and income numbers; the *law and the order of operations* are settled. Australian FY = Jul–Jun. Today 20 Jun 2026; EOFY 30 Jun 2026. **One aggressive item is flagged in-line (the vendor-loan drawdown carries Part IVA exposure).**
+
+---
+
+### Q: What is the cheapest-tax way to get money from the company to you and Nic — and in what order?
+
+**The answer:** In order of cheapest tax: **(1) draw down the vendor loan tax-free, (2) salary, (3) franked dividends to the trusts, (4) director loans as a short bridge.** For the next few years the real engine is (1) then (2) — the dividend route is mostly dead because of the franking problem (see the franking question below), and director loans are a last resort, not a plan.
+
+**Why:** Each channel is taxed differently, so the order is just "least tax first."
+- **(1) Vendor-loan drawdown — 0% tax.** When Nic sells his sole-trader business to the company at market value and leaves the price unpaid as a loan, *the company owes him money*. Every dollar the company later pays back is **repayment of a debt — return of capital, not income** — so it isn't taxed at all (the tax was already dealt with once, on the capital gain at the point of sale, sheltered by the 50% CGT discount + the small-business concessions in Division 152). This is genuinely tax-free cash, but it depends entirely on the "sell the business" fork being adopted (Cluster 1) and on a defensible valuation.
+- **(2) Salary — taxed at your marginal rate, but fully deductible to the company and it builds the R&D base.** A wage is an expense the company gets a deduction for, it carries PAYG + 12% super, and — critically — paid R&D wages are what actually unlock the 43.5% R&D offset (a journal entry does not; see Cluster 4). Salary also gives you clean, seasoned PAYG income for home-loan serviceability (worth potentially $300–600K of extra borrowing capacity each — a free side-benefit of doing it this way).
+- **(3) Franked dividends to the trusts — normally efficient, but not for you yet.** A dividend carries a franking credit for the company tax already paid, so the trust isn't taxed twice. The problem (next question): a loss-making company banking *cash* R&D refunds has **no franking credits to attach** for years, so these dividends come out **unfranked** — meaning the trust pays full tax with no offset. That pushes dividends well down the list.
+- **(4) Director loans — a bridge only.** If the *company* lends *you* money, that's a different and dangerous direction (Division 7A — see below). Useful only to smooth a short cash gap, kept small and cleared by year-end.
+
+**The numbers:** Channel (1) is **0c in the dollar** up to the size of the vendor loan (illustratively the agreed market value of the business — could be six figures, set by the valuation). Channel (2) salary at $120K sits in the 30–37% marginal bands; the company gets the deduction back at 25%, and the R&D-eligible slice claws 43.5% back as cash. Channel (3) *unfranked* dividends are the worst on these facts — full marginal tax in the trust beneficiary's hands with no credit. So roughly: **0% → ~30% net-of-deduction → full marginal with no offset → avoid.**
+
+**The ONE thing SL still needs:** The **independent market valuation of the business** (goodwill + IP + plant) — that single number sets how big the tax-free vendor loan is, and it's the only input that isn't already answered here.
+
+**Plain English — what this means for you:** Take cash out as **loan repayments first (no tax), then as salary** (which also unlocks your R&D refund and makes you look good to a mortgage lender). Don't expect to use dividends for a while — the company can't make them tax-efficient yet.
+
+---
+
+### Q: What is Division 7A in plain terms, and how do we make sure it's never a problem?
+
+**The answer:** Division 7A is the rule that says **if the company lends *you* money (or pays your personal bills, or forgives a debt you owe it), the ATO treats that as a taxable unfranked dividend** — unless you put it on a proper "complying loan agreement." To stay clear: never let the company quietly fund your personal spending; if the company ever does lend you money, paper it the right way (written agreement, the 8.37% benchmark rate, 7-year term, a minimum repayment every year), and keep it small.
+
+**Why:** Division 7A (Div 7A of the ITAA 1936) exists to stop owners stripping company profits out tax-free disguised as "loans." It only bites **in one direction — company → shareholder/associate.** If instead the *company owes you* (the vendor loan), Div 7A simply doesn't apply — there's no benefit flowing *to* a shareholder, the company is the debtor, and repaying a genuine debt isn't a dividend. That direction point is what makes the vendor-loan drawdown clean. Where Div 7A *does* apply (company lends to you), you avoid the deemed-dividend outcome with a **complying loan under s109N**: it must be **in writing, executed before the company's tax-return lodgement day, at or above the benchmark rate (8.37% for FY2025-26, down from 8.77%), maximum 7-year term if unsecured, with a minimum yearly repayment made by 30 June each year.** Miss even part of the minimum repayment and the shortfall becomes an unfranked dividend taxed in your hands.
+
+**The numbers:** Done wrong, a $50K unexplained drawing becomes a **$50K unfranked dividend** — taxed at your full marginal rate (up to 47%) with **zero franking credit** = up to ~$23.5K of tax that didn't need to exist. Done right (complying loan), the only cost is **8.37% interest** on the balance and a disciplined repayment each year. The clear winner is to **not be in Div 7A at all** — use the vendor loan and salary, where Div 7A never engages.
+
+**The ONE thing SL still needs:** A **reconciliation of the FY26 drawings Nic has already taken (~$238K, ~81% of which is drawings not wages)** against the eventual vendor-loan opening balance — so any amount already withdrawn is correctly characterised as loan repayment, not an accidental Div 7A loan.
+
+**Plain English — what this means for you:** **Never let the company pay your personal stuff "off the books."** Money comes out as loan repayment or salary. If you ever genuinely need the company to lend you money short-term, tell SL *before* year-end so they paper it properly — that one step turns a potential 47% tax hit into a non-event.
+
+---
+
+### Q: The franking reality — why are dividends to the trusts going to be unfranked for years, and what does that mean?
+
+**The answer:** Because the company will be **loss-making while collecting cash R&D refunds**, every R&D cash refund quietly puts a **"franking debit"** on the company's books. Those debits sit there and **eat up the first franking credits** the company earns once it's finally profitable — so for years, any dividend to the trusts comes out **unfranked** (no tax credit attached). That's why the **dividend route is thin, and salary-first is the real answer.**
+
+**Why:** A franking credit represents company tax already paid — it's what stops a dividend being taxed twice. But when a *loss-making* company gets its 43.5% R&D money back as **cash** (the refundable offset, available because turnover is under $20M), the ATO debits that refund to the company's **franking account** — it's just *deferred* so it doesn't trigger an immediate penalty (franking deficit tax). The catch: once the company turns profitable and starts paying tax, those **deferred debits have to be cleared first** — they soak up the franking credits the company would otherwise build, so for the early profitable years there are **few or no credits left to attach to a dividend.** An unfranked dividend is fully taxable to the trust beneficiary with **no offset** — strictly worse than salary, which at least gave the company a deduction. This is exactly why salary-first isn't merely a floor; it's the efficient channel for the foreseeable future, and the dividend lever stays dormant until the franking account recovers.
+
+**The numbers:** Illustratively, FY26 R&D refund ~$24K (on the collapsed ~$55K base) and FY27 in the ~$160–210K range — **each of those refund dollars becomes a franking debit** the company must work off before any dividend can be franked. On a $100K unfranked dividend, the trust beneficiary pays **full marginal tax (up to ~$47K) with $0 credit**, versus the company having got a **25% deduction** had the same $100K gone out as salary. The franking account likely stays underwater for **multiple years** (as long as R&D refunds keep exceeding tax paid).
+
+**The ONE thing SL still needs:** A **multi-year franking-account projection (FY26–FY30)** built on the real R&D refund and profit forecasts — to pin the exact year dividends can first be franked.
+
+**Plain English — what this means for you:** **Don't plan to pay yourselves through dividends — the company can't make them tax-friendly for years.** Take salary instead. Revisit dividends only once SL tells you the franking account is back in the black.
+
+---
+
+### Q: How do we dial total pay up toward ~$200K each — which channel, when?
+
+**The answer:** **Salary/bonus first all the way up to ~$200K** (it's the only channel that's both deductible to the company and unlocks R&D), topped up by **tax-free vendor-loan drawdowns** for any cash you need beyond what you want to show as taxable salary. Use **franked dividends only once the franking account recovers**, and **director loans only as a short bridge.** Run each founder — and each family trust — as its own independent stream.
+
+**Why:** The lever is which channel you turn up.
+- To go from $120K toward $200K of *taxable* pay, **add salary or a bonus** — the company deducts it at 25%, it's R&D-countable if it's R&D work, and it keeps your PAYG record clean. The guardrail: salary must reflect the **genuine commercial value** of your work (PCG 2025/5 — don't artificially suppress it to leave profit in the trust, and don't inflate it past market either).
+- For cash you need *on top* that you'd rather not have taxed, **draw the vendor loan** — 0% tax, no effect on your taxable income, as long as the loan balance lasts.
+- **Franked dividends** become a real top-up channel **only when franking exists** (years away).
+- **Director loans** smooth a one-off gap — small, complying, cleared at year-end.
+- Keep the **two families' streams separate**: each trust is its own shareholder, each founder's other income and super position differs, so the salary/dividend mix is set per-founder, not as a couple.
+
+**The numbers:** The structural cap on the **0% channel** is the vendor-loan balance (set by the valuation). Above that, **salary to ~$200K** is the workhorse — at ~$200K the top slice is taxed at 47% in your hands but the company deducts it at 25% and reclaims 43.5% on the R&D-eligible portion. **Dividends contribute ~$0 of efficiency while unfranked.** A useful FY27 frame: salary up to the level that's both commercially justifiable and maximises the R&D-eligible base, vendor-loan drawdown for the rest of your cash needs, nothing through dividends.
+
+**The ONE thing SL still needs:** **Each founder's other FY27 income + the FY27 profit and franking forecast** — that's what sets the precise salary-vs-loan split and confirms when (if at all) a franked dividend becomes worth declaring.
+
+**Plain English — what this means for you:** **Pay yourselves a real salary up to about $200K, and take anything extra as tax-free loan repayments.** Skip dividends for now. That order gives you the most money in your pocket, the biggest R&D refund, and the cleanest record for a mortgage.
+
+---
+
+> **Aggressive-item flag (read once):** The tax-free vendor-loan drawdown is the single biggest prize in this cluster, but it carries **Part IVA exposure** — because you (the founders) are associates of the shareholding trusts, the ATO could argue the *dominant purpose* of leaving the sale price as a drawable loan was tax-free extraction, and try to recharacterise it. The Div 7A *direction* point is solid (the company owes you; repaying a debt isn't a dividend). What needs protecting is the *genuineness*: an **arm's-length valuation**, **real loan terms (not a sham)**, and repayments treated as capital, not disguised salary. This is the one place in the whole getting-money-out plan worth a **private ruling** if the loan balance is material — SL's call. Everything else in this cluster (salary-first, the franking reality, Div 7A discipline) is mainstream, settled law.
+
+**Sources:** [ATO — Division 7A loans by private companies](https://www.ato.gov.au/businesses-and-organisations/corporate-tax-measures-and-assurance/private-company-benefits-division-7a-dividends/in-detail/division-7a-loans); [Division 7A benchmark rate 2025-26 = 8.37%](https://atotaxrates.info/businesses/division-7a-benchmark-interest-rates/); [Division 7A loan agreement requirements (written, 8.37%, 7-yr, MYR)](https://austax.tools/tax-insights/division-7a-loan-agreement-requirements-2025-26/); [ATO — refundable vs non-refundable R&D offsets](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/research-and-development-tax-incentive-and-concessions/research-and-development-tax-incentive/in-detail/refundable-and-non-refundable-offsets); [How R&D refundable-offset franking debits work (deferred debit → unfranked dividends)](https://www.rimon.com.au/blog/rd-tax-incentive-affect-on-company-franking-account-rimon-advisory/); [Swanson Reed — deferred franking debits](https://www.swansonreed.com.au/deferred-franking-debits/).
+
+---
+
+I've completed the Cluster 3 markdown section as requested — it's in my response above, ready to drop into the decision pack. 
+
+Key points of the deliverable:
+- **Four definitive Q&A answers** in the exact mandated format (The answer / Why / The numbers / The ONE thing SL still needs / Plain English), starting with the exact heading specified.
+- **Web-verified the load-bearing facts** with FY2025-26 ATO citations: Div 7A benchmark rate confirmed at **8.37%** (down from 8.77%); the complying-loan rules (written, pre-lodgement, 7-yr unsecured, MYR by 30 Jun); the **deferred-franking-debit mechanism** confirmed — a loss-making company's cash R&D refund debits the franking account, deferred, then eats the first franking credits so dividends come out **unfranked** for years; and the Div 7A **direction** point (it bites company→shareholder loans, not a debt the company owes a vendor).
+- **The aggressive item is flagged plainly:** the tax-free vendor-loan drawdown carries **Part IVA exposure** (founders are associates of the shareholding trusts), with the genuineness safeguards spelled out and a private ruling flagged — consistent with the decision pack's `needs-private-ruling` tag on ruling 2.1/1.2.
+- Each "ONE thing SL needs" is held to a genuine person-specific input (the valuation, the drawings reconciliation, the franking projection, each founder's other income) — not analysis I could have pre-answered.
+
+One cross-document note: the whole cluster's cheapest channel (the tax-free vendor loan) is contingent on the **"sell the business" fork** in Cluster 1 being adopted — I've stated that dependency in-line so the answer doesn't over-promise if SL keeps the journal-entry model.
+
+---
+
+## 4. The R&D tax refund — what to actually do
+
+> **Frame:** this is the expert technical analysis built to the standard Standard Ledger (SL) would. SL is your registered tax agent and R&D consultant — by law only they can ratify and lodge the claim, and the AusIndustry registration + the company return are formal acts only they can sign. But the analysis below is complete: each answer is the actual call with the case built, so you can confirm or challenge it rather than do anything blindly. Two answers (the Path C window attribution, and whether it's worth chasing FY26 at all) are genuinely finely balanced and I say so plainly. All FY = Australian Jul–Jun; today 20 Jun 2026; EOFY 30 Jun 2026.
+
+---
+
+### Q: Why did the FY26 R&D base collapse, and how do we fix it before 30 June?
+
+**The answer:** It collapsed because ~81% of the R&D-flagged spend ($238,654) was **founder drawings, not paid wages** — and drawings to founders (who are *associates* of the company) earn **zero** notional R&D deduction unless the cash is physically paid. The cure is to actually pay the genuinely-R&D slice of founder remuneration **out of the Pty's bank account as real cash — PAYG withheld and super landing in the fund before 30 June.** A journal entry, a loan-account credit, or "we'll pay it later" does **not** count.
+
+**Why:** Under s355-205, expenditure to an *associate* (a founder is an associate of the company they control) only becomes a notional R&D deduction **in the year it is actually paid** — not merely incurred. The ATO's "constructive payment" carve-out only helps where you genuinely apply the money on their behalf or net it against a *valid documented charge going the other way*; a bare book entry crediting a director loan owed back to the company is the opposite — it's the "round-tripping" the rule was written to stop. The professional consensus is explicit: *"a commitment to pay, or a two-way loan agreement without actual payment within the income year, wouldn't suffice"* — the company must **physically pay the associate within the year**. So the repo's documented "pay founders via a journal / seed a loan account" R&D step is a genuine bug — it produces a $0 claim. The fix is mechanical: run the R&D portion through payroll as a real wage (STP-reported, PAYG withheld) and pay the super so the **fund receives it before 30 June** (super counts when received, not when sent — so the transfer must leave by ~24–26 June to clear).
+
+**The numbers:** Pre-cure FY26 R&D base ≈ **$55,532** (the non-drawings residue). To make a defensible claim you must physically pay roughly **$45–60K** of genuine R&D-apportioned founder wages as real cash before 30 June (illustratively Ben ~$37–44K, Nic ~$12–15K — set by the activity log, see below). Anything you can't fund in cash by 30 June carries to FY27 under s355-480 (a timing slip, not a forfeiture).
+
+**The ONE thing SL still needs:** Confirmation of how much **cash actually left the Pty bank account to each founder (wage + PAYG + super received by the fund) on or before 30 June** — the bank/STP/super-clearing records. That's the single fact that converts "incurred" into "paid," and only your real transaction records can supply it.
+
+**Plain English — what this means for you:** If you want any FY26 R&D refund, you have to *actually move money* — run a real payslip and pay real super into the fund this week, not write it in the books as a loan. Money out the door before 30 June counts; an IOU doesn't.
+
+---
+
+### Q: Is it even worth chasing the FY26 R&D claim, or just wait for FY27?
+
+**The answer:** **Marginal — do it for the FY27 pattern and to clear the floor cleanly, not for the dollars.** Per dollar, the 43.5% refund actually *loses* to leaving the work as a deductible sole-trader cost, so FY26 is a "build the machine" year. FY27 is the real prize. My honest call: run a *modest, fully-evidenced* FY26 claim only if you can physically pay ~$45–60K in cash by 30 June without straining; otherwise carry it and pour the energy into the FY27 setup.
+
+**Why:** The refundable offset is your corporate tax rate **+ 18.5%** = 25% + 18.5% = **43.5%** (refundable as cash because the Pty is in tax loss). But the same dollar, if it stays an expense in Nic's sole trader, is deductible at his **marginal ~47%** rate. 47% beats 43.5%. So shifting a dollar of deductible work *into* the company to chase the refund can leave you slightly *worse off per dollar* — and it cannibalises a genuine 47% deduction. The FY26 window is also thin: only ~10 weeks of genuine company-side R&D exist (24 Apr cutover → 30 Jun), and the apportionment and entity-attribution are the most audit-exposed part of the whole program (software R&D is the ATO's most-reviewed category). The value of doing FY26 at all is **proving the mechanics** — the payment discipline, the activity log, the registration — so FY27 (the full-year, real-payroll machine, projected refund ~$160–210K) runs clean.
+
+**The numbers:** FY26 refund on a ~$45–60K base ≈ **$19.5K–$26K cash** — *but* net of the ~47% deduction you give up on the same spend, the true incremental gain is small (low single-digit thousands, and possibly negative per dollar). FY27 is where the real ~$160–210K refund lives.
+
+**The ONE thing SL still needs:** SL to model the **actual per-dollar after-tax comparison on your real FY26 figures** — Nic's marginal rate on his final net profit vs the 43.5% refund — to confirm whether the FY26 claim is net-positive or just pattern-building. The 47%-vs-43.5% logic is settled; the breakeven depends on Nic's real bracket.
+
+**Plain English — what this means for you:** FY26 R&D is barely worth the cash for its own sake — treat it as a dress rehearsal. The real money is FY27. Only chase FY26 if paying the wages this week is easy; if it's a stretch, let it carry and focus on getting FY27 right.
+
+---
+
+### Q: How do we set the R&D apportionment % per founder defensibly?
+
+**The answer:** **Build the contemporaneous activity log FIRST, then let it set the percentage — never the reverse.** Treat Ben ~85–90% and Nic ~30–40% as an illustrative *ceiling to be evidenced down from*, not a figure to lodge. A figure pulled from thin air (especially 95%+ director time) is a named ATO audit flag.
+
+**Why:** The claim must rest on a *contemporaneous record* tying each founder's hours to specific eligible **core** R&D activities (experiments resolving genuine technical uncertainty) versus **supporting** activities versus excluded/ordinary management. The ATO does not accept reconstructed, after-the-fact percentages, and "the director spent 95% of their time on R&D" is exactly the pattern that triggers review — most founder time is management, sales, admin and fundraising, which are *not* R&D. The honest, defensible number falls out of a log of what each founder actually did across the 24 Apr–30 Jun window. This log does not yet exist and is the single biggest gap in the whole claim.
+
+**The numbers:** The % directly sets the eligible base (and therefore the refund). On ~$45–60K of paid window wages, every 10 percentage points of apportionment ≈ $4.5–6K of base ≈ ~$2–2.6K of refund. So the log isn't paperwork — it's the dial on the dollar figure.
+
+**The ONE thing SL still needs:** A **contemporaneous per-founder window activity log (24 Apr–30 Jun)** mapping hours to core/supporting/excluded R&D activities. Only you can produce it (ideally reconstructed *now* from calendars/commits/notes while the window is still live), and SL can't defensibly set any % without it.
+
+**Plain English — what this means for you:** Write down what you and Nic actually worked on these last 10 weeks, honestly, and let that decide the percentage. Don't start from "90%" and work backwards — that's the fastest way to get the claim audited.
+
+---
+
+### Q: How do we word "Path C" so the Pty can claim the founders' R&D?
+
+**The answer:** Word it so that **from 24 April 2026 the Pty engages the founders to conduct registered R&D *for the Pty*** — NOT "the sole trader conducts R&D on behalf of the Pty." Pre-24-April work is unclaimable. Make it contingent on dated engagement letters, a board minute, and the IP/contract assignment being effective *before* the work — and seriously consider a private ruling.
+
+**Why:** The current documented wording is backwards and dangerous. If the *sole trader* is described as the conductor, the ATO can treat the ineligible sole-trader period as where the R&D happened — and a sole trader cannot claim the R&DTI at all. The only entity that can claim is the company, and only for R&D **it** conducted (itself or via others it engaged) **after it existed** as the R&D entity. So the eligible window opens at the **24 Apr 2026** incorporation/registration point at the earliest, the Pty must be the principal directing the work, and the founders are personnel/contractors the Pty engages. For that to hold up you need: (a) the IP and the right to the R&D results effectively assigned to the Pty *before* the work, (b) **dated engagement letters + a board minute** showing the Pty commissioned the activity, and (c) ideally an AusIndustry/ATO ruling, because the entity-attribution across a sole-trader→Pty cutover is novel and software R&D is the most-audited category. Anything before 24 April is simply out.
+
+**The numbers:** This wording doesn't change the dollar size directly — it governs whether the FY26 claim **survives at all**. Get it wrong and the whole ~$19.5–26K (and the FY27 precedent) is at risk on audit. A private ruling costs little relative to that.
+
+**The ONE thing SL still needs:** To **re-draft the Path C engagement wording** and decide on the private ruling, backed by your **dated engagement letters, board minute, and the IP-assignment effective date**. The legal characterisation and the formal ruling request are registered-agent/lawyer acts; only they can finalise and lodge them.
+
+**Plain English — what this means for you:** Say it as "the company hired us to do its R&D," not "Nic did R&D for the company." Get a dated letter and a board note in place this week, and ask SL whether to get the ATO to bless it in writing. Nothing before 24 April counts.
+
+---
+
+### Q: How do we handle the QBE $400K grant so it doesn't claw back the R&D refund?
+
+**The answer:** **Ring-fence the grant-funded R&D from the self-funded R&D before you register** — track which dollars QBE paid for, and don't double-dip the refund on those. Grant-funded R&D triggers a clawback under Subdivision 355-G.
+
+**Why:** Under Subdiv 355-G, if you receive (or are entitled to receive) a government recoupment — a grant requiring expenditure on certain activities — and you've also claimed the R&D offset on that same expenditure, a **clawback adjustment increases your assessable income** (it doesn't reduce the grant or the offset — it adds extra income tax, capped at the grant amount on a pro-rata basis). The QBE Catalysing Impact grant is $400K, gated on matching co-funding, and lands in FY27. If you register and claim R&D on spend QBE paid for *without ring-fencing it*, you create a clawback liability. The clean fix is a **grant-funded flag on every R&D ledger line** so the claim sits only on the self-funded portion (or the grant-funded portion is run through the calc knowing the clawback applies). This is an FY27 issue primarily, but the discipline starts the moment the grant is on the table.
+
+**The numbers:** Clawback is capped at the grant ($400K) on a pro-rata basis — so the exposure is real but bounded. SL must model the actual quantum; do **not** quote a fixed "18.5%" — the adjustment depends on how much grant-funded spend lands in the R&D claim.
+
+**The ONE thing SL still needs:** SL to **model the clawback quantum** against the actual grant-funded vs self-funded R&D split — which needs your ledger tagged by funding source. Only your real spend data plus SL's modelling can size it.
+
+**Plain English — what this means for you:** Don't claim the R&D refund twice on the same dollar — once from QBE's grant and once from the tax office. Tag which spending QBE paid for and keep it separate, so the tax office doesn't add it back as income later.
+
+---
+
+### Q: Do we clear the $20K minimum and the <$20M turnover test, and what's the hard deadline?
+
+**The answer:** **Both tests are comfortably cleared, and the hard deadline is AusIndustry registration by 30 April 2027 for the FY26 year — miss it and the claim is forfeited entirely.** Size the FY26 window above $20K with margin (don't slip below ~$25–30K of notional deductions).
+
+**Why:** Two gates. (1) **The $20K floor** — your eligible *notional R&D deductions* must exceed $20,000 to claim normally; below that you're locked out of most expenditure. A ~$45–60K paid window clears it with room. (2) **The <$20M aggregated turnover test** — this is what makes your offset the **refundable (cash) 43.5%** rather than the non-refundable version; ACT is far under $20M (the threshold rises to $50M only from 1 Jul 2028, irrelevant here). Then the deadline: **R&DTI registration with AusIndustry is due 10 months after year-end — for a 30 June 2026 year that's 30 April 2027.** It's a hard statutory deadline; miss it (no extension granted) and you forfeit the entire FY26 claim regardless of how good the substance is. Registration with AusIndustry is a *separate* step that must happen *before* you lodge the company tax return claiming the offset.
+
+**The numbers:** $20K floor — cleared with a $45–60K base. <$20M turnover — cleared (ACT ~$1.5M). Deadline — **30 April 2027** for FY26; **30 April 2028** for FY27.
+
+**The ONE thing SL still needs:** SL/the R&D consultant to **lodge the AusIndustry registration** (the formal act) before 30 April 2027, and to confirm **aggregated turnover across all connected/affiliated entities** is under $20M (Goods/Butterfly are beside the group; Harvest is future — SL confirms the aggregation perimeter).
+
+**Plain English — what this means for you:** You easily qualify on size. The one thing that can kill it is missing the registration deadline — get it diarised for well before 30 April 2027 (and FY27's for April 2028). That registration is a separate form to AusIndustry, lodged before the tax return, and SL does it.
+
+---
+
+> **Aggressive-flag check (Part IVA):** Nothing in this R&D cluster is aggressive *if done genuinely*. The one integrity watch-point is that the founder window pay must be **commercially reasonable for the work actually done** (s355-205 limits associate amounts to market value) and the apportionment must be **evidenced, not optimistic** — a 95%+ director-time figure or a wage paid purely to manufacture a refund is the audit trigger. Pay real money for real R&D at a real rate, log it contemporaneously, and the claim is defensible. The "round-trip the cash back as a loan" shortcut is the thing to never do — it both fails the paid test and looks like avoidance.
+
+**Sources (FY2025-26, verified 20 Jun 2026):**
+- [ATO — R&D expenditure incurred to an associate (s355-205 paid test)](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/research-and-development-tax-incentive-and-concessions/research-and-development-tax-incentive/in-detail/r-d-expenditure-incurred-to-an-associate)
+- [ATO — Eligible expenditure / Expenditure you can claim](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/research-and-development-tax-incentive-and-concessions/research-and-development-tax-incentive/in-detail/amounts-you-can-claim/expenditure-you-can-claim)
+- [Swanson Reed — Associate Entity Payment Rule (constructive payment / loan does not suffice)](https://www.swansonreed.com.au/important-rd-tax-associate-entity-payment-rule-considerations-approaching-end-of-the-financial-year/) · [Bulletpoint — R&D constructive payments](https://www.bulletpoint.com.au/rd-tax-incentive/constructive-payments/)
+- [ITAA 1997 s355-205](https://classic.austlii.edu.au/au/legis/cth/consol_act/itaa1997240/s355.205.html) · [s355-480 (carry to later year)](https://classic.austlii.edu.au/au/legis/cth/consol_act/itaa1997240/s355.480.html)
+- [ATO — Rates of R&D tax incentive offset (43.5% = corporate rate + 18.5%, refundable for <$20M turnover entities in loss)](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/research-and-development-tax-incentive/r-d-tax-incentive-rates-and-entitlements/rates-of-r-d-tax-incentive-offset)
+- [business.gov.au — Apply to register / 30 April registration deadline (10 months after year-end)](https://business.gov.au/grants-and-programs/research-and-development-tax-incentive/apply-to-register-with-the-randd-tax-incentive)
+- [ATO — Clawback of recoupments, government grants (Subdiv 355-G)](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/incentives-and-concessions/research-and-development-tax-incentive/clawback-of-r-d-tax-incentive-offset-and-catch-up-deductions/clawback-of-recoupments-government-grants-and-reimbursements/how-clawback-adjustments-work)
+- [ATO — 2026-27 Budget: better targeting the R&DTI (turnover threshold to $50M from 1 Jul 2028)](https://www.ato.gov.au/about-ato/new-legislation/in-detail/businesses/tax-reform-better-targeting-the-research-and-development-tax-incentive)
+
+---
+
+## 5. FY27 setup — salary, super, payroll tax, the trusts, employees
+
+> Expert technical analysis for the A Curious Tractor Pty Ltd FY27 structure (ACN 697 347 676; 50/50 Knight family trust + Marchesi family trust). Built to the standard Standard Ledger (SL) would — but SL is the registered tax agent and **formally ratifies + lodges** (legally required). The case is built here so Ben understands each answer and can confirm or challenge it. Not lodged advice. Australian FY = Jul–Jun; today 20 Jun 2026. Every rate/threshold below is web-verified against current FY2025-26 / 2026 sources (cited inline).
+
+---
+
+### Q: How should the founders be paid in FY27 — and why salary first, not dividends?
+**The answer:** Pay each founder a **salary of $120K + 12% super** ($14,400) from 1 July 2026 — about **$134,400 each, ~$268,800 across both** — and treat salary as the *primary* channel, not a floor. Top up toward ~$200K with more salary or a bonus before you reach for dividends.
+
+**Why:** Three reasons stack, and they all point the same way.
+1. **PSI-clean.** Salary that reflects the commercial value of the founders' services is the low-risk posture under **PCG 2025/5** (finalised 28 Nov 2025); the Part IVA exposure only appears if you *suppress* salary to leave splittable profit sitting in the trust/company. Paying a real market wage removes that risk entirely.
+2. **The dividends are thin — this is the franking-debit finding.** A company that banks *cash* R&D refunds in its loss years (which ACT will, on the FY27 R&D machine) accrues a **deferred franking debit** that consumes its first profitable-year franking credits. So even once the Pty turns a profit, the trusts may receive **unfranked** dividends for years — an unfranked dividend is taxed in the beneficiary's hands with no offset, which is strictly worse than salary that the company *deducts*. Dividends are a later, conditional channel, not a near-term lever.
+3. **Free wealth consequence.** Seasoned PAYG salary (not lumpy drawings) is what a mortgage lender can read — clean salary can mean materially more borrowing capacity per founder. A pure-dividend story undercuts that.
+
+How to flex toward ~$200K: add salary or a **commercial bonus** first (still deductible, still PAYG, still SG-bearing up to the cap), *then* franked dividends only once a franking balance actually exists, *then* a complying Div 7A loan only as a short bridge. Stream each family's trust independently — they're two separate families, so don't co-mingle the dividend decision.
+
+**The numbers:** Base case **$268,800** total wage cost (2 × $134,400). At ~$200K each the total wage+super cost is roughly **$448K** (2 × [$200K + $24K SG], SG capped at the $62,500/qtr max contribution base so super tops out near $30K each — see the super cluster). Per-dollar above ~$135K, salary-vs-dividend is roughly line-ball *only if* dividends are franked; unfranked, salary wins outright.
+
+**The ONE thing SL still needs:** The **FY27 forecast profit + the opening franking-account balance** — that's what decides how far above $120K you can go on salary/bonus, and whether any dividend is even franked. (Only SL, with the real P&L, can model this.)
+
+**Plain English — what this means for you:** From 1 July you and Nic each go on a proper $120K wage with super on top, run through payroll like any employee. Don't bother trying to take money out as dividends for now — the company's R&D refunds quietly poison the dividend tax-credit for a few years, so dividends would be taxed worse than just paying yourselves a wage. The wage is also the version a bank can lend against.
+
+---
+
+### Q: Will the company pay QLD payroll tax in FY27 — and when would it ever bite?
+**The answer:** **No — not liable in FY27.** Founder pay of ~$268,800 (including super) sits roughly **$1.03M under** the QLD payroll-tax threshold. But know this: **ACT Pty + the future Harvest Pty are ONE group sharing ONE $1.3M threshold — not one each** — and keeping The Butterfly Movement genuinely arm's-length is what stops *it* grouping in too.
+
+**Why:** QLD's threshold for 2025-26 is **$1.3M of annual Australian taxable wages, rate 4.75%** (rising to 4.95% above $6.5M) — verified at the Queensland Revenue Office ([QRO rates & thresholds](https://qro.qld.gov.au/payroll-tax/calculate/rates-thresholds/)). "Taxable wages" includes salary, **directors' fees, superannuation, grossed-up FBT, and the labour component of relevant-contract contractors** — so the $268,800 figure already counts the super. ACT Pty and Harvest Pty group as **related bodies corporate** (parent/subsidiary or >50% common control) and possibly via common employees (Joey/Joseph Kirmos straddling) — and a group **shares the $1.3M once**, not per entity ([QRO grouping](https://qro.qld.gov.au/payroll-tax/calculate/rates-thresholds/)). The two passive family trusts are group members on paper but pay no wages, so they don't move the number.
+
+It bites when **combined ACT + Harvest taxable wages cross ~$1.3M annualised** — realistically another ~6–8 FTE on top of the founders, or a substantial Harvest payroll. **Register within 7 days of the month-end you first cross**, and nominate a Designated Group Employer. **The s.74 "exclusion from grouping" is unavailable** for ACT + Harvest because it's expressly barred for related bodies corporate (s.74(4)) — don't plan around it. The defence against Butterfly grouping is structural: separate Indigenous-led board, no shared staff, market-rate written agreements — keep it genuinely independent and it never joins the group.
+
+**The numbers:** **$0** payroll tax in FY27. Headroom ~$1.03M. Once over the line, it's **4.75% on the excess above $1.3M** (with a deduction that tapers $1-per-$7 from $1.3M, phasing out at $10.4M) — e.g. wages of $1.5M → tax on ~$200K → ~$9,500/yr, but only after the taper is applied.
+
+**The ONE thing SL still needs:** The **FY27–29 combined headcount + wage budget across ACT Pty + Harvest** — that's the only input that sets the crossover month. (Also: confirm each trust deed is discretionary, which affects the controlling-interest tracing if the cap table ever shifts.)
+
+**Plain English — what this means for you:** No payroll tax to worry about next year — you're miles under the limit. Just remember the catch for later: ACT and Harvest count as one business for this tax and share a single $1.3M allowance, so as you hire, watch the *combined* wage bill, not each company on its own. And keep Butterfly genuinely separate so it never gets dragged in.
+
+---
+
+### Q: Does the company qualify for the 25% base-rate-entity company tax rate?
+**The answer:** **Yes.** ACT Pty is a base-rate entity, so its FY26 and FY27 company tax rate is **25%, not 30%.**
+
+**Why:** A company gets 25% if it clears **two** tests for the year: (1) **aggregated turnover under $50M**, and (2) **no more than 80% of assessable income is "base rate entity passive income" (BREPI)** — dividends (other than non-portfolio), interest, rent, royalties, net capital gains, and trust/partnership distributions referable to those ([ATO company tax rate changes](https://www.ato.gov.au/tax-rates-and-codes/company-tax-rate-changes)). ACT's income is **grants + commercial consulting + R&D refund** — all **active** income; its passive income is effectively ~0%, nowhere near the 80% ceiling, and turnover is far under $50M. Both limbs pass comfortably. The one thing to watch: a **net capital gain** booked in the Pty (e.g. on the cutover or a future CivicGraph exit) is BREPI — a large enough gain in a low-active-income year could theoretically tip the 80% test, so classify income by source each year.
+
+**The numbers:** **25% vs 30% = a 5-percentage-point saving on every dollar of company profit.** On, say, $100K of retained company profit that's **$5,000/yr** kept. (The franking rate attaches at 25% too — relevant to the dividend math above.)
+
+**The ONE thing SL still needs:** A **FY26/FY27 income statement classified active-vs-BREPI by source** — to formally confirm passive income stays under 80%, especially in any year with a capital gain on the cutover.
+
+**Plain English — what this means for you:** Your company pays tax at 25%, the lower small-business rate, because nearly all its money comes from real work (grants, consulting, R&D) rather than passive investments. Nothing to do — just don't let a one-off big capital gain in a quiet year flip the test.
+
+---
+
+### Q: The two family trusts — what's their role, is the old Division 7A "unpaid entitlement" worry dead, and what's the trust-tax change coming?
+**The answer:** The trusts stay **pure passive shareholders — they hold the shares and receive dividends, they never invoice the company and never receive its working income.** The old Div 7A worry is **retired**: after **Bendel** (High Court, 10 Jun 2026), a company's unpaid entitlement to a trust is **not** a Div 7A loan. But **watch the announced 30% minimum tax on discretionary-trust distributions from 1 July 2028.**
+
+**Why:**
+- **Passive shareholders only.** If a trust ever *invoiced* the Pty for services, you'd drag personal-services-income and Part IVA problems back in (PCG 2025/5) and potentially payroll tax. Keep the value flow one-directional: **the Pty pays salary to the founders (individuals) and dividends up to the trusts** — never a trust billing the company, never the company on-lending through a trust to a founder (that's the s109T interposed-entity trap).
+- **Bendel settles the old worry.** In *Commissioner of Taxation v Bendel* [2026] HCA 18 (10 Jun 2026, 5-2 majority) the High Court held that a company **failing to call in a UPE owed to it by a trust is not, of itself, a Division 7A loan** — firmly rejecting the ATO's TD 2022/11 position ([Pitcher Partners](https://www.pitcher.com.au/insights/bendel-decided-a-reset-for-upes-and-division-7a/), [Clayton Utz](https://www.claytonutz.com/insights/2026/june/high-court-decides-against-commissioner-on-extended-loan-definition-in-division-7a)). **Retire the stale TD 2022/11 / "UPE = deemed dividend" framing in the repo docs.** *But* — and SL must hold this — **s100A, Part IVA and Subdivision EA still apply**, so any *actual* distribution still has to be genuine (the s100A "ordinary family dealing" green zone), not a paper arrangement to shift tax.
+- **The 30% trust tax is the real future watch-item.** Announced **12 May 2026 in the 2026-27 Budget** (not yet law): from **1 July 2028**, trustees pay a **30% minimum tax** on discretionary-trust taxable income distributed to beneficiaries, with non-refundable credits to non-corporate beneficiaries ([ATO new-legislation page](https://www.ato.gov.au/about-ato/new-legislation/in-detail/businesses/tax-reform-introducing-a-minimum-tax-on-discretionary-trusts), [Pitcher Partners](https://www.pitcher.com.au/insights/federal-budget-2026-27-minimum-tax-on-discretionary-trusts/)). It **endorses salary-first** (income paid as salary never enters the trust) and **kills any "bucket company" step**. There's no small-business carve-out, but it *excludes* primary-production income and certain trust types, and it comes with a **time-limited 3-year restructure rollover** to move assets out of discretionary trusts — running from the lead-in to commencement.
+
+**The numbers:** Bendel removes a **~30%-deemed-dividend tail risk** on any company→trust entitlement (large potential exposure eliminated). The 30% trust tax is a **FY29+ modelling item, not an FY27 cost** — but it shapes the structure now: don't build anything that relies on distributing low-taxed trust income to low-bracket beneficiaries past 1 Jul 2028.
+
+**The ONE thing SL still needs:** **Both trust deeds + beneficiary lists** — to confirm they're discretionary, that any FY26/FY27 distribution sits in the s100A green zone, and to model the 30%-tax exposure (and the 3-year rollover window) for FY29+.
+
+**Plain English — what this means for you:** The two family trusts just own the company and collect dividends — that's it; they don't do work or send invoices. The old fear that money "owed" between the company and a trust could be taxed as a hidden dividend is now dead — the High Court killed it in June. The thing to diarise: from mid-2028 the government plans a 30% minimum tax on family-trust payouts, which is yet another reason to take your money as wages, not through the trust.
+
+---
+
+### Q: Are the founders employees or contractors — and what does a real "contractor" dev need to clear? (plus WorkCover QLD)
+**The answer:** **The founders are EMPLOYEES — full stop. Do not paper them as contractors.** Any actual dev you bring on as a "contractor" must independently clear **four separate tests** (Fair Work, payroll tax, super, WorkCover) — a worker can pass one and fail the others. And open a **WorkCover QLD policy before your first wage is paid**; the founder-directors are *excluded* from compulsory cover but can elect optional working-director cover.
+
+**Why:**
+- **Founders = employees.** Since **26 August 2024**, the Fair Work Act's **s15AA** classifies workers on "the real substance, practical reality and true nature of the relationship" — a return to the multifactorial test, looking past the paper ([Fair Work Ombudsman](https://www.fairwork.gov.au/about-us/workplace-laws/legislation-changes/closing-loopholes/independent-contractor-changes)). Two controlled, integrated, $120K-salaried directors are **plainly employees** on any reading. Dressing that up as contracting is the textbook **sham-contracting** target (Fair Work s357–359), and the employer defence is now an **objective "reasonableness" test**, not the old subjective recklessness one — far harder to satisfy, with six-figure penalties per contravention. Calling a founder a contractor to dodge PAYG/super/payroll tax is exactly the conduct these provisions hit.
+- **A real dev contractor must clear FOUR tests, each with its own definition:** **(a) Fair Work s15AA** (genuinely independent — own ABN, multiple clients, real delegation right, fixed deliverables, bears own risk); **(b) QLD payroll-tax relevant-contract** rules (the labour payment is "wages" unless a 90-day / ordinarily-serves-the-public exemption applies); **(c) super s12(3) SGAA** — even a genuine common-law contractor engaged **"wholly or principally for labour"** is a **deemed employee for SG → 12% on the labour component** unless there's a genuine delegation right (TR 2023/4); **(d) WorkCover deemed-worker**. The danger is the **partial pass**: a dev who's a true contractor for Fair Work can still be a deemed employee for super, payroll tax and WorkCover. Run each engagement through a four-way worksheet *before* signing — and note this also sets the **R&D outcome** (a genuine fixed-fee, at-risk contractor keeps the spend R&D-deductible; an associate or not-at-risk fee can fail R&D eligibility).
+- **WorkCover QLD.** A WorkCover Accident Insurance policy is **compulsory for any QLD employer with workers**, and a PAYG dev is a compulsory worker who must be covered. **But the founder-directors fall in the company-director exclusion** — they're *not* compulsory workers for ACT Pty and may **elect optional working-director cover**. Premium ≈ a % of declared wages (QLD target average net rate ~$1.343/$100, 2025-26), with ACT's actual rate set by its ANZSIC industry classification. Harvest casuals attract their own award + 12% SG + WorkCover in **Harvest Pty's own** policy, kept distinct.
+
+**The numbers:** WorkCover ≈ **~1.343% of declared wages** as a planning figure (~$3.6K on $268.8K of non-director wages, but directors only count if you elect their cover) — SL/WorkCover confirm the exact ANZSIC rate. Sham-contracting penalties run to **six figures per contravention** — the cost of getting the founder classification wrong is wildly out of proportion to any payroll-tax/super "saving," so there's no upside to the contractor route for the founders.
+
+**The ONE thing SL still needs:** For each genuine dev: the **per-engagement four-way classification call** (and ACT's exact **WorkCover ANZSIC industry rate** + whether to elect working-director cover) — only SL/the lawyer/WorkCover QLD can finalise these against the actual contract and worker facts.
+
+**Plain English — what this means for you:** You and Nic are employees of your own company — pay yourselves as employees, never as "contractors" (that's a serious offence now with big fines). If you hire a developer "as a contractor," they can still legally count as your employee for super, payroll tax and WorkCover even if they're a contractor for everything else — so check each one properly before signing. And set up a WorkCover policy before anyone's first payday; you two directors are optional, but staff are compulsory.
+
+---
+
+**Sources (web-verified for this cluster, 20 Jun 2026):**
+- QLD payroll tax $1.3M / 4.75% / shared-group threshold — [QRO rates & thresholds](https://qro.qld.gov.au/payroll-tax/calculate/rates-thresholds/)
+- Base-rate-entity 25% / <$50M turnover / ≤80% BREPI — [ATO company tax rate changes](https://www.ato.gov.au/tax-rates-and-codes/company-tax-rate-changes)
+- Bendel HCA 18, UPE-not-a-Div-7A-loan, s100A/Part IVA still live — [Pitcher Partners](https://www.pitcher.com.au/insights/bendel-decided-a-reset-for-upes-and-division-7a/), [Clayton Utz](https://www.claytonutz.com/insights/2026/june/high-court-decides-against-commissioner-on-extended-loan-definition-in-division-7a)
+- SG 12% from 1 Jul 2025, max contribution base $62,500/qtr — [ATO maximum contributions base](https://www.ato.gov.au/businesses-and-organisations/super-for-employers/payday-super/paying-super-on-payday/what-payments-are-qualifying-earnings/maximum-contributions-base)
+- 30% trust minimum tax announced 12 May 2026, commencing 1 Jul 2028, 3-year restructure rollover — [ATO new-legislation](https://www.ato.gov.au/about-ato/new-legislation/in-detail/businesses/tax-reform-introducing-a-minimum-tax-on-discretionary-trusts), [Pitcher Partners](https://www.pitcher.com.au/insights/federal-budget-2026-27-minimum-tax-on-discretionary-trusts/)
+- s15AA real-substance test (26 Aug 2024) + sham-contracting reasonableness defence — [Fair Work Ombudsman](https://www.fairwork.gov.au/about-us/workplace-laws/legislation-changes/closing-loopholes/independent-contractor-changes)
+
+---
+
+## 6. Knight Photography + the entities (Butterfly, farm, holdco, final BAS)
+
+> Expert technical analysis, built to the standard Standard Ledger (SL) would. SL is the registered tax agent and formally ratifies + lodges every item (legally required) — but each answer below is complete so Ben can confirm or challenge it, not act on it blindly. Anything genuinely aggressive (Part IVA) is flagged plainly. Australian FY = Jul–Jun; today 20 Jun 2026; EOFY 30 Jun 2026. Every dollar figure is illustrative until SL plugs in the real numbers.
+
+---
+
+### Q: Is Knight Photography a sole trader or a partnership? (Correct the record.)
+**The answer:** Knight Photography is **Ben's sole trader business** — one individual, trading under a business name on his own ABN — **not** a partnership. Correct the "partnership" label wherever it appears; a partnership needs two or more genuine partners carrying on business in common with a view to profit, and there isn't a second partner.
+
+**Why:** A partnership exists only where two-plus persons carry on a business together and share its profits and losses (Partnership Act / ATO partnership tests). KP is Ben performing photography (and dev/strategy) and invoicing for it — a one-person enterprise, which is the definition of a sole trader. Mislabelling it a "partnership" would force a separate partnership ABN, a partnership tax return, and a notional profit-split to a second partner — and because KP income is **personal services income** (it's a reward for Ben's personal efforts and skills), the PSI rules and PCG 2025/5 would claw any split straight back to Ben anyway (see PSI answer below). A partnership label buys **zero tax saving and adds Part IVA risk and admin** — it's wrong on the facts and wrong on the strategy.
+
+**The numbers:** No dollar impact from the correction itself — it's a labelling fix. It removes the cost of a needless second tax return (~$500–1,500/yr in agent fees) and removes the audit risk that a notional partner split would create.
+
+**The ONE thing SL still needs:** Confirmation that **no partnership ABN was ever registered for KP** (a quick ABN-lookup) and **how the Sept-2025 ~$100K of KP income was actually booked** in the records — so the historic returns are corrected to "sole trader, all income Ben's" if anything was mis-recorded.
+
+**Plain English — what this means for you:** Knight Photography is just *you*, trading under a name. We fix the word "partnership" in the file. Nothing changes about how you invoice or get taxed — your KP income was always yours.
+
+---
+
+### Q: How does KP handle the PSI rules — given ACT is essentially its only client?
+**The answer:** KP **fails the 80% rule** (one client — ACT — supplies well over 80% of the income), which automatically **locks out** the unrelated-clients, employment, and business-premises tests. That leaves the **results test as the only self-assessment route** to being a Personal Services Business — and KP passes it only by being run on **results-based contracts (paid for a delivered result), using its own gear, with liability to fix defects at its own cost**.
+
+**Why:** Under the ATO's PSI framework, if 80% or more of your PSI comes from one client and its associates, you **cannot** self-assess via the other three PSB tests — you either meet the **results test** or you're caught by the PSI rules (and would need a formal PSB determination from the ATO to escape, which isn't worth pursuing here). The results test requires all three conditions to be met for **at least 75% of the PSI**: (1) paid to produce a **result**, not for hours worked; (2) you **supply your own plant/tools** needed to do the work (auto-satisfied where none are needed); (3) you're **liable to rectify defects** at your own expense. Photography passes this naturally — Ben is paid for delivered photos, owns his cameras and rig, and a standard reshoot/defects clause covers limb 3. The **marginal leg is the dev/strategy/platform work** (EL, CivicGraph, JusticeHub), which is too easily "paid for time" — so the KP→ACT contracts must be deliberately framed as **per-milestone deliverables** with a defects-rectification clause, or that portion risks failing the results test. The 80%-rule lockout is settled ATO practice for FY2025-26 ([ATO — self-assessing as a PSB](https://www.ato.gov.au/businesses-and-organisations/income-deductions-and-concessions/personal-services-income/working-out-if-the-psi-rules-apply/self-assessing-as-a-psb); [TR 2022/3](https://www.ato.gov.au/law/view/view.htm?docid=%22TXR%2FTR20223%2FNAT%2FATO%2F00001%22)).
+
+**The numbers:** **Failing PSI in FY26 is low-consequence.** KP is a **sole trader** in FY26, so even if the PSI rules apply there is **no attribution** (the income is already Ben's) and **no rate change** — the only effect is a minor **deduction limitation** (employee-equivalent: home-occupancy and certain associate payments denied). On ~$250K of income that's roughly **<$2K of denied deductions** — immaterial. The cost only becomes real in **FY27+ if the income is ever routed through the Pty or a trust** — then both attribution *and* PCG 2025/5 splitting risk bite.
+
+**The ONE thing SL still needs:** KP's **actual client-revenue split** (ACT vs any others) per year to confirm the 80% trip, and the **contract wording** for the non-photography work — so SL can characterise each engagement against the results test (deliverable-based vs hourly).
+
+**Plain English — what this means for you:** Because ACT is basically KP's only customer, the simple escape hatches are shut — KP stays clean only if you bill for **finished deliverables** (not hours), use **your own gear**, and **carry the risk of fixing stuff-ups**. Get that into the contracts and you're fine. And if you miss it in FY26, it barely costs anything — the real discipline is for FY27.
+
+---
+
+### Q: Should Ben's personal-services income ever be routed through the trust (or the Pty) to split it?
+**The answer:** **No — never.** Routing Ben's personal-services income through the Knight family trust (or retaining it in the Pty) to split or defer it is **Part IVA territory** and is exactly the arrangement the ATO targets. Ben's KP income stays Ben's; the founders are paid **salary** for their services.
+
+**Why:** PSI is, by design, income from Ben's **personal exertion** — it can't be genuinely "earned" by a trust or company that didn't perform the services. **PCG 2025/5** (finalised 28 Nov 2025) reaffirms the ATO's long-held view that **satisfying the PSB tests does NOT entitle you to split the profit** away from the individual whose services generated it — and it sets out a risk framework where retaining profit in the entity or distributing to associates who provide little service is **high-risk and Part IVA-exposed** ([Moore Australia on PCG 2025/5](https://www.moore-australia.com.au/news/understanding-pcg-2025-5-atos-compliance-approach-to-psi-and-part-iva/); [ATO PCG 2025/5](https://www.ato.gov.au/law/view/view.htm?docid=%22COG%2FPCG20255%2FNAT%2FATO%2F00001%22)). The defensible posture is **salary-first** — pay Ben (and Nic) a salary reflecting the **commercial value** of their services, with the trusts as **purely passive shareholders** receiving only dividends/franking, never attributed PSI. PCG 2025/5 gives a **genuine-attempt transition runway to 30 June 2027** to land in the low-risk zone — use it.
+
+**The numbers:** The amount at risk if mis-structured is roughly **$25–30K/yr of tax benefit** that the ATO could unwind under Part IVA, plus penalties and interest. The salary-first answer costs nothing and is the **low-risk** position — provided the salary genuinely reflects commercial value and isn't suppressed to leave splittable profit behind.
+
+**The ONE thing SL still needs:** Sign-off that the **FY27 founder salary ($120K each) reflects the commercial market value** of Ben's and Nic's services (so it sits in the PCG 2025/5 low-risk zone), and a documented genuine-attempt-by-30-Jun-2027 file.
+
+**Plain English — what this means for you:** Don't try to push your photography/consulting pay through the trust to save tax — the ATO will reverse it and penalise it. Pay yourselves a proper **salary** instead. The trusts just hold shares and receive dividends; they never "earn" your personal work.
+
+---
+
+### Q: Is ACT's tax deduction for paying Knight Photography safe?
+**The answer:** **Yes — completely safe**, regardless of how KP's PSI shakes out, as long as the charge is **arm's-length / market value** and genuinely for services ACT received.
+
+**Why:** The PSI rules govern only **how the supplier (Ben) is taxed** — they never touch the **payer's** deduction. ACT's deduction for paying KP is an ordinary **s8-1** business deduction (expense incurred in carrying on the business to produce assessable income). So even if KP fails every PSI test, that has **zero effect** on ACT being able to deduct what it pays KP. The only conditions are that the payment is real, at market value (not inflated to shift profit), and supported by invoices/contracts. This is independent of — and must not be confused with — the separate question of whether KP-routed work is **R&D-eligible** for ACT (that's the pre-24-April sole-trader-period issue, answered in the R&D cluster; likely "no" for pre-incorporation work).
+
+**The numbers:** No exposure on the deduction itself. Keep the charge at market value; if it were inflated, the *excess* could be challenged — but the base deduction is secure.
+
+**The ONE thing SL still needs:** Confirmation the **KP charge-out rate is market-supported** (a simple benchmark of comparable photography/dev rates), so the deduction can't be attacked as non-arm's-length.
+
+**Plain English — what this means for you:** ACT paying KP is a normal, fully deductible business cost — that doesn't change no matter what happens with KP's own PSI status. Just keep the price fair and the paperwork real.
+
+---
+
+### Q: Should KP register for GST / backdate it?
+**The answer:** **Yes — register, backdating to the first breach** of the $75K threshold (around the 30 Sep 2025 ~$100K invoice, or 1 Jul 2025 if SL prefers conservative). Between two GST-registered entities (KP and ACT) **the net effect is a wash** — a timing/cashflow matter, not a real ~$25K cost.
+
+**Why:** GST registration is **compulsory** once turnover hits **$75K** (unchanged since 2000), with a 21-day window; the ATO will **backdate** registration to the date you were required to register and assess GST on sales from then (up to 4 years back) ([ATO/austax GST threshold](https://austax.tools/gst-registration-threshold-75000-australia/)). KP plainly crossed $75K. But because **ACT is itself GST-registered**, every dollar of GST KP charges ACT, **ACT claims straight back as an input tax credit** — the two cancel out across the group. So the "cost" is purely the **timing** of remitting vs reclaiming, not a permanent ~$25K hit. Registering and backdating cleans up the compliance gap cheaply. (Note: the prior invoices need checking — if they were issued GST-*exclusive*, KP wears the 1/11th on the backdated period unless it can re-issue; that's the only live cashflow question.)
+
+**The numbers:** **Net ~$0 economic cost** between two registered entities — it's a **wash**. The only real-money question is whether KP's already-issued invoices were GST-inclusive or exclusive (a 1/11th timing cost on the gap period if exclusive, recoverable as ACT's credit either way).
+
+**The ONE thing SL still needs:** Whether KP's **issued invoices were GST-inclusive or GST-exclusive**, and the exact effective registration date — to set the backdate and confirm the input-credit netting leaves nothing stuck.
+
+**Plain English — what this means for you:** KP should've been GST-registered once it passed $75K — so we register and backdate it. Because ACT claims back the GST KP charges, it all nets out; this is paperwork tidy-up, not a real cost.
+
+---
+
+### Q: How does The Butterfly Movement (Goods) sit relative to the group — under a holding company, or beside it?
+**The answer:** Butterfly sits **BESIDE the group**, connected by **arm's-length agreements** (services, grant, asset-use) — **not under a holding company**, and not as a subsidiary. It's a charity limited by guarantee: it has **members, not shares**, so there is **nothing to "own"**, and asserting control would threaten its **PBI/DGR and charity status**.
+
+**Why:** A company limited by guarantee (CLG) has **no share capital** — a share-subsidiary is **mechanically impossible**; there are no shares for a holdco to hold ([ACNC — charitable CLG](https://www.acnc.gov.au/tools/templates/charitable-company-limited-guarantee-constitution-template)). Beyond the mechanics, Butterfly's value to the ecosystem **is** its endorsed **PBI + DGR** status (held since 2012) and its **Indigenous-led board** — and that status depends on it being **independent and run for its charitable purpose**, governed by its own board, not deployed for the founders' or a for-profit group's benefit. If ACT (a for-profit group) exercised **control** over a charity, that's a textbook integrity risk to the PBI/DGR endorsement and an ACNC governance concern. So the correct architecture is: Butterfly **standalone**, connected by **genuinely arm's-length** written agreements (e.g. ACT provides services to Butterfly at market rate; Butterfly receives grants; community-owned plant under documented terms), with the **Indigenous-led board directing deployment** (OCAP). Inter-entity GST needs care — a DGR/PBI charity recovers input credits only to the extent inputs support taxable activity, so a management fee may carry **partially non-recoverable (stuck) GST**, while genuine grants carry no GST.
+
+**The numbers:** No equity value flows either way (charity assets are locked to charitable purpose — they can't be distributed to founders). The one real cost is **inter-entity GST**: up to roughly **~$9K/yr non-recoverable** on a $100K management fee if much of Butterfly's activity is grant-funded/non-enterprise. Characterise each flow as **grant (no GST)** vs **fee (GST, partial credit)** to minimise it.
+
+**The ONE thing SL still needs (and the charity/DGR lawyer):** Butterfly's **constitution + member/director list at the 26 June handover**, and a review that **none of the draft inter-entity agreements (or any appointment right) compromises the PBI/DGR/ACNC standing** — the lawyer items to close **before the 26 June handover**.
+
+**Plain English — what this means for you:** Goods/Butterfly is a charity that **can't be owned** — it has members, not shares. Sit it **next to** the group and work with it through fair, market-rate agreements its own Indigenous-led board signs off. Don't try to put it under a parent company or control it — that would put its charity tax status at risk. Get the lawyer to lock the agreements before 26 June.
+
+---
+
+### Q: The farm — should it be an entity or stay personal?
+**The answer:** **Keep it personal in Nic's name.** Accommodation/stay income goes in Nic's individual return; any lease of the farm to an ACT entity must be **documented at market rate**.
+
+**Why:** The farm is already held in Nic's name (resolve any lingering canon ambiguity between "personal name" and "family trust" — that's a title check). Keeping it personal **avoids** triggering **QLD transfer duty + CGT** that moving the land into a company or super fund would cause, with no offsetting concession. It keeps the land **out of the trading entity's liability perimeter** (the operating risk sits in ACT Pty / Harvest Pty, not against the land). If an ACT entity uses the farm (e.g. Harvest), document a **market-rate lease** — QLD **abolished lease duty in 2005**, so a market-rent lease with no premium and no reversion option attracts **NIL duty** — but the rent must be arm's-length so it's deductible to the tenant and properly returned by Nic, and so it doesn't create a non-commercial-loss or Part IVA issue. An SMSF holding the farm is **not viable now** (balances below the ~$200K viability floor; lumpy/illiquid asset).
+
+**The numbers:** Keeping it personal **saves the duty + CGT** that a transfer would crystallise (potentially five figures on the land value). Any lease is duty-free; the only figure is the **market rent**, which is a deductible cost to the tenant and assessable income to Nic — broadly neutral if set correctly.
+
+**The ONE thing SL still needs:** The **land title** (personal name vs family trust — resolve definitively), and the terms of **any existing or proposed lease + accommodation income**, to confirm the market-rate treatment and Nic's return.
+
+**Plain English — what this means for you:** Leave the farm in Nic's own name — moving it would cost duty and capital gains tax for no benefit, and it keeps the land safe from business risk. If an ACT business uses it, just sign a normal market-rent lease.
+
+---
+
+### Q: Should the group elect tax consolidation?
+**The answer:** **No.** Tax consolidation requires a **wholly-owned (100%) group**, which ACT isn't — and even if it qualified, it's not worth the cost at this scale.
+
+**Why:** A tax-consolidated group needs an Australian-resident head company owning **100%** (directly or indirectly) of each subsidiary; consolidation is an **"all-in," irrevocable** choice across every wholly-owned resident entity ([ATO — consolidation eligibility](https://www.ato.gov.au/businesses-and-organisations/corporate-tax-measures-and-assurance/consolidation/eligibility)). The group **fails this at the gate**: Harvest Pty is planned with an **external minority** (the landlord), so it's not 100%-owned; and the two family trusts sit *above* ACT Pty as shareholders, not as a corporate head company beneath which everything is wholly owned. Consolidation also brings a heavy compliance load (Allocable Cost Amount calculations on entry/exit) that **outweighs the benefit** for a group this size. So it's a clear no — revisit only if the structure ever becomes a genuine 100%-owned corporate chain.
+
+**The numbers:** No benefit forgone (the group can't consolidate anyway). Avoids the ACA-calculation and ongoing compliance cost (several $K/yr) that consolidation would add.
+
+**The ONE thing SL still needs:** The **final Harvest cap table** (confirming the external minority) — formally documenting that the 100% test fails and consolidation is off the table.
+
+**Plain English — what this means for you:** "Consolidating" the group for tax only works if you own everything 100% — you won't (Harvest has an outside shareholder, and the trusts own the shares, not a parent company). So we don't consolidate. Nothing to do.
+
+---
+
+### Q: The holding company — set it up now, or later?
+**The answer:** **Later.** Let ACT Pty trade from 1 July; build a holdco **only when a raise or sale actually needs one**, via a **Division 615 share-for-share rollover** that drops a new holding company *above* the existing Pty. The current **50/50 two-trust ownership satisfies Div 615** cleanly.
+
+**Why:** A Div 615 rollover lets the shareholders swap their shares in ACT Pty for shares in a new interposed holdco **with no CGT**, provided: (a) **all** shares in the original company are exchanged; (b) consideration is **only** shares in the holdco and **nothing else**; (c) the holdco ends up owning **100%** of ACT Pty; and (d) **each member's proportionate interest in the holdco equals their proportionate interest in the original company** (s615-20(2)) ([BDO / Lexology on Div 615](https://www.bdo.com.au/en-au/insights/tax/technical-updates/division-615-rollovers-courts-provide-helpful-guidance-for-capital-gains-tax-(cgt)-rollover-relief)). With the register holding **only the two family trusts at 50/50**, each trust swaps its 50% in ACT Pty for 50% in the holdco — proportions preserved, "nothing else" satisfied — so it works **whenever** ACT needs it, with **no disturbance** to contracts, the R&D registration, the name, or the bank accounts. Doing it **now** adds cost and complexity for no benefit; doing it **later** (when QBE matching, a CivicGraph spinout, or a sale needs a clean parent) preserves all the flexibility. The s615-65 **choice must be made within ~2 months** of the rollover when it happens.
+
+**The numbers:** Building it now = wasted setup + ongoing cost for an unused entity. Building it later via Div 615 = **NIL CGT, NIL marketable-securities duty** (QLD has none), so deferring costs nothing and keeps the option free.
+
+**The ONE thing SL still needs:** Confirmation the share register holds **only the two trusts' 50 each and nothing else** (no other share classes, no options) — the Div 615 "nothing else" condition — at the point a holdco is actually inserted.
+
+**Plain English — what this means for you:** Don't bother with a parent holding company yet. Trade from the Pty. If a future deal or raise needs a holdco on top, you can slot one in later with no tax cost — your clean 50/50 ownership makes that easy.
+
+---
+
+### Q: When is the final sole-trader BAS due, and what's the cancel-registrations sequence?
+**The answer:** Nic's final sole-trader BAS is the **Q4 FY26 (Apr–Jun 2026) quarter**, due **28 July 2026** if self-lodged, or **~25 August 2026** if a BAS/tax agent lodges it under the lodgement-program concession. (The "28 Oct" date floating in earlier drafts is **wrong**.) Then cancel registrations **in order — GST, PAYG withholding, ABN last** — and only **after** all final obligations are met.
+
+**Why:** The June quarter BAS is due **28 July**; registered agents get a **two-week concession to 25 August 2026** for the June quarter ([BAS due dates 2025-26](https://atotaxrates.info/businesses/bas-statement/bas-statement-due-dates/); [tax-agent concession](https://42advisory.com.au/42-advisory-blog/key-ato-due-dates-bas-payg-fbt-super-tpar)) — so SL lodging gives the extra fortnight. The ATO's own cessation guidance sets the **sequence**: lodge the **final BAS** (including any GST adjustment on equipment Nic keeps personally — a **Division 138** increasing adjustment of 1/11th of market value), finalise **PAYG withholding (STP)** and any **TPAR**, then **cancel GST**, then **cancel PAYG withholding** (must be cancelled before the ABN), then **cancel the ABN last** (within 28 days of ceasing, but only after every lodgement/payment obligation is met) ([ATO — cancelling business registrations](https://www.ato.gov.au/businesses-and-organisations/starting-registering-or-closing-a-business/changing-selling-or-closing-your-business/cancelling-business-registrations)). **Keep the bank account open** for run-off (late debtor receipts, final supplier payments). Note: equipment *sold into* the Pty inside a going-concern transfer is a GST-free **supply**, not a Div 138 adjustment — Div 138 only bites on assets Nic **keeps for private use**.
+
+**The numbers:** No tax cost to the sequencing itself. The one real figure is the **Div 138 GST adjustment** on any equipment Nic keeps personally (**1/11th of market value** on the final BAS) — depends on which gear he retains.
+
+**The ONE thing SL still needs:** Confirmation Nic's **lodgement history qualifies for the 25-Aug agent concession** (else it's 28 Jul), the **list/value of equipment** he keeps personally (for the Div 138 adjustment), and that **PAYGW STP is finalised** before cancellation.
+
+**Plain English — what this means for you:** Your last sole-trader BAS is the April–June quarter — due 28 July, or ~25 August if SL lodges it for you. Then cancel things **in order: GST → PAYG withholding → ABN (last)**, and only once every final return is in. Keep the bank account open a while so late money in and out still has somewhere to land.
+
+---
+
+*Expert technical analysis for SL to formally ratify + lodge — not lodged advice. Every rate/threshold/date carries a current FY2025-26 ATO or QLD source above. Built 2026-06-20 from the round-1–3 EOFY research pack + fresh ATO/QLD web verification.*
+
+Files: source pack at `/Users/benknight/Code/act-global-infrastructure/thoughts/shared/plans/2026-06-19-eofy-decision-pack.md` (C5, C7), `/Users/benknight/Code/act-global-infrastructure/thoughts/shared/plans/2026-06-19-eofy-round3-compliance-detail.md` (Lanes 1, 5, 8), and `/Users/benknight/Code/act-global-infrastructure/thoughts/shared/drafts/2026-06-19-standard-ledger-eofy-questions.md`.


### PR DESCRIPTION
## What this is

**The Answered Case** — every question in the Standard Ledger email, **answered** as the expert rather than left as a question to wait on. For each: the answer · why (+ law/cites) · the numbers · the one thing SL still needs from you · plain-English "what it means for you". Built across 4 research rounds (decision pack #196, options + round-3 #198, money-movement plan #195) + an adversarial skeptic pass.

So Ben can *understand* each answer and confirm it or push back — not wait blind. SL still formally ratifies + lodges (legally required of a registered agent).

## Skeptic fixes applied before merge

- **Super carry-forward** corrected to reach back to **2020-21, not 2018-19** (~$112.5K max, not "$150K+").
- **CGT-shelter double-count** fixed: for under-55 founders the small-business **retirement-exemption slice must be paid INTO super**, so it is not all drawable as a vendor loan — re-figured inline (~$225K drawable + $75K to super on the $300K example, not $300K all in-pocket).
- **Confidence banner up top:** three answers open "GO/YES" but are genuinely SL's formal calls, not settled — the **sell-vs-journal-entry fork**, the **tax-free vendor-loan drawdown** (Part IVA exposed), and the **Path C R&D** re-frame (private ruling near-essential).

Skeptic verdict on the rest: **sound + web-verified** — the R&D paid-in-cash rule, the franking-debit reality, the Div 7A direction, GST going-concern, the QLD duty scale, Bendel, and the Div 293 maths.

## Note

Docs only — no code, schema, or migrations. For SL/lawyer to ratify; not lodged advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
