### PR TITLE
fix(finance): exclude DELETED/VOIDED + pre-Jan from ACT-HV; re-clean to $124,077.68

### DIFF
--- a/apps/command-center/src/app/api/finance/projects/[code]/route.ts
+++ b/apps/command-center/src/app/api/finance/projects/[code]/route.ts
@@ -497,22 +497,30 @@ export async function GET(
     // ---- REAL EXPENSE COMPUTATION (bills + unmatched bank spend, deduped) ----
     // The pre-existing project_monthly_financials only counts bank txns, missing
     // ACCPAY bills. Recompute from raw to give the page accurate numbers + audit alerts.
+    // Harvest (ACT-HV) spend only counts from 1 Jan 2026 — pre-Jan rows are not Harvest,
+    // and a full Xero sync re-tags them onto ACT-HV via tracking categories, so guard at read time.
+    const harvestStart = projectCode === 'ACT-HV' ? '2026-01-01' : null
+    let billsQuery = supabase
+      .from('xero_invoices')
+      .select('id, xero_id, date, contact_name, total, status, line_items, project_code_source')
+      .eq('project_code', projectCode)
+      .eq('type', 'ACCPAY')
+      .in('status', ['AUTHORISED', 'PAID'])
+    let spendsQuery = supabase
+      .from('xero_transactions')
+      .select('id, xero_transaction_id, date, contact_name, total, status, type, line_items, project_code_source, has_attachments')
+      .eq('project_code', projectCode)
+      .in('type', ['SPEND', 'SPEND-OVERPAYMENT'])
+      // Exclude deleted/voided bank txns — they are not real spend. Caught 2026-06-26 when
+      // DELETED Kennedy's ghosts inflated ACT-HV by ~$21K (bills were already status-filtered; spends weren't).
+      .not('status', 'in', '("DELETED","VOIDED")')
+    if (harvestStart) {
+      billsQuery = billsQuery.gte('date', harvestStart)
+      spendsQuery = spendsQuery.gte('date', harvestStart)
+    }
     const [realBillsRes, realSpendsRes] = await Promise.all([
-      supabase
-        .from('xero_invoices')
-        .select('id, xero_id, date, contact_name, total, status, line_items, project_code_source')
-        .eq('project_code', projectCode)
-        .eq('type', 'ACCPAY')
-        .in('status', ['AUTHORISED', 'PAID'])
-        .order('date', { ascending: false })
-        .range(0, 4999),
-      supabase
-        .from('xero_transactions')
-        .select('id, xero_transaction_id, date, contact_name, total, status, type, line_items, project_code_source, has_attachments')
-        .eq('project_code', projectCode)
-        .in('type', ['SPEND', 'SPEND-OVERPAYMENT'])
-        .order('date', { ascending: false })
-        .range(0, 4999),
+      billsQuery.order('date', { ascending: false }).range(0, 4999),
+      spendsQuery.order('date', { ascending: false }).range(0, 4999),
     ])
     const realBills = realBillsRes.data || []
     const realSpends = realSpendsRes.data || []

--- a/scripts/build-harvest-ledger.mjs
+++ b/scripts/build-harvest-ledger.mjs
@@ -69,12 +69,16 @@ async function fetchAll(table, query) {
 }
 
 async function main() {
+  // ACT-HV = Harvest, spend from 1 Jan 2026 only; exclude deleted/voided bank txns
+  // (DELETED ghosts inflated the total by ~$21K — caught 2026-06-26).
+  const HV_START = '2026-01-01';
   const bills = await fetchAll('xero_invoices', sb.from('xero_invoices')
     .select('xero_id, date, contact_name, total, status, invoice_number, line_items')
-    .eq('project_code', 'ACT-HV').eq('type', 'ACCPAY').in('status', ['AUTHORISED','PAID']));
+    .eq('project_code', 'ACT-HV').eq('type', 'ACCPAY').in('status', ['AUTHORISED','PAID']).gte('date', HV_START));
   const spends = await fetchAll('xero_transactions', sb.from('xero_transactions')
     .select('xero_transaction_id, date, contact_name, total, status, type, line_items')
-    .eq('project_code', 'ACT-HV').in('type', ['SPEND','SPEND-OVERPAYMENT']));
+    .eq('project_code', 'ACT-HV').in('type', ['SPEND','SPEND-OVERPAYMENT'])
+    .not('status', 'in', '("DELETED","VOIDED")').gte('date', HV_START));
 
   // build matched-payment set
   const paidBills = bills.filter(b => b.status === 'PAID');

