### PR TITLE
docs(eofy): aligned day-by-day next-week action plan (run to 30 June)

### DIFF
--- a/thoughts/shared/runbooks/eofy-next-week-action-plan.md
+++ b/thoughts/shared/runbooks/eofy-next-week-action-plan.md
@@ -1,0 +1,131 @@
+# EOFY 2026 — Next Week, Day by Day (the run to 30 June)
+
+> The single aligned action plan: every action across the EOFY pack, sequenced by day, each with **owner · what it unblocks · done-when**. Built 2026-06-20 by an alignment workflow + skeptic pass (7 completeness/specificity fixes applied: corporate-trustee, supply-day-tied GST, corrected super years, valuation-now, QBE ring-fence, PPSR, Child-Safe). Companion to the playbook + The Answered Case. SL ratifies + lodges — the founders' job is the list below.
+
+## Next week — the run to 30 June (day by day)
+
+> **THE CRITICAL PATH (everything hangs off this one chain):**
+> 1. **TODAY** — Ben sends the Standard Ledger (SL) email + books the Monday call; Ben+Nic lock Decision 1 in writing; the open-day insurance is bound. Nothing money-related moves until SL rules.
+> 2. **Mon 22 Jun** — the SL call rules the 7 gating questions (transfer mechanism · R&D $ + % · Nic's super · Knight Photography/GST · Nic's salary figure · Path C wording · pre-30-June deductions). Each ruling unblocks exactly one money move.
+> 3. **~Wed 24 Jun** — super *sent* (fund must RECEIVE by 30 Jun).
+> 4. **Tue 30 Jun** — R&D founder wages physically PAID out of the Pty (cash, not a journal — the one irreversible lever). Then AusIndustry registration by 30 Apr 2027 locks the refund.
+>
+> **SL is the registered tax agent — they ratify and lodge. The founders' job is the short list of actions below.** Nothing appears before the thing that unblocks it.
+>
+> **Genuinely TODAY (Sat 20 Jun):** (1) the open-day Public Liability — above every tax move; (2) send the SL email + book the call; (3) lock Decision 1 in writing (also: both founders pull myGov super screens).
+> **Hard deadlines that bite:** super *sent* ~Wed 24 Jun (received by 30 Jun) · R&D wages *paid* by Tue 30 Jun · trustee resolutions signed 30 Jun · AusIndustry R&D registration by 30 Apr 2027 (miss = forfeit the whole FY26 claim).
+
+---
+
+### TODAY — Saturday 20 June (the open day + unblock everything)
+
+- **Ben+Nic** — Before the gates open, phone the broker and ask for a **same-day single-event Public Liability binder for today's Harvest open day, explicitly declaring children present + food service + farm/animals, and confirm there is NO children/youth-activity exclusion, NO abuse/molestation exclusion, and the entity name is correct.** Do NOT rely on the standing policy (mis-rated as "performing artist", wrong entity name, excludes event management, carries an abuse exclusion) and do NOT buy a cheap online one-off (LCIS-type products explicitly exclude children's activities). → **unblocks:** running the open day insured instead of effectively uninsured (a child-injury/abuse claim otherwise lands on the directors personally, six-to-seven figures) · **done when:** a written binder/COC naming A Curious Tractor Pty Ltd is in hand by email, OR (fallback) you've stripped the children/animal/live-fire/cafe elements, run an adults-and-families gathering, and written down the scope cut.
+- **Ben** — Confirm the **Witta landlord's own Public Liability is current** and note ACT as an interested party if the lease requires it. → **unblocks:** closes the landlord-side gap on the day · **done when:** landlord PL sighted or confirmed by text.
+- **Ben** — **Send the Standard Ledger email** (`thoughts/shared/drafts/2026-06-19-standard-ledger-eofy-questions.md` — fill in `[name]` first; attach the answered-case so SL ratifies rather than re-derives) and in the same email **ask SL to book the call for Monday 22 June**. → **unblocks:** every ruling and every money move next week · **done when:** email sent AND a call time is in the calendar.
+- **Ben+Nic** — **Lock Decision 1 in writing**: "the operating entity is A Curious Tractor Pty Ltd — trade from the Pty from 1 July; interpose a holding company later (Div 615) only if a raise/sale needs it; the subsidiary hive-down is rejected." Record it as a dated, signed-off paragraph in `wiki/decisions/`. → **unblocks:** every novation letter and every from-1-July contract name (standing rule: no letters until this is locked) · **done when:** both founders have signed it off in the file.
+- **Ben+Nic** — Each log into **myGov → ATO → Super** and read off two numbers: your **total super balance at 30 June 2025** (is it under $500K?) and your **available carry-forward (unused concessional) amount** — for an FY26 contribution the reachable years are **2020-21 → 2024-25 (~$112.5K theoretical max); 2018-19 and 2019-20 have EXPIRED**, so do NOT plan against the old $167,500 ceiling, and note 2020-21's unused cap expires at the END of FY26 (use-it-or-lose-it). Screenshot both and send to SL. → **unblocks:** sizing the super decision (whether either of you can put in more than $30K) — SL cannot rule on carry-forward without these · **done when:** both numbers captured for each founder and sent to SL.
+- **Nic** — Get the **NAB Pty bank account live** (or confirm the date it goes live). → **unblocks:** the seed loan, the R&D-window wage payments, Xero, and 1 July trading · **done when:** account number issued and able to receive/send.
+
+---
+
+### Sunday 21 June (prep — no money moves)
+
+- **Ben+Nic** — Write a **contemporaneous R&D activity log for 24 Apr → 30 Jun**, honestly mapping each founder's hours to specific R&D activities (the experiments resolving real technical uncertainty) vs supporting work vs management/admin/sales. Reconstruct now from calendars/git commits/notes while the window is live. Do NOT start from "90%" and work back — let the log set the percentage (illustrative ceiling Ben ~85%, Nic ~30%). → **unblocks:** the R&D apportionment % SL needs to size the 30 Jun wage payment · **done when:** a per-founder week-by-week hours table exists across the 10-week window, ready for SL.
+- **Ben** — Draft the **Path C engagement letters + a board minute** worded as *"from 24 Apr 2026 the Pty engages the founders to conduct registered R&D for the Pty"* (NOT "the sole trader does R&D on behalf of the Pty"), with the IP-assignment effective date noted as before the work. → **unblocks:** the R&D claim surviving audit; the 30 Jun wage payment being attributable to the Pty · **done when:** dated engagement letters + board minute drafted, ready for SL to finalise.
+- **Nic** — Find and write down **your super fund's published EOFY contribution cut-off date** (often a few business days before 30 Jun) and confirm you hold the cash to contribute. → **unblocks:** the real "send-by" date for the super move · **done when:** the fund's cut-off date is known and noted against Wednesday.
+
+---
+
+### Monday 22 June — the SL call: lock the rulings (no money moves today)
+
+> On this call SL formally rules each item; each ruling unblocks one money move later in the week. Bring: both founders' myGov screens, the R&D activity log, Nic's net business-profit figure, and the collected-cash vs receivables position.
+
+- **SL** — **Ruling 1 — transfer mechanism (SL's #1 call):** for the 50/50 two-family-trust structure, confirm the path — neither Subdiv 328-G (fails the unchanged-economic-ownership test) nor Subdiv 122-A (needs 100% to Nic) fits, so the recommended fork is a **market-value SALE of the business (goodwill + IP + plant), gain sheltered by the 50% discount + Div 152, price left owing to Nic as a tax-free vendor loan.** → **unblocks:** the cutover, the founder vendor-loan, the duty + GST treatment · **done when:** SL states the chosen mechanism in writing.
+- **SL** — **Ruling 2 — Nic's super:** confirm the $30K concessional cap is unused and model the **Division 293** stack (does his real profit + recharacterised salary + the contribution cross $250K?) → go/no-go on $30K, and whether carry-forward lets him exceed it. → **unblocks:** the ~24 Jun super contribution · **done when:** SL gives a dollar figure to contribute.
+- **SL** — **Ruling 3 — R&D $ to pay + apportionment %:** from the activity log, set the genuinely-R&D founder-wage amount to physically pay (illustratively ~$45–60K total: Ben ~$37–44K, Nic ~$12–15K) and the defensible % per founder (haircut toward ~85% Ben / ~30% Nic). → **unblocks:** the 30 Jun R&D wage payment · **done when:** SL gives the per-founder paid-wage figure.
+- **SL** — **Ruling 4 — Knight Photography:** confirm sole trader (not partnership), the **results-test** PSI posture (ACT is >80% of revenue so the other PSB tests are locked out), and **GST registration backdated** to the first $75K breach (~30 Sep 2025). → **unblocks:** Ben's KP invoices + Ben's super top-up · **done when:** SL confirms KP legal form + GST date.
+- **SL** — **Ruling 5 — Nic's arm's-length director-salary figure** for the drawings→salary recharacterisation (the $200K is a placeholder). → **unblocks:** Nic's R&D-window amount + the cutover journal · **done when:** SL sets the figure.
+- **SL** — **Ruling 6 — Path C mapping** accepted for AusIndustry (the Pty engages the founders for its R&D from 24 Apr), and **decide whether to seek a private ruling** given entity-attribution is in the ATO's most-audited area. → **unblocks:** the FY26 R&D registration · **done when:** SL confirms the wording + the private-ruling call.
+- **SL** — **Ruling 7 — pre-30-June deductions:** confirm the $20K instant-asset write-off + the 12-month prepayment rule, and **flag the trap** — assets that transfer to the Pty get clawed back as a Div 40 balancing charge, so prepayments are the clean lever, not new asset buys. → **unblocks:** the discretionary spend · **done when:** SL confirms which spend is a genuine win.
+- **SL** — **Commission the one independent goodwill + IP + plant valuation NOW** — it's the long-pole blocker: the sale price, the vendor-loan balance, the Div 152 shelter, the QLD duty base AND the equipment GST adjustment all wait on it. → **unblocks:** the entire sale/duty/loan chain · **done when:** the valuer is engaged this week.
+- **SL / Lawyer** — **Confirm each family trust uses a CORPORATE trustee** — and if not, switch BEFORE the Pty share subscription is minuted (amend trustee only, never a beneficiary-class change → resettlement; s117 duty-free + CGT-free). → **unblocks:** a clean, duty-safe cap table for the whole restructure · **done when:** trustee form confirmed or switched.
+- **SL / Lawyer** — **Decide whether to PPSR-register the seed/vendor loan** (secured-creditor protection vs complicating a future raise via subordination) — decide BEFORE the loan note is drafted Tuesday. → **unblocks:** Tuesday's loan-note terms · **done when:** the PPSR decision is made.
+- **Ben+Nic+SL** — **Go/no-go talk-through** at the end of the call: confirm SL's answers, current bank balances, collected-vs-receivable cash, and the after-tax targets. No transfers today. → **unblocks:** Tuesday's actualise day · **done when:** every planned transfer has a confirmed dollar figure and a green light or a documented hold.
+- **Ben** — Phone the broker to **bind D&O / Management Liability with a retroactive date of 24 April 2026** (the Pty has been director-unprotected since incorporation), plus Statutory Liability and Employment Practices Liability. → **unblocks:** covers the cutover decisions being made this week · **done when:** broker confirms the bind / cover note issued.
+
+---
+
+### Tuesday 23 June — actualise (the green rows only)
+
+- **Ben** — **Issue the Knight Photography FY26 invoices** SL greenlit (Phase 2 + the Q4 split + any Pty-window invoice), sole-trader→sole-trader, paid via the existing sole-trader account, applying SL's backdated-GST treatment. (Ordinary deductions to the sole trader — NOT a Pty R&D lever.) → **unblocks:** recognising Ben's FY26 income; feeds the drawings/cash sizing · **done when:** invoices raised in Xero and sent.
+- **Nic+Ben** — **Sole trader pays Ben + Nic their FY26 drawings**, sized to *collected* cash (check the real bank balance, not the debtor list — the docs don't reconcile the uncollected figure). → **unblocks:** founder FY26 cash extraction at the marginal rate · **done when:** transfers cleared and matched to invoices/notes.
+- **Nic+Ben** — **Seed the Pty by a director loan ($75–100K)** from Nic, with a **signed loan note and separate loan accounts**. → **unblocks:** the 30 Jun R&D-window wage payments (the Pty needs cash to pay them) · **done when:** money is in the Pty account and the loan note is signed.
+- **Ben+Nic** — **Capture evidence as you go:** every transfer today gets a matching invoice/note/signed paper in the Notion EOFY tracker. → **unblocks:** the R&D and cutover audit trail · **done when:** each Tuesday move has a paired document.
+
+---
+
+### Wednesday 24 June — super (the earliest money deadline)
+
+- **Nic** — **Transfer the SL-confirmed super amount (up to $30K, or the higher carry-forward figure if SL cleared it) to your super fund by BPAY/EFT today**, so the fund *receives* it before 30 Jun ("sent" is not "received" — allow 1–3 business days and respect the fund's own cut-off). → **unblocks:** the FY26 super deduction (~$9K saved) · **done when:** payment initiated and you hold the transfer receipt.
+- **Nic** — **Lodge the Notice of Intent to claim (NAT 71121) with the fund** and hold its **written acknowledgement** before rolling/withdrawing anything or lodging the return (no acknowledgement = no deduction at all). → **unblocks:** validity of the super deduction · **done when:** NAT 71121 lodged and the fund's written acknowledgement is on file.
+- **Ben** — If SL confirmed Ben's super route via Knight Photography, **make the equivalent personal contribution + lodge your own NAT 71121** on the same receive-by-30-June timing (Ben likely dodges Div 293). → **unblocks:** Ben's FY26 super deduction · **done when:** contribution sent and NAT 71121 acknowledgement held.
+
+---
+
+### Thursday 25 June — registrations + overseas finding
+
+- **SL+Ben** — **Register the Pty for GST + PAYG-withholding, effective on or before the transfer/supply day** (ABN 36 697 347 676 already issued). GST registration on the day is what makes the going-concern exemption hold — it cannot be backdated. **⚠️ The supply/cutover day is a TARGET that may honestly slip into July — if it does, the GST effective date AND the going-concern clause's signing date must still bracket whatever the real supply day turns out to be. Never backdate either.** → **unblocks:** the GST-free going-concern transfer + the first payrun · **done when:** GST + PAYGW registrations are live with an effective date ≤ supply day.
+- **Lawyer (via SL)** — Draft the **written going-concern clause (s38-325)** for the transfer agreement, to be signed on/before the supply day; confirm the vendor-loan satisfies "for consideration". → **unblocks:** a transfer with no GST to fund (~$7–27K timing saved) · **done when:** the clause is drafted and ready to sign on the supply day.
+- **R&D consultant+SL** — If claiming overseas R&D from the World Tour, **lodge the AusIndustry Overseas Finding before the 27 June departure** (pitch-only on the trip; sign nothing in-country). → **unblocks:** the FY27 overseas R&D claim · **done when:** the Overseas Finding application is lodged.
+
+---
+
+### Friday 26 June — Butterfly / Goods handover + discretionary spend
+
+- **Ben + DGR/charity lawyer** — Close the **Butterfly (Goods) handover lawyer items**: confirm Butterfly sits *beside* the group at arm's length (a charity limited by guarantee — members not shares, can't be owned; already endorsed DGR+PBI since 2012, governed by its own Indigenous-led board); confirm no inter-entity agreement or appointment right compromises its PBI/DGR/ACNC standing; and characterise each money flow as grant (no GST) vs fee (GST). → **unblocks:** the 26 Jun handover; the Goods commercial relationship · **done when:** the lawyer signs off the agreements and the member/director list is confirmed.
+- **Ben+Nic** — Make any **genuine pre-30-June discretionary spend** SL cleared — **prepay genuine FY27 costs** (insurance, SaaS, rent under the 12-month rule) at the ~47% sole-trader rate. **Do not panic-buy equipment to write it off** — gear that transfers to the Pty triggers a Div 40 balancing charge that claws the deduction back; prepayments are the clean lever. → **unblocks:** the one-shot FY26 deduction at the higher marginal rate · **done when:** prepayments paid and receipted before 30 Jun.
+
+---
+
+### Monday 29 June — last prep before cutover
+
+- **Ben+Nic** — **Finalise and sign the R&D engagement letters + board minute** (drafted Sunday, SL-reviewed Monday) so the dated paper showing the Pty commissioned the registered R&D is executed before the 30 Jun wage payment. → **unblocks:** the Path C FY26 R&D claim surviving audit · **done when:** engagement letters and board minute signed and dated.
+- **Ben+Nic** — **Final go/no-go check** with SL on the 30 Jun moves: confirm the Pty has the cash (seed loan landed), the per-founder paid-wage figure, the trustee-resolution list, and whether banking/Xero/registrations are genuinely invoice-ready for cutover. → **unblocks:** a clean Tuesday execution · **done when:** the 30 Jun action list is confirmed green or a documented honest-delay is agreed.
+
+---
+
+### Tuesday 30 June — EOFY (the irreversible cutover)
+
+- **Ben+Nic (Pty)** — **⭐ Physically PAY the genuinely-R&D slice of founder wages out of the Pty bank account — real payslip, PAYG withheld and STP-reported, super sent so the fund RECEIVES it — cash out the door before midnight.** Size it to SL's apportionment, not 100% of effort. A journal entry, a loan-account credit, or "pay then lend back" does NOT count and produces a $0 claim. This is the one irreversible lever. → **unblocks:** the entire FY26 R&D refund (~$19.5–26K) · **done when:** the bank/STP/super-clearing records show net wage actually left the Pty to each founder by 30 Jun.
+- **Ben+Nic+SL** — **Sign the trustee distribution resolutions** for the Knight + Marchesi trusts **if either trust has FY26 income** (statutory 30 Jun deadline, no extension — unsigned by 30 Jun → 47% trust tax). → **unblocks:** correct trust taxation for FY26 · **done when:** each per-trust written resolution is signed and dated 30 Jun.
+- **Ben+Nic+SL** — **CUTOVER (target 30 Jun):** sole trader stops, Pty starts. **If banking/Xero/registrations/the going-concern clause genuinely aren't invoice-ready, invoke the honest-delay rule** — keep the sole trader trading into July and cut over when ready. **Never backdate** (it breaks the GST going-concern exemption and looks like a sham). → **unblocks:** FY27 trading from the Pty · **done when:** either the cutover is clean and cleanly dated, or an honest split-year is documented — no retroactive dates.
+- **Ben+Nic** — For any genuinely-R&D amount you *can't* fund in cash by today, **consciously carry it to FY27 under s355-480 — and tell SL to tag those lines "do NOT s8-1-deduct"** (that election is irreversible and forfeits the later R&D deduction). → **unblocks:** preserving the FY27 R&D value on unpaid amounts · **done when:** SL has the carry list flagged.
+
+---
+
+### FY27 / set-up-later (after 1 July — not this week)
+
+- **Pty+SL** — **First Pty payrun, week 1 of July:** $120K/yr salary each + 12% super (~$134,400 each), payday-super cadence, founders as **employees** (never papered as contractors — that's now a serious offence). → **done when:** first payslips issued with PAYG + SG.
+- **Pty+SL** — **Open a WorkCover QLD policy before the first wage is paid**; founder-directors are excluded from compulsory cover but may elect optional working-director cover; any dev/casual is compulsory. → **done when:** policy bound and the wage declaration lodged.
+- **Broker** — **Bind the full insurance program (Part 2):** correctly-rated Public + Products Liability $20M for community events with children, PI, Management Liability/D&O (retro 24 Apr 2026), Cyber, and **named abuse/molestation cover** (Ansvar / Berkley / Community Underwriting — gated on a documented Child-Safe framework + QLD Blue Cards). Strip the performing-artist rating and the molestation exclusion. → **done when:** a program is bound with no molestation exclusion and a 24 Apr retro date.
+- **SL+valuer** — **Commission the one independent goodwill + IP + plant valuation** (capitalised maintainable earnings for goodwill; income approach for IP; WDV/market for plant) — one figure used consistently across BOTH the QLD duty return and the CGT/Div 152 calc (they pull against each other). The single biggest data gap; everything downstream waits on it. → **done when:** the valuer's apportioned report is in hand.
+- **SL** — **Run the maximum-net-asset-value ($6M) test** and confirm the Div 152 small-business CGT shelter holds; date the sale contract within FY26 to keep the 50% discount. → **done when:** MNAV calc done and the shelter confirmed.
+- **Pty+SL** — **Div 7A complying loan agreements** for any company→founder debit loans (8.37% FY26 benchmark, ≤7yr term, minimum yearly repayment) — in place before the FY26 return lodgement day. → **done when:** written agreements signed.
+- **SL** — **QLD payroll-tax grouping check** before the first payrun (ACT Pty + future Harvest share ONE $1.3M threshold; founder pay ~$269K leaves ~$1.03M headroom; stand up a group-wages tracker alerting at ~$1.1M). → **done when:** SL confirms not-yet-liable and the tracker is built.
+- **QLD duties specialist** — **Lodge the QLD transfer-duty return with QRO** (Form D2.2 / exemption 58) on goodwill + business name only (IP/plant alone aren't dutiable; ~$3.5K–$17K, not 5.75%); rule on whether the Pty has "already traded" (the restructure-exemption kill-switch). Not self-assessable. → **done when:** duty assessed and lodged.
+- **Ben + lawyer** — **Execute the IP assignment deed** (codebases, LCAA, Empathy Ledger, ALMA, JusticeHub, Goods) after an IP-clause audit of grant/partnership contracts. → **done when:** deed executed.
+- **Ben** — **Re-paper contract novations** (QBE $400K, Minderoo, Goods, EL licensing) to the Pty — and **ring-fence the QBE grant-funded R&D from the self-funded R&D before registering** (grant-funded R&D triggers a Subdiv 355-G clawback). → **done when:** contracts novated and the R&D ledger flagged by funding source.
+- **SL+lawyer** — **Book the goodwill/business-transfer journals + cross-entity P&L journals** (target August) per the chosen mechanism; treat transferring equipment as a Div 40 balancing charge (ordinary income at market value), not a CGT event — accounting only, explicitly NOT the R&D basis. → **done when:** journals booked.
+- **SL/lawyer** — **Draft the Knight Photography results-based FY27 services agreement** (per-milestone deliverables, own equipment, defects-rectification clause) so KP passes the PSI results test; document the founder salary as commercially-valued for the PCG 2025/5 low-risk zone. → **done when:** agreement drafted.
+- **Nic+SL** — **Final sole-trader BAS** (Q4 FY26, Apr–Jun) — 28 Jul if self-lodged, ~25 Aug if SL lodges under the agent concession (the "28 Oct" date in old drafts is wrong) — including any Div 138 GST adjustment on equipment Nic keeps personally; then **cancel registrations in order: GST → PAYG withholding → ABN (last)**, only after all final obligations are met. Keep the bank account open for run-off. → **done when:** final BAS lodged and registrations cancelled in sequence.
+- **R&D consultant + SL** — **Tag every R&D ledger line by funding source (grant vs self-funded) BEFORE AusIndustry registration** — QBE-grant-funded R&D is EXCLUDED from the claim (Subdiv 355-G clawback); SL models the clawback quantum (do NOT quote a fixed 18.5%). A hard predecessor of the registration below. → **done when:** the R&D ledger is flagged by funding source.
+- **Ben+Nic** — **Document the Child-Safe framework (National Principles) + confirm QLD Blue Card status** for anyone in child-contact roles — the precondition abuse-cover underwriters (Ansvar / Berkley / Community Underwriting) require before they will quote; a governance deliverable, not just an insurance line. A predecessor of binding the abuse cover. → **done when:** documented + Blue Cards confirmed, ahead of the broker submission.
+- **SL + R&D consultant** — **⭐ Register the FY26 R&D activity with AusIndustry by 30 April 2027** — hard statutory deadline, no extension; miss it and the entire FY26 claim is forfeited. Lodge the DISR registration *before* the company tax return. → **done when:** AusIndustry registration lodged and acknowledged (diarise well before 30 Apr 2027).
+
+---
+
+**Who you'll need:**
+- **SL (Standard Ledger — accountant / registered tax agent):** rules the 7 gating questions Monday, sizes every dollar figure, confirms and lodges the tax, registers GST/PAYG, runs the Div 152 / MNAV / payroll-tax-grouping calcs, and registers the FY26 R&D with AusIndustry.
+- **Broker:** the same-day open-day Public Liability TODAY, then D&O (retro 24 Apr) this week, then the full correctly-rated program incl. named abuse cover for FY27.
+- **Lawyer (SHA / charity / sale docs):** the going-concern clause, the Butterfly/Goods arm's-length agreements, the QLD transfer-duty return, the IP assignment deed, the Div 7A and KP services agreements.
+- **R&D consultant:** the Path C activity-log methodology, the Overseas Finding before 27 Jun departure, and the AusIndustry FY26 registration by 30 Apr 2027.


### PR DESCRIPTION
## What this is

The **aligned day-by-day action plan** for the run to 30 June — every action across the EOFY pack (playbook, decision pack, answered case, options, round-3, money plan) pulled into ONE specific, logical, sequenced plan a founder can just work down.

Each action carries **owner · what-it-unblocks · done-when**, in strict dependency order: send the SL email → Monday SL call rules the 7 gating questions → the money moves they each unblock (super sent ~24 Jun, R&D wages paid 30 Jun, cutover). Plus an FY27 set-up tail and a "who you'll need" list.

## Built + checked

Workflow `wf_d495eb1b-4a4` (2 candidate plans → merge → skeptic). **7 skeptic fixes folded in:**
- corporate-trustee-before-share-subscription step (was missing)
- GST registration + going-concern clause tied to the **actual supply day** (honest-delay safe, never backdated)
- corrected super catch-up years (**2020-21→2024-25, ~$112.5K**, not the stale $167,500)
- **commission the valuation NOW** (the long-pole everything downstream waits on)
- QBE grant **ring-fence** as its own pre-registration step
- **PPSR decision before the loan note**
- **Child-Safe framework + Blue Cards** as the abuse-cover prerequisite

No wrong dates, no contradictions of the locked decisions (Option A trade-from-Pty, salary-first, sale-fork is SL's call, Butterfly beside the group).

## Also

Published to Notion (EOFY Setup Tracker) and linked at the top of the founder-facing explainer page. Docs only — no code/schema. SL ratifies + lodges; not lodged advice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
