### PR TITLE
feat(civicgraph): dedicated CivicGraph client + route grant-estate reads/writes

### DIFF
--- a/apps/command-center/src/app/api/grants/[id]/draft/route.ts
+++ b/apps/command-center/src/app/api/grants/[id]/draft/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph, supabase } from '@/lib/supabase'
 import { generateEmbedding } from '@/lib/embeddings'
 import Anthropic from '@anthropic-ai/sdk'
 import { LLMClient } from '@/lib/llm-adapter'
@@ -52,8 +52,8 @@ export async function POST(
 
     // 1. Load grant opportunity + funder documents in parallel
     const [grantResult, funderDocsResult] = await Promise.all([
-      supabase.from('grant_opportunities').select('*').eq('id', id).single(),
-      supabase.from('grant_funder_documents').select('name, doc_type, content_summary').eq('opportunity_id', id).order('sort_order'),
+      civicgraph.from('grant_opportunities').select('*').eq('id', id).single(),
+      civicgraph.from('grant_funder_documents').select('name, doc_type, content_summary').eq('opportunity_id', id).order('sort_order'),
     ])
 
     const grant = grantResult.data
@@ -231,7 +231,7 @@ Write ONLY the section content (no heading, no markdown formatting).`
 
     // 5. Optionally store drafts in grant_applications
     // Check if an application already exists for this grant + project
-    const { data: existingApp } = await supabase
+    const { data: existingApp } = await civicgraph
       .from('grant_applications')
       .select('id, documents')
       .eq('opportunity_id', id)
@@ -242,7 +242,7 @@ Write ONLY the section content (no heading, no markdown formatting).`
       // Merge new drafts into existing documents
       const existingDocs = (existingApp.documents as Record<string, unknown>) || {}
       const updatedDocs = { ...existingDocs, drafts: { ...(existingDocs.drafts as Record<string, unknown> || {}), ...drafts } }
-      await supabase
+      await civicgraph
         .from('grant_applications')
         .update({ documents: updatedDocs })
         .eq('id', existingApp.id)

--- a/apps/command-center/src/app/api/grants/[id]/milestones/route.ts
+++ b/apps/command-center/src/app/api/grants/[id]/milestones/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph } from '@/lib/supabase'
 
 interface Milestone {
   name: string
@@ -53,7 +53,7 @@ export async function GET(
   try {
     const { id } = await params
 
-    const { data, error } = await supabase
+    const { data, error } = await civicgraph
       .from('grant_applications')
       .select('id, milestones, amount_requested, opportunity_id')
       .eq('id', id)
@@ -67,7 +67,7 @@ export async function GET(
 
     // If no milestones, check if we can auto-generate
     if (milestones.length === 0 && data.opportunity_id) {
-      const { data: opp } = await supabase
+      const { data: opp } = await civicgraph
         .from('grant_opportunities')
         .select('closes_at, amount_max')
         .eq('id', data.opportunity_id)
@@ -76,7 +76,7 @@ export async function GET(
       if (opp?.closes_at) {
         milestones = generateMilestones(opp.closes_at, data.amount_requested || opp.amount_max || 50000)
         // Auto-save generated milestones
-        await supabase
+        await civicgraph
           .from('grant_applications')
           .update({ milestones })
           .eq('id', id)
@@ -112,7 +112,7 @@ export async function PATCH(
     const { index, completed, assignee } = body as { index: number; completed?: boolean; assignee?: string }
 
     // Fetch current milestones
-    const { data, error } = await supabase
+    const { data, error } = await civicgraph
       .from('grant_applications')
       .select('milestones')
       .eq('id', id)
@@ -130,7 +130,7 @@ export async function PATCH(
     if (completed !== undefined) milestones[index].completed = completed
     if (assignee !== undefined) milestones[index].assignee = assignee
 
-    const { error: updateErr } = await supabase
+    const { error: updateErr } = await civicgraph
       .from('grant_applications')
       .update({ milestones })
       .eq('id', id)

--- a/apps/command-center/src/app/api/grants/[id]/route.ts
+++ b/apps/command-center/src/app/api/grants/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph } from '@/lib/supabase'
 
 export async function GET(
   request: Request,
@@ -10,12 +10,12 @@ export async function GET(
 
     // Fetch grant + funder documents in parallel
     const [grantResult, docsResult] = await Promise.all([
-      supabase
+      civicgraph
         .from('grant_opportunities')
         .select('*')
         .eq('id', id)
         .single(),
-      supabase
+      civicgraph
         .from('grant_funder_documents')
         .select('*')
         .eq('opportunity_id', id)
@@ -51,7 +51,7 @@ export async function PATCH(
       if (body.application_status) oppUpdates.application_status = body.application_status
       if (body.url !== undefined) oppUpdates.url = body.url || null
 
-      const { error } = await supabase
+      const { error } = await civicgraph
         .from('grant_opportunities')
         .update(oppUpdates)
         .eq('id', id)
@@ -66,7 +66,7 @@ export async function PATCH(
     if (body.notes !== undefined) updates.notes = body.notes
     if (body.project_code) updates.project_code = body.project_code
 
-    const { data, error } = await supabase
+    const { data, error } = await civicgraph
       .from('grant_applications')
       .update(updates)
       .eq('id', id)
@@ -88,7 +88,7 @@ export async function DELETE(
   try {
     const { id } = await params
 
-    const { error } = await supabase
+    const { error } = await civicgraph
       .from('grant_applications')
       .delete()
       .eq('id', id)

--- a/apps/command-center/src/app/api/grantscope/entities/route.ts
+++ b/apps/command-center/src/app/api/grantscope/entities/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph } from '@/lib/supabase'
 
 /**
  * GET /api/grantscope/entities
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
   // ABN lookup — return single entity with relationships
   if (abn) {
     const cleanAbn = abn.replace(/\s/g, '')
-    const { data: entity, error } = await supabase
+    const { data: entity, error } = await civicgraph
       .from('gs_entities')
       .select('*')
       .eq('abn', cleanAbn)
@@ -38,21 +38,21 @@ export async function GET(request: NextRequest) {
     }
 
     // Fetch relationships for this entity
-    const { data: relationships } = await supabase
+    const { data: relationships } = await civicgraph
       .from('gs_relationships')
       .select('*')
       .or(`source_entity_id.eq.${entity.id},target_entity_id.eq.${entity.id}`)
       .limit(100)
 
     // Check ACNC data
-    const { data: acncData } = await supabase
+    const { data: acncData } = await civicgraph
       .from('acnc_charities')
       .select('*')
       .eq('abn', cleanAbn)
       .single()
 
     // Check foundation data
-    const { data: foundationData } = await supabase
+    const { data: foundationData } = await civicgraph
       .from('foundations')
       .select('*, foundation_programs(id, name, focus_area, grant_size_min, grant_size_max)')
       .eq('acnc_abn', cleanAbn)
@@ -67,7 +67,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Search mode
-  let query = supabase
+  let query = civicgraph
     .from('gs_entities')
     .select('id, canonical_name, abn, entity_type, state, sector, latest_revenue, latest_assets, website, is_community_controlled, tags', { count: 'exact' })
 

--- a/apps/command-center/src/app/api/grantscope/foundations/search/route.ts
+++ b/apps/command-center/src/app/api/grantscope/foundations/search/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph } from '@/lib/supabase'
 
 /**
  * GET /api/grantscope/foundations/search
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Number(params.get('limit') || 50), 200)
   const offset = Number(params.get('offset') || 0)
 
-  let query = supabase
+  let query = civicgraph
     .from('foundations')
     .select('*, foundation_programs(id, name, focus_area, grant_size_min, grant_size_max)', { count: 'exact' })
 

--- a/apps/command-center/src/app/api/grantscope/grants/matching/route.ts
+++ b/apps/command-center/src/app/api/grantscope/grants/matching/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph } from '@/lib/supabase'
 
 /**
  * GET /api/grantscope/grants/matching
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
   const limit = Math.min(Number(params.get('limit') || 50), 200)
   const offset = Number(params.get('offset') || 0)
 
-  let query = supabase
+  let query = civicgraph
     .from('grant_opportunities')
     .select('*', { count: 'exact' })
 

--- a/apps/command-center/src/app/api/grantscope/intelligence/route.ts
+++ b/apps/command-center/src/app/api/grantscope/intelligence/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { supabase } from '@/lib/supabase'
+import { civicgraph, supabase } from '@/lib/supabase'
 
 /**
  * GET /api/grantscope/intelligence
@@ -21,24 +21,27 @@ export async function GET() {
     recentGrants,
     pipelineValue,
   ] = await Promise.all([
-    supabase.from('gs_entities').select('id', { count: 'exact', head: true }),
-    supabase.from('foundations').select('id', { count: 'exact', head: true }),
-    supabase.from('grant_opportunities').select('id', { count: 'exact', head: true }),
-    supabase.from('grant_opportunities').select('id', { count: 'exact', head: true })
+    civicgraph.from('gs_entities').select('id', { count: 'exact', head: true }),
+    civicgraph.from('foundations').select('id', { count: 'exact', head: true }),
+    civicgraph.from('grant_opportunities').select('id', { count: 'exact', head: true }),
+    civicgraph.from('grant_opportunities').select('id', { count: 'exact', head: true })
       .gte('closes_at', now),
-    supabase.from('grant_opportunities').select('id, title:name, close_date:closes_at, amount_max, funder_name:provider', { count: 'exact' })
+    civicgraph.from('grant_opportunities').select('id, title:name, close_date:closes_at, amount_max, funder_name:provider', { count: 'exact' })
       .gte('closes_at', now).lte('closes_at', thirtyDays)
       .order('closes_at', { ascending: true })
       .limit(10),
-    supabase.from('foundations')
+    civicgraph.from('foundations')
       .select('id, name, total_giving_annual, website')
       .not('total_giving_annual', 'is', null)
       .order('total_giving_annual', { ascending: false })
       .limit(10),
-    supabase.from('grant_opportunities')
+    civicgraph.from('grant_opportunities')
       .select('id, title:name, funder_name:provider, amount_max, close_date:closes_at, created_at')
       .order('created_at', { ascending: false })
       .limit(10),
+    // v_pipeline_value: ownership unresolved — likely aggregates grant_opportunities/applications,
+    // so at data-move time it probably travels with the grant estate (→ civicgraph). Left on the
+    // app's own client for now; resolve when CivicGraph's estate actually moves.
     supabase.from('v_pipeline_value').select('*').limit(1).single(),
   ])
 

--- a/apps/command-center/src/lib/supabase.ts
+++ b/apps/command-center/src/lib/supabase.ts
@@ -35,3 +35,30 @@ export const elSupabase = new Proxy({} as SupabaseClient, {
     return (getELSupabase() as unknown as Record<string | symbol, unknown>)[prop]
   },
 })
+
+// CivicGraph (GrantScope) shared-data instance.
+//
+// Dedicated client for CivicGraph-owned tables that act-global only consumes/co-writes
+// (gs_entities, gs_relationships, acnc_*, foundations*, grant_opportunities, grant_applications).
+// TODAY it resolves to the SAME box as `supabase` (CIVICGRAPH_* unset → fall back), so it is
+// behaviourally a no-op. This decouples the *connection* ahead of the data move: when CivicGraph's
+// estate moves to its own Supabase project, set CIVICGRAPH_SUPABASE_URL + CIVICGRAPH_SUPABASE_KEY
+// and every grantscope-table query in this app repoints in one place — no query rewrites.
+//
+// env: CIVICGRAPH_SUPABASE_URL, CIVICGRAPH_SUPABASE_KEY (service-role; falls back to the app's own).
+let _civicgraph: SupabaseClient | null = null
+
+function getCivicGraph(): SupabaseClient {
+  if (!_civicgraph) {
+    const url = process.env.CIVICGRAPH_SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || ''
+    const key = process.env.CIVICGRAPH_SUPABASE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+    _civicgraph = createClient(url, key)
+  }
+  return _civicgraph
+}
+
+export const civicgraph = new Proxy({} as SupabaseClient, {
+  get(_target, prop) {
+    return (getCivicGraph() as unknown as Record<string | symbol, unknown>)[prop]
+  },
+})


### PR DESCRIPTION
## What

Adds a dedicated `civicgraph` Supabase client to command-center and routes all CivicGraph/GrantScope-owned table queries through it — **decoupling the connection ahead of CivicGraph's data move off the shared "Empathy Ledger" box.**

## Why

The shared box (`tednluwflfhxyucgwigh`) saturates because ~6 apps' query bursts collide on one pool. The durable fix is giving CivicGraph its own DB. Before moving any data, each consumer needs an *explicit* client so the eventual move is a one-env-var flip, not a query rewrite. `empathy-ledger-v2` already does this; this brings act-global to parity.

## How — behaviourally a no-op today

- New `civicgraph` proxy in `apps/command-center/src/lib/supabase.ts`, reading `CIVICGRAPH_SUPABASE_URL` / `CIVICGRAPH_SUPABASE_KEY`, **falling back to the app's own client when unset** — so it points at the same box today and changes nothing.
- Routed grant-estate tables (`gs_entities`, `gs_relationships`, `acnc_charities`, `foundations`, `grant_opportunities`, `grant_applications`, `grant_funder_documents`) through `civicgraph` across:
  - the 4 `/api/grantscope/*` routes
  - the in-app grant write paths: `api/grants/[id]/{route,draft,milestones}`
- act-global-owned tables (`projects`, `project_knowledge`, `v_pipeline_value`, `hybrid_memory_search` rpc) deliberately **stay on the app's own client**. The two mixed-ownership files got per-query routing, not a blanket swap.

## At data-move time

Set `CIVICGRAPH_SUPABASE_URL` + `CIVICGRAPH_SUPABASE_KEY` to CivicGraph's new project → every grantscope query in this app repoints in one place.

## Deferred — NOT in this PR (only needed at actual move-time)

- grant-engine client repoint at the `new GrantEngine({ supabase })` construction site (a discovery script/cron, not an app route)
- notion-workers `index.ts` `grant_opportunities` write
- ~25 finance / briefing / harvest / telegram **read** sites for `grant_opportunities` / `grant_applications`
- resolve `v_pipeline_value` + `grant_funder_documents` ownership

## Verification

- `tsc --noEmit` clean (0 errors)
- Verified no grant-estate query left on the app client; act-global-owned tables confirmed still on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