--- a/scripts/build-harvest-notion-rollup.mjs
+++ b/scripts/build-harvest-notion-rollup.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Build the clean ACT-HV per-supplier rollup for the Notion "Spend by supplier"
+ * database. Post-Jan only, live status (excl DELETED/VOIDED), deduped
+ * (placeholder-bill + bill-payment overlap). Emits JSON rows matching the
+ * Notion schema: Supplier / Amount / Lines / Category / Garden area.
+ *
+ *   node scripts/build-harvest-notion-rollup.mjs   # prints total + writes JSON
+ */
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'fs';
+
+const sb = createClient(
+  process.env.SUPABASE_SHARED_URL || 'https://tednluwflfhxyucgwigh.supabase.co',
+  process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+const f = (n) => '$' + Number(n || 0).toLocaleString('en-AU', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const U = (s) => (s || '').trim().toUpperCase();
+const CUT = '2026-01-01';
+
+// vendor (lowercase substring) -> {cat, garden}
+function classify(nameRaw) {
+  const n = (nameRaw || '').toLowerCase();
+  const G = 'Garden & landscaping', P = 'Paths & structures', L = 'Labour', PAV = 'Pavilion',
+    T = 'Tools & equipment', M = 'Materials & hardware', D = 'Design & branding',
+    H = 'Hospitality & meals', F = 'Fuel & travel', O = 'Other';
+  const rule = (cat, garden = false) => ({ cat, garden });
+  if (n.includes('maleny landscaping') || n.includes('savage landscape') || n.includes('savage transport') || n.includes('sophie') || n.includes('hickey')) return rule(G, true);
+  if (n.includes('kennedy') || n.includes('smartwood') || n.includes("st mary")) return rule(P, true); // heritage decking = Garden Paths
+  if (n.includes('longara')) return rule(PAV); // milk crates -> pavilion build
+  if (n.includes('joseph kirmos') || n.includes('chris w') || n.includes('tnt plaster') || n.includes('rnm')) return rule(L);
+  if (n.includes('thais') || n.includes('pupio')) return rule(D);
+  if (n.includes('total tools') || n.includes('sydney tools') || n.includes('carbatec') || n.includes('dnp') || n.includes('diggermate') || n.includes('kennards') || n.includes('hydraulink') || n.includes('bolt in') || n.includes('coastal fastener') || n.includes('supercheap') || n.includes('bcf')) return rule(T);
+  if (n.includes('bunnings') || n.includes('maleny hardware') || n.includes('officeworks') || n.includes('auscot') || n.includes('bussell') || n.includes('salin') || n.includes('amazon')) return rule(M);
+  if (n.includes('liberty') || n.includes('bp') || n === 'bp' || n.includes('caltex') || n.includes('7-eleven') || n.includes('avis')) return rule(F);
+  if (n.includes('woolworths') || n.includes('iga') || n.includes('coles') || n.includes('bakery') || n.includes('hot bread') || n.includes('fisher') || n.includes('mapleton') || n.includes('nest in witta') || n.includes('hotel') || n.includes('cafe') || n.includes('restaurant') || n.includes('diner') || n.includes('thai') || n.includes('oyster') || n.includes('frank food') || n.includes('pastr') || n.includes('food co') || n.includes('source bulk') || n.includes('alsahwa') || n.includes('pocky') || n.includes('light years') || n.includes('sukhothai')) return rule(H);
+  return rule(O);
+}
+
+async function pageAll(b) { const o = []; let from = 0; while (true) { const { data, error } = await b.range(from, from + 999); if (error) throw error; if (!data?.length) break; o.push(...data); if (data.length < 1000) break; from += 1000; } return o; }
+
+async function main() {
+  const bills = (await pageAll(sb.from('xero_invoices').select('xero_id,date,contact_name,total,status,invoice_number').eq('project_code', 'ACT-HV').eq('type', 'ACCPAY').gte('date', CUT)))
+    .filter(b => ['AUTHORISED', 'PAID'].includes(b.status));
+  const spends = (await pageAll(sb.from('xero_transactions').select('xero_transaction_id,date,contact_name,total,status,type').eq('project_code', 'ACT-HV').in('type', ['SPEND', 'SPEND-OVERPAYMENT']).gte('date', CUT)))
+    .filter(s => !['DELETED', 'VOIDED'].includes(s.status));
+  // drop placeholder-bill dups (no inv# matching a live txn same vendor/amount ±14d)
+  const phBill = new Set();
+  for (const b of bills) { if (b.invoice_number) continue; const bd = new Date(b.date); if (spends.find(s => U(s.contact_name) === U(b.contact_name) && Number(s.total) === Number(b.total) && Math.abs((new Date(s.date) - bd) / 864e5) <= 14)) phBill.add(b.xero_id); }
+  const cleanBills = bills.filter(b => !phBill.has(b.xero_id));
+  const paid = cleanBills.filter(b => b.status === 'PAID');
+  const matched = new Set();
+  for (const s of spends) { const sd = new Date(s.date); if (paid.find(b => U(b.contact_name) === U(s.contact_name) && Number(b.total) === Number(s.total) && Math.abs((new Date(b.date) - sd) / 864e5) <= 14)) matched.add(s.xero_transaction_id); }
+  const cleanSpends = spends.filter(s => !matched.has(s.xero_transaction_id));
+
+  // roll up by supplier (canonicalise a couple of name variants)
+  const canon = (nm) => {
+    let s = (nm || '').trim();
+    if (/maleny hardware|auscot|bussell/i.test(s)) s = 'Maleny Hardware & Rural';
+    if (/^kennedy/i.test(s)) s = "Kennedy's";
+    return s;
+  };
+  const by = new Map();
+  const add = (nm, amt) => { const k = canon(nm); if (!by.has(k)) by.set(k, { amount: 0, lines: 0 }); const e = by.get(k); e.amount += Number(amt); e.lines += 1; };
+  for (const b of cleanBills) add(b.contact_name, b.total);
+  for (const s of cleanSpends) add(s.contact_name, s.total);
+
+  const rows = [...by.entries()].map(([supplier, v]) => {
+    const c = classify(supplier);
+    return { supplier, amount: Math.round(v.amount * 100) / 100, lines: v.lines, category: c.cat, garden: c.garden };
+  }).filter(r => r.amount > 0).sort((a, b) => b.amount - a.amount);
+
+  const total = rows.reduce((a, r) => a + r.amount, 0);
+  const lines = rows.reduce((a, r) => a + r.lines, 0);
+  const byCat = {};
+  for (const r of rows) byCat[r.category] = (byCat[r.category] || 0) + r.amount;
+  const garden = rows.filter(r => r.garden).reduce((a, r) => a + r.amount, 0);
+
+  console.log(`CLEAN ACT-HV (post-Jan, live, deduped, incl 5 re-tags): ${f(total)}`);
+  console.log(`Suppliers: ${rows.length} | Lines: ${lines} | Garden area: ${f(garden)}`);
+  console.log('\nBy category:');
+  Object.entries(byCat).sort((a, b) => b[1] - a[1]).forEach(([k, v]) => console.log(`  ${k.padEnd(22)} ${f(v)}`));
+  console.log('\nSuppliers:');
+  rows.forEach(r => console.log(`  ${f(r.amount).padStart(13)}  ${String(r.lines).padStart(2)}L  ${r.garden ? '🌱' : '  '} ${r.category.padEnd(22)} ${r.supplier}`));
+
+  writeFileSync('thoughts/shared/reports/harvest-notion-rollup-2026-06-26.json', JSON.stringify({ total, lines, suppliers: rows.length, garden, byCat, rows }, null, 2));
+  console.log('\nJSON: thoughts/shared/reports/harvest-notion-rollup-2026-06-26.json');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/harvest-notion-reconcile.mjs
+++ b/scripts/harvest-notion-reconcile.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Reconcile the clean ACT-HV rollup against the existing Notion "Spend by
+ * supplier" DB rows (Xero-derived slots only — manual Planned rows preserved).
+ * Emits a plan: UPDATE (match by normalised name) / CREATE / ZERO.
+ *   node scripts/harvest-notion-reconcile.mjs
+ */
+import { readFileSync } from 'fs';
+
+const rollup = JSON.parse(readFileSync('thoughts/shared/reports/harvest-notion-rollup-2026-06-26.json', 'utf8')).rows;
+
+// existing Xero-derived DB slots: [pageId, supplierName]
+const SLOTS = [
+  ['36cebcf981cf818aadf1fb6843aec04f', 'Thais Pupio Design'],
+  ['36cebcf981cf81858aedd00049ed0fbc', "Kennedy's"],
+  ['36cebcf981cf81acaaf1ce55fba1bb45', 'Sophie Deirdre Hickey'],
+  ['36cebcf981cf81d380e7dc3e8206262b', 'Longara'],
+  ['36cebcf981cf81499348e7ef96664201', 'Maleny Landscaping Supplies'],
+  ['36cebcf981cf8179b13be99c973cb370', 'Joseph Kirmos (Joey)'],
+  ['36cebcf981cf81af996eeafd98adafea', 'Savage Landscape Supplies'],
+  ['36cebcf981cf8193ba2df83ed6fcf137', 'Bunnings Warehouse'],
+  ['36cebcf981cf816e8a33e2afa0edd306', 'Smartwood'],
+  ['36cebcf981cf81d5957afa82577f55e4', 'Total Tools East Brisbane'],
+  ['36cebcf981cf81fa9dbef733d42931c8', 'Diggermate Franchising'],
+  ['36cebcf981cf812799b6f170fd07a530', 'Maleny Hardware And Rural Supplies'],
+  ['36cebcf981cf8151b6fbe6aa0b1f8525', 'Mapleton Public House'],
+  ['36cebcf981cf81fd8dfbe4cb8ad44d30', "Fisher's Oysters"],
+  ['36cebcf981cf81ee95d0d825b917ca62', 'Liberty Maleny'],
+  ['36cebcf981cf81ff8d96e9dd7b9b4dd9', 'Hydraulink Brisbane North'],
+  ['36cebcf981cf81768d0cf3ec58eb654e', 'Maleny Hardware'],
+  ['36cebcf981cf8158a1a1c2b3712388a6', 'IGA'],
+  ['36cebcf981cf8188bbc3c2a820fd1bde', 'Woolworths'],
+  ['36cebcf981cf81c38af1c7189e21f896', 'Savage Transport Trust'],
+  ['36cebcf981cf81458a03c6a7ca141bad', 'Sukhothai Authentic Thai Restaurant'],
+  ['36cebcf981cf811b9558d7658b510d52', 'Nest In Witta'],
+  ['36cebcf981cf8185baadf7600b350613', 'Bussell Rural Co (Maleny Hardware & Rural)'],
+  ['36cebcf981cf81d69369dbecadc7256d', 'Salin Appliance Spares'],
+  ['36cebcf981cf8186909cc1472792e556', 'Light Years Asian Diner'],
+  ['36cebcf981cf8117b44ae6cc0f444c30', '7-Eleven'],
+  ['36cebcf981cf812ba7dcc317956ab0e5', 'Art Museum'],
+  ['36cebcf981cf8136810ef5fa03b0b8cb', 'Maleny Hotel'],
+  ['36cebcf981cf814699b6fff6c8b5b5e5', 'Alsahwa Estate'],
+  ['36cebcf981cf81c8af3fec8560623efc', 'Brisbane City Council'],
+  ['36cebcf981cf8153aba9e74f1fd9bc00', 'BCF'],
+  ['36cebcf981cf81e08485d204036fa08f', 'Frank Food & Wine'],
+  ['36cebcf981cf81288cc5d75c840787ed', "CJ's Pastries"],
+  ['36cebcf981cf81c19253eab77522fc4e', 'Supercheap Auto'],
+  ['36cebcf981cf813b8145e73bc92f5c83', 'Maleny Bakery'],
+  ['36cebcf981cf81e3b4dcf4105f989693', 'Avis'],
+  ['36cebcf981cf81c887fffaa9d49ba860', 'Maleny Hardware & Ru (removed — duplicate)'],
+  ['36cebcf981cf8198beb4e40b1ef1703d', 'Auscot Rural Co (removed — duplicate)'],
+];
+
+const norm = (s) => (s || '').toLowerCase()
+  .replace(/\(.*?\)/g, ' ')           // strip parentheticals
+  .replace(/removed.*duplicate/g, ' ')
+  .replace(/\bsupplies\b|\bsupply\b|\bpty\b|\bltd\b|\bt\/as\b|\bco\b|\bwarehouse\b|\bfranchising\b|\bbrisbane\b|\bnorth\b|\beast\b/g, ' ')
+  .replace(/&/g, ' and ')
+  .replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+
+// canonical key (collapse maleny-hardware variants, kennedy, joey)
+const key = (s) => {
+  let n = norm(s);
+  if (n.includes('maleny hardware') || n.includes('bussell rural') || n.includes('auscot rural')) return 'maleny hardware rural';
+  if (n.includes('maleny landscaping')) return 'maleny landscaping';
+  if (n.startsWith('kennedy')) return 'kennedy';
+  if (n.includes('joseph kirmos')) return 'joseph kirmos';
+  return n;
+};
+
+const slotByKey = new Map();
+for (const [id, name] of SLOTS) { const k = key(name); if (!slotByKey.has(k)) slotByKey.set(k, { id, name }); }
+
+const updates = [], creates = [];
+const usedSlots = new Set();
+for (const r of rollup) {
+  const k = key(r.supplier);
+  const slot = slotByKey.get(k);
+  if (slot && !usedSlots.has(slot.id)) { usedSlots.add(slot.id); updates.push({ id: slot.id, ...r }); }
+  else creates.push(r);
+}
+const zeros = SLOTS.filter(([id]) => !usedSlots.has(id)).map(([id, name]) => ({ id, name }));
+
+const esc = (s) => JSON.stringify(s);
+console.log(`PLAN: ${updates.length} updates, ${creates.length} creates, ${zeros.length} zeros\n`);
+console.log('--- UPDATES (pageId | supplier | amount | lines | category | garden) ---');
+for (const u of updates) console.log(`${u.id} | ${u.supplier} | ${u.amount} | ${u.lines} | ${u.category} | ${u.garden ? 'YES' : 'NO'}`);
+console.log('\n--- CREATES (supplier | amount | lines | category | garden) ---');
+for (const c of creates) console.log(`${c.supplier} | ${c.amount} | ${c.lines} | ${c.category} | ${c.garden ? 'YES' : 'NO'}`);
+console.log('\n--- ZEROS (pageId | was) ---');
+for (const z of zeros) console.log(`${z.id} | ${z.name}`);
+console.log(`\nCheck: updates+creates total = $${[...updates, ...creates].reduce((a, r) => a + r.amount, 0).toFixed(2)}`);

--- a/scripts/harvest-resweep-apply.mjs
+++ b/scripts/harvest-resweep-apply.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Harvest (ACT-HV) forensic re-sweep — APPLY the 5 confirmed pull-backs.
+ *
+ * Pulls real Harvest spend that the May Xero sync scattered off ACT-HV (onto
+ * ACT-CORE / NULL) back onto ACT-HV. Stamped with a manual source so the
+ * auto-tagger guard protects it from being re-scrambled on the next sync.
+ * Ben confirmed all 5 are Harvest costs (2026-06-26).
+ *
+ *   node scripts/harvest-resweep-apply.mjs            # dry-run (default)
+ *   node scripts/harvest-resweep-apply.mjs --apply    # write
+ */
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(
+  process.env.SUPABASE_SHARED_URL || 'https://tednluwflfhxyucgwigh.supabase.co',
+  process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+const APPLY = process.argv.includes('--apply');
+const SOURCE = 'manual-harvest-resweep-2026-06-26';
+
+// id, expected vendor/amount/date for safety re-check before write
+const TARGETS = [
+  { id: '97b6b8cb-d557-4965-9ae2-773479848bda', vendor: "Kennedy's", total: 8594.91, date: '2026-04-27', note: 'decking (was ACT-CORE)' },
+  { id: 'bef4978a-1743-46aa-adda-24085e9b5b64', vendor: "Kennedy's", total: 6787.64, date: '2026-06-12', note: 'decking (was NULL)' },
+  { id: '51b2b59a-8a96-47c5-a868-8d56a4fea519', vendor: "Kennedy's", total: 4064.56, date: '2026-05-11', note: 'decking (was NULL)' },
+  { id: 'a77cf9e7-2265-407c-b473-7f8fdc4e545d', vendor: 'Thais Pupio Design', total: 3000.00, date: '2026-02-02', note: 'design (was NULL)' },
+  { id: 'f3d4cf9f-2c57-4d6c-9453-32462bd0af3b', vendor: 'MALENY LANDSCAPING SUPPLIES', total: 895.00, date: '2026-03-09', note: 'garden (was NULL)' },
+];
+
+async function main() {
+  let changed = 0, sum = 0;
+  for (const t of TARGETS) {
+    const { data, error } = await sb.from('xero_transactions')
+      .select('xero_transaction_id, contact_name, total, date, project_code, project_code_source')
+      .eq('xero_transaction_id', t.id).single();
+    if (error || !data) { console.log(`!! ${t.id} not found — SKIP`); continue; }
+    // safety: amount + date must still match what we confirmed
+    if (Number(data.total) !== t.total || data.date !== t.date) {
+      console.log(`!! ${t.id} drifted (db ${data.total}/${data.date} vs expected ${t.total}/${t.date}) — SKIP`); continue;
+    }
+    console.log(`${APPLY ? 'WRITE' : 'DRY '} ${t.date}  $${t.total.toFixed(2).padStart(9)}  ${data.project_code || 'NULL'} -> ACT-HV  ${t.vendor}  [${t.note}]`);
+    sum += t.total; changed++;
+    if (APPLY) {
+      const { error: uerr } = await sb.from('xero_transactions')
+        .update({ project_code: 'ACT-HV', project_code_source: SOURCE })
+        .eq('xero_transaction_id', t.id);
+      if (uerr) { console.log(`   ERROR: ${uerr.message}`); }
+    }
+  }
+  console.log(`\n${APPLY ? 'APPLIED' : 'DRY-RUN'}: ${changed} rows, $${sum.toFixed(2)} pulled onto ACT-HV (source ${SOURCE})`);
+  if (!APPLY) console.log('Re-run with --apply to write.');
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/harvest-resweep-worklist.mjs
+++ b/scripts/harvest-resweep-worklist.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Harvest (ACT-HV) forensic re-sweep worklist (READ-ONLY).
+ *
+ * Why this exists: a full Xero sync re-tags pre-Jan rows onto ACT-HV via
+ * xero_tracking, and scrambles live-vs-deleted / cross-project tags. The
+ * May-2026 manual clean keeps getting wiped. This rebuilds the picture from
+ * scratch so the clean number + re-tag decisions can be reviewed before any
+ * write. NEVER writes to Supabase or Xero.
+ *
+ * Output: thoughts/shared/handoffs/sl-cleanup/.. no — writes
+ *   thoughts/shared/reports/harvest-resweep-worklist-<today>.md
+ * and prints a summary.
+ */
+import './lib/load-env.mjs';
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync } from 'fs';
+
+const sb = createClient(
+  process.env.SUPABASE_SHARED_URL || 'https://tednluwflfhxyucgwigh.supabase.co',
+  process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY,
+);
+const f = (n) => '$' + Number(n || 0).toLocaleString('en-AU', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const U = (s) => (s || '').trim().toUpperCase();
+const CUT = '2026-01-01';
+const TODAY = process.argv[2] || '2026-06-26'; // pass date to keep deterministic
+
+async function pageAll(builder) {
+  const out = []; let from = 0; const size = 1000;
+  while (true) {
+    const { data, error } = await builder.range(from, from + size - 1);
+    if (error) throw new Error(error.message);
+    if (!data?.length) break;
+    out.push(...data);
+    if (data.length < size) break;
+    from += size;
+  }
+  return out;
+}
+
+async function main() {
+  // 1) vendor universe = any vendor that currently has an ACT-HV-tagged row (any status, any date)
+  const hvBills = await pageAll(sb.from('xero_invoices')
+    .select('xero_id,date,contact_name,total,status,invoice_number,project_code_source')
+    .eq('project_code', 'ACT-HV').eq('type', 'ACCPAY'));
+  const hvTxns = await pageAll(sb.from('xero_transactions')
+    .select('xero_transaction_id,date,contact_name,total,type,status,project_code_source')
+    .eq('project_code', 'ACT-HV').in('type', ['SPEND', 'SPEND-OVERPAYMENT']));
+  const vendors = [...new Set([...hvBills, ...hvTxns].map(r => U(r.contact_name)))].filter(Boolean);
+
+  // 2) pull ALL records (any project, any status) for those vendors, post-Jan
+  //    (so we can see live spend sitting on NULL / ACT-CORE / elsewhere)
+  const allBills = [], allTxns = [];
+  for (const v of vendors) {
+    const b = await pageAll(sb.from('xero_invoices')
+      .select('xero_id,date,contact_name,total,status,invoice_number,project_code,project_code_source')
+      .eq('type', 'ACCPAY').ilike('contact_name', v.replace(/[%_]/g, ' ') + '%').gte('date', CUT));
+    const t = await pageAll(sb.from('xero_transactions')
+      .select('xero_transaction_id,date,contact_name,total,type,status,project_code,project_code_source')
+      .in('type', ['SPEND', 'SPEND-OVERPAYMENT']).ilike('contact_name', v.replace(/[%_]/g, ' ') + '%').gte('date', CUT));
+    allBills.push(...b); allTxns.push(...t);
+  }
+  // de-dupe rows pulled multiple times by overlapping ilike
+  const ub = new Map(allBills.map(r => [r.xero_id, r]));
+  const ut = new Map(allTxns.map(r => [r.xero_transaction_id, r]));
+  const bills = [...ub.values()].filter(r => vendors.includes(U(r.contact_name)));
+  const txns = [...ut.values()].filter(r => vendors.includes(U(r.contact_name)));
+
+  const liveBillStatus = (s) => ['AUTHORISED', 'PAID'].includes(s);
+  const deadBillStatus = (s) => ['VOIDED', 'DELETED', 'DRAFT'].includes(s);
+  const liveTxnStatus = (s) => !['DELETED', 'VOIDED'].includes(s);
+
+  // 3) classify per vendor
+  const byVendor = new Map();
+  const push = (v, rec) => { if (!byVendor.has(v)) byVendor.set(v, []); byVendor.get(v).push(rec); };
+  for (const b of bills) push(U(b.contact_name), { k: 'bill', ...b, id: b.xero_id });
+  for (const t of txns) push(U(t.contact_name), { k: 'txn', ...t, id: t.xero_transaction_id });
+
+  // current clean ACT-HV (only rows currently tagged ACT-HV, live status, post-Jan, deduped)
+  let currentCleanBills = bills.filter(b => b.project_code === 'ACT-HV' && b.date >= CUT && liveBillStatus(b.status));
+  const currentLiveTxns = txns.filter(t => t.project_code === 'ACT-HV' && t.date >= CUT && liveTxnStatus(t.status));
+  // placeholder-bill dup: no inv# matching a live txn (any project) same vendor+amount ±14d
+  const allLiveTxns = txns.filter(t => liveTxnStatus(t.status) && t.date >= CUT);
+  const phBill = new Set();
+  for (const b of currentCleanBills) {
+    if (b.invoice_number) continue;
+    const bd = new Date(b.date);
+    if (allLiveTxns.find(s => U(s.contact_name) === U(b.contact_name) && Number(s.total) === Number(b.total) && Math.abs((new Date(s.date) - bd) / 864e5) <= 14)) phBill.add(b.xero_id);
+  }
+  currentCleanBills = currentCleanBills.filter(b => !phBill.has(b.xero_id));
+  const paid = currentCleanBills.filter(b => b.status === 'PAID');
+  const overlapTxn = new Set();
+  for (const s of currentLiveTxns) { const sd = new Date(s.date); if (paid.find(b => U(b.contact_name) === U(s.contact_name) && Number(b.total) === Number(s.total) && Math.abs((new Date(b.date) - sd) / 864e5) <= 14)) overlapTxn.add(s.xero_transaction_id); }
+  const cleanTxns = currentLiveTxns.filter(t => !overlapTxn.has(t.xero_transaction_id));
+  const currentCleanTotal = currentCleanBills.reduce((a, b) => a + Number(b.total), 0) + cleanTxns.reduce((a, t) => a + Number(t.total), 0);
+
+  // re-tag candidates: live rows for these vendors sitting on NULL or non-ACT-HV project, post-Jan,
+  // NOT already counted, NOT an obvious dup of a counted row
+  const countedKeys = new Set([...currentCleanBills, ...cleanTxns].map(r => `${U(r.contact_name)}|${Number(r.total)}|${r.date}`));
+  const retagCandidates = [];
+  for (const r of [...bills.map(b => ({ k: 'bill', ...b, id: b.xero_id, live: liveBillStatus(b.status) })),
+                   ...txns.map(t => ({ k: 'txn', ...t, id: t.xero_transaction_id, live: liveTxnStatus(t.status) }))]) {
+    if (r.project_code === 'ACT-HV') continue;
+    if (!r.live) continue;
+    if (r.date < CUT) continue;
+    retagCandidates.push(r);
+  }
+
+  // 4) render
+  const md = [];
+  md.push(`# Harvest (ACT-HV) forensic re-sweep worklist — ${TODAY}`);
+  md.push('');
+  md.push('_READ-ONLY. Rebuilt after the May clean was wiped by a Xero sync. Two pools below: (A) what to KEEP/clean on the current ACT-HV tag, (B) live Harvest-vendor spend sitting OFF ACT-HV that may need re-tagging in._');
+  md.push('');
+  md.push('## Headline');
+  md.push(`- Vendor universe (any current ACT-HV row): **${vendors.length}**`);
+  md.push(`- **Current clean ACT-HV total (live, post-Jan, deduped): ${f(currentCleanTotal)}** — ${currentCleanBills.length} bills + ${cleanTxns.length} txns`);
+  md.push(`- Placeholder-bill dups dropped: ${phBill.size} · bill-payment overlaps dropped: ${overlapTxn.size}`);
+  md.push(`- **Re-tag candidate pool (live spend OFF ACT-HV for these vendors): ${f(retagCandidates.reduce((a, r) => a + Number(r.total), 0))} across ${retagCandidates.length} rows**`);
+  md.push('');
+  md.push('## B) Re-tag candidates — live spend NOT on ACT-HV (review each: is it Harvest?)');
+  md.push('');
+  md.push('| Date | Vendor | $ | Kind | Status | Current proj | Source |');
+  md.push('|---|---|---:|---|---|---|---|');
+  for (const r of retagCandidates.sort((a, b) => Number(b.total) - Number(a.total))) {
+    md.push(`| ${r.date} | ${r.contact_name} | ${f(r.total)} | ${r.k} | ${r.status} | ${r.project_code || 'NULL'} | ${r.project_code_source || ''} |`);
+  }
+  md.push('');
+  md.push('## A) Per-vendor detail (all post-Jan rows for ACT-HV vendors)');
+  md.push('');
+  const vsorted = [...byVendor.entries()].sort((a, b) => {
+    const sum = (rows) => rows.filter(r => (r.k === 'bill' ? liveBillStatus(r.status) : liveTxnStatus(r.status))).reduce((s, r) => s + Number(r.total), 0);
+    return sum(b[1]) - sum(a[1]);
+  });
+  for (const [v, rows] of vsorted) {
+    md.push(`### ${v}`);
+    md.push('| Date | $ | Kind | Status | Proj | inv# | Source |');
+    md.push('|---|---:|---|---|---|---|---|');
+    for (const r of rows.sort((a, b) => a.date.localeCompare(b.date))) {
+      md.push(`| ${r.date} | ${f(r.total)} | ${r.k} | ${r.status} | ${r.project_code || 'NULL'} | ${r.invoice_number || '-'} | ${r.project_code_source || ''} |`);
+    }
+    md.push('');
+  }
+  const outPath = `thoughts/shared/reports/harvest-resweep-worklist-${TODAY}.md`;
+  writeFileSync(outPath, md.join('\n'));
+  console.log(`Vendors: ${vendors.length}`);
+  console.log(`CURRENT CLEAN ACT-HV (live, deduped): ${f(currentCleanTotal)}  (${currentCleanBills.length} bills + ${cleanTxns.length} txns)`);
+  console.log(`Placeholder dups dropped: ${phBill.size} | overlaps dropped: ${overlapTxn.size}`);
+  console.log(`RE-TAG CANDIDATE POOL (live, off ACT-HV): ${f(retagCandidates.reduce((a, r) => a + Number(r.total), 0))} across ${retagCandidates.length} rows`);
+  console.log(`\nTop re-tag candidates:`);
+  for (const r of retagCandidates.sort((a, b) => Number(b.total) - Number(a.total)).slice(0, 20))
+    console.log(`  ${r.date} ${f(r.total).padStart(12)} ${r.status.padEnd(10)} ${(r.project_code || 'NULL').padEnd(9)} ${r.contact_name}`);
+  console.log(`\nWorklist: ${outPath}`);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/thoughts/shared/reports/harvest-notion-rollup-2026-06-26.json
+++ b/thoughts/shared/reports/harvest-notion-rollup-2026-06-26.json
@@ -1,0 +1,370 @@
+{
+  "total": 124077.68000000001,
+  "lines": 160,
+  "suppliers": 50,
+  "garden": 51632.29,
+  "byCat": {
+    "Design & branding": 19920,
+    "Paths & structures": 24822.48,
+    "Garden & landscaping": 26809.809999999998,
+    "Labour": 12360.29,
+    "Pavilion": 6363,
+    "Tools & equipment": 17921.69,
+    "Materials & hardware": 7182.6,
+    "Fuel & travel": 2372.67,
+    "Hospitality & meals": 5174.020000000001,
+    "Other": 1151.1200000000001
+  },
+  "rows": [
+    {
+      "supplier": "Thais Pupio Design",
+      "amount": 19920,
+      "lines": 3,
+      "category": "Design & branding",
+      "garden": false
+    },
+    {
+      "supplier": "Kennedy's",
+      "amount": 19447.11,
+      "lines": 3,
+      "category": "Paths & structures",
+      "garden": true
+    },
+    {
+      "supplier": "Sophie Deirdre Hickey",
+      "amount": 10524.5,
+      "lines": 8,
+      "category": "Garden & landscaping",
+      "garden": true
+    },
+    {
+      "supplier": "MALENY LANDSCAPING SUPPLIES",
+      "amount": 10406.1,
+      "lines": 11,
+      "category": "Garden & landscaping",
+      "garden": true
+    },
+    {
+      "supplier": "Joseph Kirmos",
+      "amount": 9000,
+      "lines": 2,
+      "category": "Labour",
+      "garden": false
+    },
+    {
+      "supplier": "Longara",
+      "amount": 6363,
+      "lines": 2,
+      "category": "Pavilion",
+      "garden": false
+    },
+    {
+      "supplier": "Savage Landscape Supplies",
+      "amount": 5579.21,
+      "lines": 5,
+      "category": "Garden & landscaping",
+      "garden": true
+    },
+    {
+      "supplier": "Smartwood",
+      "amount": 5375.37,
+      "lines": 2,
+      "category": "Paths & structures",
+      "garden": true
+    },
+    {
+      "supplier": "DNP Australia",
+      "amount": 4803.43,
+      "lines": 2,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Sydney Tools",
+      "amount": 4557,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Total Tools East Brisbane",
+      "amount": 4546.55,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Bunnings Warehouse",
+      "amount": 4459.27,
+      "lines": 9,
+      "category": "Materials & hardware",
+      "garden": false
+    },
+    {
+      "supplier": "CHRIS W",
+      "amount": 3360.29,
+      "lines": 7,
+      "category": "Labour",
+      "garden": false
+    },
+    {
+      "supplier": "Diggermate Franchising",
+      "amount": 2413.17,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Liberty Maleny",
+      "amount": 1868.09,
+      "lines": 9,
+      "category": "Fuel & travel",
+      "garden": false
+    },
+    {
+      "supplier": "Maleny Hardware & Rural",
+      "amount": 1865.93,
+      "lines": 10,
+      "category": "Materials & hardware",
+      "garden": false
+    },
+    {
+      "supplier": "Mapleton Public House",
+      "amount": 1400,
+      "lines": 2,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Woolworths",
+      "amount": 1297.72,
+      "lines": 16,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Hydraulink Brisbane North",
+      "amount": 883.07,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "IGA",
+      "amount": 820.63,
+      "lines": 6,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Officeworks",
+      "amount": 628.5,
+      "lines": 3,
+      "category": "Materials & hardware",
+      "garden": false
+    },
+    {
+      "supplier": "The Matnic Trust",
+      "amount": 591.28,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "Maleny Hotel",
+      "amount": 514.59,
+      "lines": 5,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Kennards Hire",
+      "amount": 405,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Nest In Witta",
+      "amount": 307.62,
+      "lines": 14,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Savage Transport Trust",
+      "amount": 300,
+      "lines": 1,
+      "category": "Garden & landscaping",
+      "garden": true
+    },
+    {
+      "supplier": "Sukhothai Authentic Thai Restaurant",
+      "amount": 268.1,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Salin Appliance Spares",
+      "amount": 228.9,
+      "lines": 1,
+      "category": "Materials & hardware",
+      "garden": false
+    },
+    {
+      "supplier": "Caltex Glasshouse",
+      "amount": 226.78,
+      "lines": 2,
+      "category": "Fuel & travel",
+      "garden": false
+    },
+    {
+      "supplier": "Maleny Bakery",
+      "amount": 193.74,
+      "lines": 2,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Sunshine Coast Council",
+      "amount": 148,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "7-Eleven",
+      "amount": 144.96,
+      "lines": 2,
+      "category": "Fuel & travel",
+      "garden": false
+    },
+    {
+      "supplier": "BP",
+      "amount": 132.84,
+      "lines": 3,
+      "category": "Fuel & travel",
+      "garden": false
+    },
+    {
+      "supplier": "Coastal Fasteners",
+      "amount": 130.94,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Bolt In Co Sunshine Coast",
+      "amount": 127.6,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Flight Bar Witta",
+      "amount": 126.83,
+      "lines": 5,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "Art Museum",
+      "amount": 120,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "Coles Supermarkets",
+      "amount": 106.28,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Unknown Supplier",
+      "amount": 103.59,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "Pocky Asian Restaurant",
+      "amount": 79.79,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Maleny Food Co Cafe",
+      "amount": 68.92,
+      "lines": 2,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Maleny Hot Bread Bake",
+      "amount": 54.76,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "The Dawn Pottery",
+      "amount": 51.92,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "BCF",
+      "amount": 44.94,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "The Source Bulk Foods Maleny",
+      "amount": 24.22,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Frank Food & Wine",
+      "amount": 23.35,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "CJ's Pastries",
+      "amount": 14.3,
+      "lines": 1,
+      "category": "Hospitality & meals",
+      "garden": false
+    },
+    {
+      "supplier": "Supercheap Auto",
+      "amount": 9.99,
+      "lines": 1,
+      "category": "Tools & equipment",
+      "garden": false
+    },
+    {
+      "supplier": "Rosetta Books Maleny",
+      "amount": 5.5,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    },
+    {
+      "supplier": "SQ *FLIGHT BAR WITTA Witta",
+      "amount": 4,
+      "lines": 1,
+      "category": "Other",
+      "garden": false
+    }
+  ]
+}

--- a/thoughts/shared/reports/harvest-resweep-worklist-2026-06-26.md
+++ b/thoughts/shared/reports/harvest-resweep-worklist-2026-06-26.md
@@ -1,0 +1,741 @@
+# Harvest (ACT-HV) forensic re-sweep worklist — 2026-06-26
+
+_READ-ONLY. Rebuilt after the May clean was wiped by a Xero sync. Two pools below: (A) what to KEEP/clean on the current ACT-HV tag, (B) live Harvest-vendor spend sitting OFF ACT-HV that may need re-tagging in._
+
+## Headline
+- Vendor universe (any current ACT-HV row): **82**
+- **Current clean ACT-HV total (live, post-Jan, deduped): $101,630.57** — 77 bills + 79 txns
+- Placeholder-bill dups dropped: 0 · bill-payment overlaps dropped: 0
+- **Re-tag candidate pool (live spend OFF ACT-HV for these vendors): $69,060.37 across 101 rows**
+
+## B) Re-tag candidates — live spend NOT on ACT-HV (review each: is it Harvest?)
+
+| Date | Vendor | $ | Kind | Status | Current proj | Source |
+|---|---|---:|---|---|---|---|
+| 2026-04-27 | Kennedy's | $8,594.91 | txn | AUTHORISED | ACT-CORE | keyword_match |
+| 2026-06-12 | Kennedy's | $6,787.64 | txn | AUTHORISED | NULL |  |
+| 2026-01-21 | Bionic Group | $4,705.00 | bill | PAID | ACT-GD | manual |
+| 2026-01-05 | Carbatec Brisbane | $4,575.65 | bill | PAID | ACT-GD | manual |
+| 2026-03-11 | Joseph Kirmos | $4,500.00 | bill | PAID | ACT-GD | manual-joey-5050-2026-05-26 |
+| 2026-02-16 | Joseph Kirmos | $4,500.00 | bill | PAID | ACT-GD | manual-joey-5050-2026-05-26 |
+| 2026-05-11 | Kennedy's | $4,064.56 | txn | AUTHORISED | NULL |  |
+| 2026-03-02 | Diggermate Franchising | $3,755.85 | bill | AUTHORISED | ACT-FM | vendor_rule |
+| 2026-02-02 | Thais Pupio Design | $3,000.00 | txn | AUTHORISED | NULL |  |
+| 2026-01-10 | The Matnic Trust | $2,826.92 | bill | PAID | ACT-GD | xero_tracking |
+| 2026-01-11 | Carbatec Brisbane | $1,811.70 | bill | PAID | ACT-GD | manual |
+| 2026-01-19 | Sunshine Coast Council | $1,738.03 | bill | PAID | ACT-FM | xero_tracking |
+| 2026-02-19 | Hatch Electrical | $1,443.03 | txn | AUTHORISED | NULL |  |
+| 2026-02-18 | Hatch Electrical | $1,421.55 | bill | AUTHORISED | ACT-FM | vendor_rule |
+| 2026-03-10 | Fisher's Oysters | $1,120.00 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-03-09 | MALENY LANDSCAPING SUPPLIES | $895.00 | txn | AUTHORISED | NULL |  |
+| 2026-01-12 | Hatch Electrical | $772.62 | bill | PAID | ACT-FM | xero_tracking |
+| 2026-01-11 | Bunnings Warehouse | $616.97 | bill | PAID | ACT-IN | xero_tracking |
+| 2026-04-07 | Booking.com | $601.36 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-03-02 | Woolworths | $585.36 | bill | PAID | ACT-IN | vendor_rule |
+| 2026-05-25 | IGA | $484.84 | txn | AUTHORISED | NULL |  |
+| 2026-02-22 | Avis | $483.60 | bill | PAID | ACT-IN | vendor_rule |
+| 2026-02-18 | Officeworks | $426.00 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-05-26 | Caltex Glasshouse | $375.16 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-01-15 | Liberty Maleny | $367.69 | bill | PAID | ACT-IN | xero_tracking |
+| 2026-01-26 | IGA | $366.58 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-02-20 | Amazon | $349.48 | txn | AUTHORISED | NULL |  |
+| 2026-01-24 | Liberty Maleny | $323.67 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-03-10 | Google | $300.00 | bill | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-03-02 | Mapleton Public House | $280.00 | txn | AUTHORISED | NULL |  |
+| 2026-01-15 | Woolworths | $279.25 | bill | PAID | ACT-GD | xero_tracking |
+| 2026-02-04 | IGA | $248.06 | bill | PAID | ACT-GD | xero_tracking |
+| 2026-03-06 | Mapleton Public House | $235.83 | txn | AUTHORISED | NULL |  |
+| 2026-06-12 | Maleny Hotel | $219.17 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-06-11 | Maleny Hotel | $213.11 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-06-11 | Maleny Hotel | $213.11 | txn | AUTHORISED | NULL |  |
+| 2026-03-03 | BP | $212.21 | txn | AUTHORISED | NULL |  |
+| 2026-05-17 | Bunnings Warehouse | $208.86 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-01-19 | Pocky Asian Restaurant | $206.44 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-02-23 | Booking.com | $202.50 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-03-09 | Unknown Supplier | $185.25 | bill | AUTHORISED | ACT-EL | xero_tracking |
+| 2026-04-13 | Avis | $170.25 | txn | AUTHORISED | ACT-IN | vendor_rule |
+| 2026-06-01 | Amazon | $167.18 | txn | AUTHORISED | NULL |  |
+| 2026-02-06 | BP | $161.90 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-02-07 | BP | $153.72 | bill | PAID | ACT-GD | xero_tracking |
+| 2026-02-05 | BP | $148.98 | txn | AUTHORISED | ACT-IN | vendor_rule |
+| 2026-02-18 | Liberty Maleny | $139.50 | bill | PAID | ACT-GD | xero_tracking |
+| 2026-01-18 | Light Years Asian Diner | $138.00 | bill | PAID | ACT-SH | keyword_match |
+| 2026-03-02 | BP | $133.63 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-06-04 | Woolworths | $131.50 | txn | AUTHORISED | NULL |  |
+| 2026-02-13 | Amazon | $126.50 | txn | AUTHORISED | NULL |  |
+| 2026-02-04 | BP | $125.70 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-01-26 | Woolworths | $124.89 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-02-09 | Woolworths | $124.10 | txn | AUTHORISED | ACT-JP | xero_tracking |
+| 2026-01-19 | Liberty Maleny | $120.58 | bill | PAID | ACT-FM | xero_tracking |
+| 2026-02-25 | Supercheap Auto | $119.99 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-02-13 | IGA | $119.89 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-01-12 | Pocky Asian Restaurant | $119.06 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-06-23 | Officeworks | $116.30 | txn | AUTHORISED | ACT-CN | xero_tracking |
+| 2026-04-07 | IGA | $111.51 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-01-17 | Alsahwa Estate | $105.67 | bill | PAID | ACT-SH | keyword_match |
+| 2026-03-28 | 7-Eleven | $103.64 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-05-06 | Caltex Glasshouse | $99.80 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-05-24 | Woolworths | $94.33 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-02-17 | Amazon | $93.40 | txn | AUTHORISED | NULL |  |
+| 2026-02-05 | Flight Bar Witta | $88.95 | txn | AUTHORISED | ACT-GD | manual |
+| 2026-02-02 | Woolworths | $88.43 | txn | AUTHORISED | ACT-IN | vendor_rule |
+| 2026-02-25 | Maleny Hardware And Rural Supplies | $81.90 | txn | AUTHORISED | NULL |  |
+| 2026-03-29 | Pocky Asian Restaurant | $81.10 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-01-30 | Google Australia | $67.98 | bill | PAID | ACT-IN | xero_tracking |
+| 2026-04-01 | Google | $67.98 | bill | PAID | ACT-IN | vendor_rule |
+| 2026-02-28 | Google | $67.98 | bill | PAID | ACT-IN | xero_tracking |
+| 2026-04-30 | Google Australia | $67.98 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-02-06 | IGA | $62.97 | bill | PAID | ACT-GD | xero_tracking |
+| 2026-05-19 | Bunnings Warehouse | $62.80 | txn | AUTHORISED | ACT-GD | xero_tracking |
+| 2026-03-28 | IGA | $51.01 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-05-01 | Amazon | $49.00 | txn | AUTHORISED | NULL |  |
+| 2026-02-20 | Coles Supermarkets | $48.45 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-02-25 | Maleny Hardware And Rural Supplies | $47.90 | txn | AUTHORISED | NULL |  |
+| 2026-05-16 | Coles Supermarkets | $45.56 | txn | AUTHORISED | ACT-OO | xero_tracking |
+| 2026-03-31 | IGA | $44.28 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-01-22 | Unknown Supplier | $43.10 | txn | AUTHORISED | ACT-JH | xero_tracking |
+| 2026-03-15 | Woolworths | $42.50 | bill | PAID | ACT-IN | xero_tracking |
+| 2026-04-15 | Woolworths | $38.10 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-04-08 | The Source Bulk Foods Maleny | $36.17 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-03-30 | Coastal Fasteners | $35.20 | txn | AUTHORISED | NULL |  |
+| 2026-03-06 | Sunshine Coast Council | $35.00 | txn | AUTHORISED | NULL |  |
+| 2026-05-05 | Sunshine Coast Council | $35.00 | txn | AUTHORISED | NULL |  |
+| 2026-02-26 | Coles Supermarkets | $33.65 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-03-03 | IGA | $33.42 | bill | PAID | ACT-FM | vendor_rule |
+| 2026-01-27 | Amazon | $28.99 | txn | AUTHORISED | NULL |  |
+| 2026-05-01 | Amazon | $28.99 | txn | AUTHORISED | NULL |  |
+| 2026-02-25 | Officeworks | $23.00 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-03-20 | Coles Supermarkets | $16.98 | txn | AUTHORISED | ACT-FM | vendor_rule |
+| 2026-03-31 | Coles Supermarkets | $12.10 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-01-26 | 7-Eleven | $11.50 | txn | AUTHORISED | ACT-EL | xero_tracking |
+| 2026-02-25 | Amazon | $9.99 | bill | PAID | ACT-IN | vendor_rule |
+| 2026-03-28 | IGA | $8.95 | txn | AUTHORISED | ACT-IN | xero_tracking |
+| 2026-04-17 | Avis | $8.30 | txn | AUTHORISED | ACT-IN | vendor_rule |
+| 2026-02-25 | Officeworks | $4.18 | bill | PAID | ACT-10 | xero_tracking |
+| 2026-04-16 | Coles Supermarkets | $4.00 | txn | AUTHORISED | ACT-IN | xero_tracking |
+
+## A) Per-vendor detail (all post-Jan rows for ACT-HV vendors)
+
+### THAIS PUPIO DESIGN
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-02 | $3,000.00 | txn | AUTHORISED | NULL | - |  |
+| 2026-02-12 | $15,500.00 | bill | PAID | ACT-HV | 3 | xero_tracking |
+| 2026-02-15 | $1,420.00 | bill | PAID | ACT-HV | 2 | vendor_rule |
+
+### KENNEDY'S
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-04-24 | $8,594.91 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-24 | $8,525.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-27 | $8,594.91 | txn | AUTHORISED | ACT-CORE | - | keyword_match |
+| 2026-05-07 | $4,031.50 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-11 | $4,064.56 | txn | AUTHORISED | NULL | - |  |
+| 2026-06-12 | $6,787.64 | txn | AUTHORISED | NULL | - |  |
+
+### JOSEPH KIRMOS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-16 | $4,500.00 | bill | PAID | ACT-GD | INV-004 | manual-joey-5050-2026-05-26 |
+| 2026-03-11 | $4,500.00 | bill | PAID | ACT-GD | INV-005 | manual-joey-5050-2026-05-26 |
+| 2026-03-29 | $4,500.00 | bill | VOIDED | NULL | - | manual-duplicate-of-fa46775c |
+| 2026-03-29 | $4,500.00 | bill | PAID | ACT-HV | INV-006 | manual-joey-5050-2026-05-26 |
+| 2026-05-06 | $4,500.00 | bill | PAID | ACT-HV | INV-007 | manual-joey-5050-2026-05-26 |
+
+### MALENY LANDSCAPING SUPPLIES
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-02 | $1,395.00 | bill | PAID | ACT-HV | 123800 | vendor_rule |
+| 2026-03-05 | $895.00 | bill | PAID | ACT-HV | 123854 | vendor_rule |
+| 2026-03-06 | $212.50 | bill | AUTHORISED | ACT-HV | 123875 | vendor_rule |
+| 2026-03-06 | $212.50 | bill | AUTHORISED | ACT-HV | 123876 | vendor_rule |
+| 2026-03-09 | $895.00 | txn | AUTHORISED | NULL | - |  |
+| 2026-03-16 | $1,995.00 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+| 2026-03-16 | $1,995.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-17 | $1,305.00 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+| 2026-03-17 | $1,305.00 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+| 2026-03-17 | $1,305.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-17 | $1,305.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-18 | $652.50 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+| 2026-03-18 | $652.50 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-08 | $653.40 | bill | PAID | ACT-HV | 124411 | xero_tracking |
+| 2026-04-22 | $890.10 | bill | PAID | ACT-HV | 124734 | xero_tracking |
+| 2026-04-23 | $890.10 | bill | AUTHORISED | ACT-HV | RB20354581630 | xero_tracking |
+
+### SOPHIE DEIRDRE HICKEY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-21 | $1,660.00 | bill | PAID | ACT-HV | 000105 | vendor_rule |
+| 2026-03-02 | $2,042.50 | bill | PAID | ACT-HV | 000108 | vendor_rule |
+| 2026-03-17 | $1,140.00 | bill | VOIDED | NULL | - | manual-duplicate-of-a1d66188 |
+| 2026-03-17 | $1,140.00 | bill | PAID | ACT-HV | 000111 | xero_tracking |
+| 2026-03-20 | $4,950.00 | bill | VOIDED | NULL | - | manual-duplicate-of-5d474188 |
+| 2026-03-20 | $4,950.00 | bill | PAID | ACT-HV | 000112 | xero_tracking |
+| 2026-04-27 | $317.00 | bill | PAID | ACT-HV | 000116 | xero_tracking |
+| 2026-05-05 | $65.00 | bill | PAID | ACT-HV | 000121 | xero_tracking |
+| 2026-05-25 | $4.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-25 | $346.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### CARBATEC BRISBANE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-05 | $2,338.70 | bill | VOIDED | ACT-GD | - | manual |
+| 2026-01-05 | $4,575.65 | bill | PAID | ACT-GD | - | manual |
+| 2026-01-06 | $2,338.70 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-01-06 | $4,575.65 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-01-11 | $1,811.70 | bill | PAID | ACT-GD | - | manual |
+| 2026-01-12 | $1,811.70 | txn | DELETED | ACT-GD | - | xero_tracking |
+
+### LONGARA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-23 | $3,155.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-02-27 | $3,212.04 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-28 | $3,095.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-03 | $3,150.96 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### DIGGERMATE FRANCHISING
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-02 | $2,413.17 | bill | PAID | ACT-HV | QDFY-020326 | xero_tracking |
+| 2026-03-02 | $3,755.85 | bill | AUTHORISED | ACT-FM | QDFY-020326 | vendor_rule |
+
+### SAVAGE LANDSCAPE SUPPLIES
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-27 | $1,467.22 | bill | PAID | ACT-HV | r73G | vendor_rule |
+| 2026-03-04 | $885.92 | bill | PAID | ACT-HV | p2jh | vendor_rule |
+| 2026-03-04 | $442.96 | bill | PAID | ACT-HV | bTjq | vendor_rule |
+| 2026-04-23 | $1,971.10 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-05 | $812.01 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### SMARTWOOD
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-06 | $2,665.03 | bill | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-01-06 | $2,710.34 | bill | PAID | ACT-HV | - | xero_tracking |
+| 2026-01-07 | $2,710.34 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-01-07 | $2,665.03 | txn | DELETED | ACT-GD | - | xero_tracking |
+
+### BUNNINGS WAREHOUSE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-11 | $616.97 | bill | PAID | ACT-IN | - | xero_tracking |
+| 2026-01-12 | $616.97 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-03-27 | $111.20 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+| 2026-03-27 | $111.20 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-15 | $111.20 | bill | PAID | ACT-HV | RB20247849280 | xero_tracking |
+| 2026-04-21 | $322.94 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-24 | $2,223.94 | bill | PAID | ACT-HV | 001-75845-8176-2026-04-24 | xero_tracking |
+| 2026-05-01 | $310.32 | bill | PAID | ACT-HV | W284861346 | xero_tracking |
+| 2026-05-02 | $427.88 | bill | PAID | ACT-HV | RB20420226420 | xero_tracking |
+| 2026-05-05 | $27.78 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-05 | $310.32 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-12 | $59.82 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-14 | $864.19 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-17 | $208.86 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-05-19 | $62.80 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-06-04 | $66.72 | txn | DELETED | ACT-CN | - | xero_tracking |
+| 2026-06-08 | $1,660.63 | txn | DELETED | ACT-HV | - | xero_tracking |
+
+### DNP AUSTRALIA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-16 | $739.54 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-14 | $4,063.89 | bill | PAID | ACT-HV | 97608 | xero_tracking |
+
+### BIONIC GROUP
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-21 | $4,705.00 | bill | PAID | ACT-GD | INV-5102 | manual |
+| 2026-04-29 | $3,320.00 | bill | VOIDED | ACT-HV | RB20383392160 | xero_tracking |
+
+### SYDNEY TOOLS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-05 | $4,557.00 | bill | PAID | ACT-HV | 20414969 | xero_tracking |
+
+### TOTAL TOOLS EAST BRISBANE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-04 | $4,546.55 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+| 2026-01-05 | $4,546.55 | txn | DELETED | ACT-HV | - | xero_tracking |
+
+### HATCH ELECTRICAL
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-12 | $772.62 | bill | PAID | ACT-FM | - | xero_tracking |
+| 2026-01-13 | $772.62 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-02-18 | $1,421.55 | bill | AUTHORISED | ACT-FM | 829 | vendor_rule |
+| 2026-02-19 | $1,443.03 | txn | AUTHORISED | NULL | - |  |
+
+### THE MATNIC TRUST
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-09 | $2,826.92 | bill | VOIDED | ACT-IN | - | xero_tracking |
+| 2026-01-10 | $2,826.92 | bill | PAID | ACT-GD | 00036199 | xero_tracking |
+| 2026-03-11 | $591.28 | bill | PAID | ACT-HV | 00036245 | xero_tracking |
+
+### CHRIS W
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-19 | $380.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-02-09 | $722.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-09 | $809.50 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-07 | $583.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-18 | $100.88 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-18 | $600.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-18 | $164.91 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### LIBERTY MALENY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-15 | $367.69 | bill | PAID | ACT-IN | - | xero_tracking |
+| 2026-01-16 | $367.69 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-01-19 | $120.58 | bill | PAID | ACT-FM | 747013-6 | xero_tracking |
+| 2026-01-24 | $323.67 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-02-06 | $194.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-02-06 | $213.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-02-18 | $139.50 | bill | PAID | ACT-GD | 758155-6 | xero_tracking |
+| 2026-02-19 | $216.07 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-08 | $212.77 | bill | PAID | ACT-HV | 765074-6 | xero_tracking |
+| 2026-03-17 | $536.63 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-24 | $5.00 | bill | PAID | ACT-HV | 782366-6 | xero_tracking |
+| 2026-05-04 | $100.88 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-09 | $272.26 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-15 | $164.91 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-18 | $183.19 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-28 | $35.17 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### WOOLWORTHS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-15 | $279.25 | bill | PAID | ACT-GD | 4236 | xero_tracking |
+| 2026-01-26 | $124.89 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-02-02 | $88.43 | txn | AUTHORISED | ACT-IN | - | vendor_rule |
+| 2026-02-09 | $124.10 | txn | AUTHORISED | ACT-JP | - | xero_tracking |
+| 2026-02-12 | $60.50 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-02 | $585.36 | bill | PAID | ACT-IN | 5663 | vendor_rule |
+| 2026-03-09 | $116.82 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-12 | $16.90 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-12 | $101.55 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-15 | $42.50 | bill | PAID | ACT-IN | - | xero_tracking |
+| 2026-03-15 | $42.50 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-20 | $68.10 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-14 | $59.30 | txn | DELETED | ACT-IN | - | xero_tracking |
+| 2026-04-15 | $38.10 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-04-15 | $59.30 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-16 | $18.00 | bill | PAID | ACT-HV | 4604 | xero_tracking |
+| 2026-04-17 | $24.80 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-22 | $56.64 | bill | PAID | ACT-HV | 397 | xero_tracking |
+| 2026-04-27 | $45.02 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-27 | $282.28 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-05 | $269.66 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-08 | $100.25 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-13 | $28.30 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-20 | $36.35 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-24 | $94.33 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-06-03 | $131.50 | txn | DELETED | NULL | - |  |
+| 2026-06-04 | $131.50 | txn | AUTHORISED | NULL | - |  |
+| 2026-06-08 | $13.25 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### IGA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-26 | $366.58 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-02-04 | $248.06 | bill | PAID | ACT-GD | 410792 | xero_tracking |
+| 2026-02-06 | $62.97 | bill | PAID | ACT-GD | 411643 | xero_tracking |
+| 2026-02-13 | $119.89 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-03-03 | $33.42 | bill | PAID | ACT-FM | 417591 | vendor_rule |
+| 2026-03-06 | $294.04 | bill | PAID | ACT-HV | 513985 | xero_tracking |
+| 2026-03-06 | $26.99 | bill | PAID | ACT-HV | 418236 | xero_tracking |
+| 2026-03-16 | $161.07 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-28 | $8.95 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-03-28 | $51.01 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-03-31 | $44.28 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-04-07 | $111.51 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-04-23 | $206.86 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-25 | $484.84 | txn | AUTHORISED | NULL | - |  |
+| 2026-06-20 | $71.70 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-20 | $59.97 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### SUNSHINE COAST COUNCIL
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-19 | $1,738.03 | bill | PAID | ACT-FM | - | xero_tracking |
+| 2026-01-20 | $1,738.03 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-03-04 | $148.00 | bill | PAID | ACT-HV | WM217422\1 | xero_tracking |
+| 2026-03-06 | $35.00 | txn | AUTHORISED | NULL | - |  |
+| 2026-05-05 | $35.00 | txn | AUTHORISED | NULL | - |  |
+
+### MAPLETON PUBLIC HOUSE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-17 | $1,120.00 | bill | PAID | ACT-HV | 63666716 | vendor_rule |
+| 2026-02-27 | $280.00 | bill | PAID | ACT-HV | 15626408 | vendor_rule |
+| 2026-03-02 | $280.00 | txn | AUTHORISED | NULL | - |  |
+| 2026-03-06 | $235.83 | txn | AUTHORISED | NULL | - |  |
+
+### OFFICEWORKS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-18 | $426.00 | bill | PAID | ACT-10 | 9406404001730298 | xero_tracking |
+| 2026-02-25 | $23.00 | bill | PAID | ACT-10 | 9407257001376259 | xero_tracking |
+| 2026-02-25 | $4.18 | bill | PAID | ACT-10 | 9407257281375956 | xero_tracking |
+| 2026-03-05 | $357.00 | bill | PAID | ACT-HV | 9408430001224392 | xero_tracking |
+| 2026-03-05 | $3.50 | bill | PAID | ACT-HV | RB19812995460 | xero_tracking |
+| 2026-06-05 | $37.00 | txn | DELETED | ACT-CF | - | xero_tracking |
+| 2026-06-17 | $268.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-23 | $116.30 | txn | AUTHORISED | ACT-CN | - | xero_tracking |
+
+### MALENY HOTEL
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-04-24 | $51.51 | bill | PAID | ACT-HV | 967677 | xero_tracking |
+| 2026-04-27 | $29.28 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-14 | $221.19 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-15 | $111.10 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-26 | $101.51 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-11 | $213.11 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-06-11 | $213.11 | txn | AUTHORISED | NULL | - |  |
+| 2026-06-12 | $219.17 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+
+### FISHER'S OYSTERS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-05 | $1,120.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-10 | $1,120.00 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+
+### BP
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-03 | $34.49 | bill | PAID | ACT-HV | 627781 | xero_tracking |
+| 2026-02-03 | $161.90 | bill | DRAFT | ACT-IN | - | xero_tracking |
+| 2026-02-03 | $148.98 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-02-04 | $161.90 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-02-04 | $125.70 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-02-05 | $148.98 | txn | AUTHORISED | ACT-IN | - | vendor_rule |
+| 2026-02-06 | $161.90 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-02-07 | $153.72 | bill | PAID | ACT-GD | 484385 | xero_tracking |
+| 2026-03-02 | $133.63 | bill | PAID | ACT-10 | RB19763325530 | xero_tracking |
+| 2026-03-03 | $212.21 | txn | AUTHORISED | NULL | - |  |
+| 2026-06-06 | $64.78 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-06-10 | $101.02 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-06-18 | $92.55 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-18 | $5.80 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### MALENY HARDWARE AND RURAL SUPPLIES
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-06 | $507.51 | bill | PAID | ACT-HV | - | xero_tracking |
+| 2026-01-07 | $507.51 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-01-08 | $27.75 | bill | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-01-09 | $27.75 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-01-14 | $65.64 | bill | VOIDED | ACT-HV | - | xero_tracking |
+| 2026-01-15 | $40.19 | bill | VOIDED | ACT-HV | - | xero_tracking |
+| 2026-01-15 | $65.64 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-01-16 | $40.19 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-01-19 | $133.58 | txn | AUTHORISED | ACT-HV | - | ai_router |
+| 2026-02-21 | $38.85 | bill | AUTHORISED | ACT-HV | 195821 | vendor_rule |
+| 2026-02-23 | $16.95 | bill | AUTHORISED | ACT-HV | 195962 | vendor_rule |
+| 2026-02-25 | $47.90 | txn | AUTHORISED | NULL | - |  |
+| 2026-02-25 | $81.90 | txn | AUTHORISED | NULL | - |  |
+| 2026-03-26 | $113.40 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-26 | $113.40 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-03-28 | $224.10 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-04-13 | $278.30 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-27 | $266.95 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-29 | $77.70 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-04-30 | $902.85 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-05-04 | $76.00 | txn | DELETED | ACT-FM | - | xero_tracking |
+| 2026-05-21 | $35.70 | txn | AUTHORISED | ACT-HV | - | ai_router |
+
+### HYDRAULINK BRISBANE NORTH
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-11 | $883.07 | bill | PAID | ACT-HV | - | xero_tracking |
+| 2026-01-12 | $883.07 | txn | DELETED | ACT-FM | - | xero_tracking |
+
+### AMAZON
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-27 | $28.99 | txn | AUTHORISED | NULL | - |  |
+| 2026-02-13 | $126.50 | txn | AUTHORISED | NULL | - |  |
+| 2026-02-17 | $93.40 | txn | AUTHORISED | NULL | - |  |
+| 2026-02-20 | $349.48 | txn | AUTHORISED | NULL | - |  |
+| 2026-02-25 | $9.99 | bill | PAID | ACT-IN | D01-8609354-2418638 | vendor_rule |
+| 2026-05-01 | $49.00 | txn | AUTHORISED | NULL | - |  |
+| 2026-05-01 | $28.99 | txn | AUTHORISED | NULL | - |  |
+| 2026-06-01 | $167.18 | txn | AUTHORISED | NULL | - |  |
+
+### BOOKING.COM
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-23 | $202.50 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-04-07 | $601.36 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+
+### CALTEX GLASSHOUSE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-05 | $94.17 | bill | PAID | ACT-HV | 00939190 | xero_tracking |
+| 2026-05-06 | $99.80 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-05-26 | $375.16 | txn | AUTHORISED | ACT-GD | - | xero_tracking |
+| 2026-06-12 | $132.61 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### AVIS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-22 | $483.60 | bill | PAID | ACT-IN | RB19733002060 | vendor_rule |
+| 2026-03-11 | $312.11 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-03-11 | $1,247.62 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-03-11 | $672.08 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-03-11 | $483.60 | txn | DELETED | ACT-GD | - | xero_tracking |
+| 2026-04-10 | $160.18 | txn | DELETED | ACT-IN | - | xero_tracking |
+| 2026-04-11 | $8.35 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-13 | $170.25 | txn | AUTHORISED | ACT-IN | - | vendor_rule |
+| 2026-04-17 | $8.30 | txn | AUTHORISED | ACT-IN | - | vendor_rule |
+
+### MALENY HARDWARE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-31 | $641.09 | bill | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### POCKY ASIAN RESTAURANT
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-12 | $119.06 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-01-19 | $206.44 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-03-29 | $81.10 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-06-13 | $79.79 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### GOOGLE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-28 | $67.98 | bill | PAID | ACT-IN | - | xero_tracking |
+| 2026-03-10 | $300.00 | bill | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-04-01 | $67.98 | bill | PAID | ACT-IN | - | vendor_rule |
+
+### KENNARDS HIRE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-05-20 | $405.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### UNKNOWN SUPPLIER
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-22 | $43.10 | txn | AUTHORISED | ACT-JH | - | xero_tracking |
+| 2026-02-01 | $103.59 | bill | PAID | ACT-HV | 297670 | xero_tracking |
+| 2026-03-09 | $185.25 | bill | AUTHORISED | ACT-EL | POS069630(527) | xero_tracking |
+
+### NEST IN WITTA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-21 | $35.70 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-01-28 | $44.88 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-04 | $17.85 | bill | PAID | ACT-HV | HXCc | xero_tracking |
+| 2026-03-13 | $5.10 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-03-16 | $5.10 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-22 | $20.09 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-23 | $20.09 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-04-24 | $24.48 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-04-27 | $24.48 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-06 | $5.10 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-07 | $6.12 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-08 | $10.40 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-05-08 | $6.12 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-11 | $26.52 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-11 | $10.40 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-28 | $5.61 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-11 | $26.52 | txn | DELETED | ACT-HV | - | xero_tracking |
+| 2026-06-12 | $32.64 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-13 | $14.79 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-18 | $58.34 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### SAVAGE TRANSPORT TRUST
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-02 | $300.00 | bill | PAID | ACT-HV | 333 | xero_tracking |
+
+### SUKHOTHAI AUTHENTIC THAI RESTAURANT
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-05 | $268.10 | bill | PAID | ACT-HV | Suk000026 | xero_tracking |
+
+### COLES SUPERMARKETS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-20 | $48.45 | bill | PAID | ACT-10 | 7821 | xero_tracking |
+| 2026-02-26 | $33.65 | bill | PAID | ACT-10 | 8978 | xero_tracking |
+| 2026-03-05 | $106.28 | bill | PAID | ACT-HV | 3848 | xero_tracking |
+| 2026-03-20 | $16.98 | txn | AUTHORISED | ACT-FM | - | vendor_rule |
+| 2026-03-31 | $12.10 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-04-16 | $4.00 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-05-16 | $45.56 | txn | AUTHORISED | ACT-OO | - | xero_tracking |
+
+### 7-ELEVEN
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-26 | $11.50 | txn | AUTHORISED | ACT-EL | - | xero_tracking |
+| 2026-03-28 | $103.64 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+| 2026-05-14 | $132.96 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-06-20 | $12.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### BUSSELL RURAL CO PTY LTD T/AS MALENY HARDWARE & RURAL
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-06 | $237.70 | bill | PAID | ACT-HV | - | xero_tracking |
+
+### SALIN APPLIANCE SPARES
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-10 | $228.90 | bill | VOIDED | NULL | - | manual-duplicate-of-salin-paid |
+| 2026-03-11 | $228.90 | bill | PAID | ACT-HV | - | xero_tracking |
+| 2026-03-11 | $228.90 | txn | DELETED | ACT-GD | - | xero_tracking |
+
+### FLIGHT BAR WITTA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-03 | $20.68 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-02-03 | $40.16 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-02-05 | $88.95 | txn | AUTHORISED | ACT-GD | - | manual |
+| 2026-05-19 | $32.99 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-20 | $26.54 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+| 2026-05-21 | $6.46 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### MALENY BAKERY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-03 | $8.40 | bill | AUTHORISED | ACT-HV | 788506 | manual |
+| 2026-04-24 | $185.34 | bill | PAID | ACT-HV | 00#00297088 | xero_tracking |
+
+### COASTAL FASTENERS
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-30 | $35.20 | txn | AUTHORISED | NULL | - |  |
+| 2026-04-16 | $130.94 | bill | PAID | ACT-HV | RB20247673190 | xero_tracking |
+
+### LIGHT YEARS ASIAN DINER
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-18 | $138.00 | bill | PAID | ACT-SH | - | keyword_match |
+| 2026-01-19 | $138.00 | txn | DELETED | ACT-HV | - | xero_tracking |
+
+### GOOGLE AUSTRALIA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-30 | $67.98 | bill | PAID | ACT-IN | - | xero_tracking |
+| 2026-01-31 | $67.98 | txn | DELETED | ACT-IN | - | xero_tracking |
+| 2026-02-28 | $67.98 | txn | DELETED | ACT-IN | - | xero_tracking |
+| 2026-03-31 | $67.98 | txn | DELETED | ACT-IN | - | xero_tracking |
+| 2026-04-30 | $67.98 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+
+### SUPERCHEAP AUTO
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-25 | $119.99 | bill | PAID | ACT-10 | 54176 | xero_tracking |
+| 2026-03-05 | $9.99 | bill | PAID | ACT-HV | 893860 | xero_tracking |
+
+### BOLT IN CO SUNSHINE COAST
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-04-16 | $127.60 | bill | PAID | ACT-HV | 87653 | xero_tracking |
+
+### ART MUSEUM
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-02-22 | $120.00 | bill | PAID | ACT-HV | 7MH-5CK-CY9N | xero_tracking |
+
+### MALENY HARDWARE & RU
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-26 | $113.40 | bill | AUTHORISED | ACT-HV | - | manual-bulk-2026-05-30 |
+
+### AUSCOT RURAL CO PTY LTD T/AS MALENY HARDWARE & RURAL
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-26 | $113.40 | bill | PAID | ACT-HV | - | manual-bulk-2026-05-30 |
+
+### ALSAHWA ESTATE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-01-17 | $105.67 | bill | PAID | ACT-SH | - | keyword_match |
+| 2026-01-18 | $105.67 | txn | DELETED | ACT-HV | - | xero_tracking |
+
+### MALENY FOOD CO CAFE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-03 | $22.33 | bill | PAID | ACT-HV | 1141261 | xero_tracking |
+| 2026-03-06 | $46.59 | bill | PAID | ACT-HV | 4141685 | xero_tracking |
+
+### THE SOURCE BULK FOODS MALENY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-06 | $24.22 | bill | PAID | ACT-HV | 138974-257 | xero_tracking |
+| 2026-04-08 | $36.17 | txn | AUTHORISED | ACT-IN | - | xero_tracking |
+
+### MALENY HOT BREAD BAKE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-06-13 | $54.76 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### THE DAWN POTTERY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-06-20 | $51.92 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### BCF
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-05 | $44.94 | bill | PAID | ACT-HV | RB19811864000 | xero_tracking |
+
+### FRANK FOOD & WINE
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-06 | $23.35 | bill | PAID | ACT-HV | SP-55 0305235449 | xero_tracking |
+| 2026-06-11 | $11.67 | txn | DELETED | ACT-HV | - | xero_tracking |
+
+### CJ'S PASTRIES
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-04 | $14.30 | bill | PAID | ACT-HV | DNy8 | xero_tracking |
+
+### ROSETTA BOOKS MALENY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-06-20 | $5.50 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### SQ *FLIGHT BAR WITTA WITTA
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-09 | $4.00 | txn | AUTHORISED | ACT-HV | - | xero_tracking |
+
+### BENJAMIN KNIGHT
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-04-14 | $59.30 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-15 | $38.10 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-15 | $6.29 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-16 | $11.00 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-16 | $6.00 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-16 | $4.00 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-16 | $6.00 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-16 | $5.00 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-16 | $49.00 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-17 | $5.05 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-17 | $67.95 | bill | VOIDED | ACT-OO | Expense Claims | xero_tracking |
+| 2026-04-17 | $17.23 | bill | VOIDED | ACT-HV | Expense Claims | xero_tracking |
+| 2026-04-24 | $24.48 | bill | VOIDED | ACT-HV | Expense Claims | xero_tracking |
+| 2026-05-06 | $5.10 | bill | VOIDED | ACT-HV | Expense Claims | xero_tracking |
+| 2026-05-07 | $6.12 | bill | VOIDED | ACT-HV | Expense Claims | xero_tracking |
+| 2026-05-12 | $30.00 | bill | VOIDED | ACT-PI | Expense Claims | xero_tracking |
+| 2026-05-12 | $10.29 | bill | VOIDED | ACT-PI | Expense Claims | xero_tracking |
+
+### PESTWORX MALENY
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-03-28 | $165.00 | bill | VOIDED | ACT-HV | RB20053541250 | xero_tracking |
+
+### BRISBANE CITY COUNCIL
+| Date | $ | Kind | Status | Proj | inv# | Source |
+|---|---:|---|---|---|---|---|
+| 2026-05-14 | $100.04 | txn | DELETED | ACT-HV | - | xero_tracking |


### PR DESCRIPTION
## What
Forensic re-clean of The Harvest (ACT-HV) spend after a Xero sync wiped the May clean-up.

**Root-cause bug:** the project finance API (`/api/finance/projects/[code]`) and the ledger script filtered **bill** status but never **bank-txn** status — so `DELETED`/`VOIDED` spends counted. 36 DELETED ghosts (incl Kennedy's $21K = the voided $8,525 dup + reposts) inflated ACT-HV to ~$135K.

**Fix:** exclude `DELETED`/`VOIDED` bank txns in both the API and the ledger, and guard ACT-HV to `>= 2026-01-01` at read time (durable against the next sync re-leaking pre-Jan rows via tracking categories).

**Result:** clean ACT-HV spend-to-date = **$124,077.68** (verified via ledger; reconciles with the prior ~$126K baseline). Notion "Spend to date" page already refreshed to match.

## Files
- `apps/command-center/.../finance/projects/[code]/route.ts` — the API fix
- `scripts/build-harvest-ledger.mjs` — same fix in the ledger
- `scripts/harvest-resweep-{worklist,apply}.mjs`, `build-harvest-notion-rollup.mjs`, `harvest-notion-reconcile.mjs` — the forensic re-sweep tooling
- `thoughts/shared/reports/harvest-resweep-worklist-*.md`, `harvest-notion-rollup-*.json` — evidence

## Verification
- Ledger re-runs to exactly $124,077.68
- `npx tsc --noEmit` clean in command-center

🤖 Generated with [Claude Code](https://claude.com/claude-code)