### PR TITLE
finance: weekly check-in cadence + Dext→Xero AI alignment

### DIFF
--- a/.claude/skills/bas-cycle/SKILL.md
+++ b/.claude/skills/bas-cycle/SKILL.md
@@ -93,7 +93,8 @@ node scripts/sync-bill-attachments-to-txns.mjs --apply  # Copy bill receipts
 - `references/quarterly-learnings.md` — patterns accumulated across quarters
 - `references/q1-fy26-retro.md` — baseline retrospective
 - `workflows/quarterly-checklist.md` — step-by-step BAS prep runbook
-- `workflows/weekly-hygiene.md` — routine maintenance
+- `workflows/weekly-hygiene.md` — routine maintenance (the receipts half of the weekly check-in)
+- `wiki/finance/weekly-finance-checkin.md` — the unified weekly ritual (receipts + card + deadlines); run the weekly pass from here
 
 ## How this skill learns
 

--- a/.claude/skills/bas-cycle/workflows/weekly-hygiene.md
+++ b/.claude/skills/bas-cycle/workflows/weekly-hygiene.md
@@ -1,0 +1,75 @@
+# Weekly hygiene — the bas-cycle routine maintenance pass
+
+The receipts/GST half of the [weekly finance check-in](../../../../wiki/finance/weekly-finance-checkin.md).
+~10–15 min/week during a quarter. The card-line half is `reconcile-cycle`; the two
+run back-to-back in one weekly sitting — see the unified check-in for the full
+running order, deadline ladder, and log.
+
+> **Why weekly, not monthly:** small batches = fewer errors, and receipts get
+> harder to find the colder they get. Weekly capture is also the R&D evidence
+> pass — every receipt kept on an R&D-project cost preserves the 43.5% offset.
+
+## The pass (run from repo root)
+
+```bash
+# 1. Refresh — get onto live data (the mirror lags the last Xero click)
+node scripts/sync-xero-to-supabase.mjs
+node scripts/sync-xero-tokens.mjs --dry-run       # 3 token stores drift; confirm auth live
+
+# 2. Process new receipts
+node scripts/ocr-dext-processing.mjs --apply           # OCR new Dext rows
+node scripts/match-receipts-to-xero.mjs --apply        # auto-match new receipts to txns
+node scripts/sync-bill-attachments-to-txns.mjs --apply # copy bill receipts → bank txns
+
+# 3. Check the trend for the LIVE quarter (swap Q4 for the current quarter)
+node scripts/bas-completeness.mjs Q4
+node scripts/bas-completeness.mjs Q4 --gap-only        # only the genuine missing receipts
+```
+
+## What "good" looks like
+
+- **Coverage % climbs or holds every week.** If it *declines*, stop and
+  investigate — something regressed (a sync break, a new unreceipted vendor, a
+  batch of DELETED-shadow rows polluting the count). Don't just re-run and hope.
+- **The gap list shrinks toward the sub-$82.50 / no-receipt-needed floor.**
+  Above that floor, chase; at/below it, most are fees/transfers/drawings that
+  legitimately need no receipt (path 6 of the 6-path model).
+
+## Per-row fixes → the workbench, not the CLI
+
+The scripts above are the *batch* auto-match. Per-row receipt/project assignment
+happens on **`/finance/workbench`** (Receipt gaps card), which stamps
+`manual_workbench` so the nightly auto-taggers don't overwrite your call. Do the
+judgment calls there, not by hand-editing the mirror.
+
+## Vendor playbooks (don't re-derive)
+
+Before chasing a vendor's missing receipt, check
+`references/vendor-patterns.md` — most recurring vendors have a known move:
+
+- **Qantas / Uber / Webflow / Virgin / Booking.com** — connectors already create
+  ACCPAY bills with PDFs attached. The receipt is in Xero on the *bill* side;
+  it just needs Find & Match to the bank line. **Don't download from the vendor
+  portal — it's already there, on the wrong side.**
+- **SaaS relayed through Stripe** (Supabase, Descript, Anthropic) — the tight
+  `from:domain` Gmail search misses these; use `receipt-broad-search.mjs`.
+
+## Money guards (same as the whole suite)
+
+Two-account rule (NAB Visa #8815 + NJ Marchesi T/as ACT Everyday only) · exclude
+DELETED/VOIDED (NULL-safe) · sum GST in SQL not supabase-js (1000-row cap) ·
+verify any GST figure against the accrual P&L (`project_monthly_financials`)
+before it goes near a lodgement.
+
+## Time budget
+
+Spend no more than ~15 min/week here. This is *maintenance* — the deep work
+(pre-close sweep, gmail deep-search, ambiguous resolution) belongs to the
+`workflows/quarterly-checklist.md` phases 2–4, not the weekly pass. If the weekly
+hygiene is taking longer every week, something upstream is broken — check before
+blaming workload.
+
+## Close the loop
+
+Append the receipts line to the check-in weekly log, and add any new vendor quirk
+to `references/vendor-patterns.md`. Next week starts one vendor smarter.

--- a/.claude/skills/reconcile-cycle/SKILL.md
+++ b/.claude/skills/reconcile-cycle/SKILL.md
@@ -74,6 +74,7 @@ the reference), date (±12 days), and a **shared vendor token** (amount alone ne
 
 ## Workflows
 
+- `wiki/finance/weekly-finance-checkin.md` — the unified weekly ritual (receipts + card + deadlines). This skill is the card-line step of that pass; run the whole weekly session from there.
 - `workflows/weekly-triage.md` — run the cockpit → work DUPLICATES first → MATCHES → CREATES → export.
 - `workflows/tracer-bullet.md` — prove ONE line end-to-end in Xero before any batch.
 

--- a/thoughts/shared/handoffs/2026-07-08-weekly-checkin-dext-alignment-handoff.md
+++ b/thoughts/shared/handoffs/2026-07-08-weekly-checkin-dext-alignment-handoff.md
@@ -1,0 +1,67 @@
+---
+title: Handoff — weekly finance check-in cadence + Dext→Xero AI alignment
+date: 2026-07-08
+status: open — cadence + strategy shipped (PR #209); execution items need local CLI + UIs
+branch: claude/zero-tax-bas-checkin-gypl9l
+pr: https://github.com/Acurioustractor/act-global-infrastructure/pull/209
+from: claude.ai remote session (Opus 4.8) — read-only status via Xero + Supabase MCP
+related:
+  - wiki/finance/weekly-finance-checkin.md (the ritual)
+  - wiki/finance/dext-xero-ai-alignment.md (the strategy)
+  - thoughts/shared/reports/weekly-checkin-2026-07-08.md (this week's worklist)
+  - thoughts/shared/proposals/monday-finance-checkin-cron.md (Tier-2, proposed)
+---
+
+# Handoff → Claude Code CLI
+
+The remote session could only do **read-only** finance work (Xero + Supabase MCP,
+no repo credentials, no UIs). Everything below needs a **local CLI session** with
+`.env.local`, Xero/Dext auth, and Ben at the Xero/Dext UIs. Start there.
+
+## State (verified live 2026-07-08)
+- **FY26 BAS lodged by Standard Ledger.** Books clean through FY26 (10 residual
+  Visa lines/$2.3K). Next deadline: **Q1 FY27 BAS, due 28 Oct 2026** (first Pty BAS).
+- **Xero still on the sole-trader org** (Nicholas Marchesi, ABN 21591780066) — Pty
+  cutover has NOT switched Xero yet.
+- **Dext 99.3% linked** (1,539/1,550). Orphan pile: **275 gmail-`review` + 97
+  `captured` + 17 `failed` + 39 dext-`review`** (all unlinked).
+- **29 open NAB Visa lines**, all receipted → reconcile clicks pending (Xero UI-only).
+
+## Resume points (in priority order)
+
+### 1. Clear this week's card lines — `reconcile-cycle` (~15 min, Ben in Xero UI)
+- **Code the 4 untagged lines first** (`/finance/tagger-v2`): Apple $14.99,
+  Hugging Face $13.06, Qantas Group Accom $440 (ACT-EL), Qantas $1,492.66 (ACT-EL).
+- Then reconcile all 29 off the sidecar sheet. Worklist:
+  `thoughts/shared/reports/weekly-checkin-2026-07-08.md`.
+- Refresh mirror first: `node scripts/sync-xero-to-supabase.mjs`.
+
+### 2. Clear the receipt orphan pile — the Dext alignment (bigger; systemic)
+Per `wiki/finance/dext-xero-ai-alignment.md`:
+- Triage the 275 gmail-`review` + 97 `captured` + 39 dext-`review`: real & not in
+  Xero → forward into Dext; junk → mark `junk`.
+- **Repoint the Gmail scraper from publisher → gap-detector** (stop it creating the
+  orphan pile). This is the code change that makes the fix stick.
+- Confirm the 4 Dext/Xero config decisions with Ben (plan tier, auto-publish
+  threshold, which mailbox auto-forwards to Dext, retire the Gmail publisher?).
+
+### 3. Wire the Monday nudge (Tier-2 — Ben's go)
+Build `scripts/weekly-finance-checkin.mjs` (thin aggregator) + PM2 entry per
+`thoughts/shared/proposals/monday-finance-checkin-cron.md`, then `pm2 save`.
+
+### 4. Confirm with Standard Ledger (unblocks the record)
+Exact Q4 FY26 lodge date + which two quarters; is the Pty cutover done; start the
+R&D FY25-26 claim assembly (~$200K, due 30 Apr 2027; pack `thoughts/shared/rd-pack-fy26/`).
+
+## Tier gates (don't skip)
+- Reconcile click = Xero UI-only (API can't set IsReconciled) — never automate.
+- Dext/Xero writes, cron install, retiring the publisher = Tier-2/3 → Ben's verb.
+- Money math → TDD-first; two-account rule; sum in SQL not supabase-js; verify vs
+  `project_monthly_financials`.
+
+## Kickoff prompt (paste into the CLI)
+> Read `thoughts/shared/handoffs/2026-07-08-weekly-checkin-dext-alignment-handoff.md`
+> on branch `claude/zero-tax-bas-checkin-gypl9l`, then run resume point 1: refresh
+> the Xero mirror, code the 4 untagged Visa lines, and produce the reconcile
+> worklist for me to click. Then propose resume point 2 (the Dext alignment) before
+> making any changes.

--- a/thoughts/shared/proposals/monday-finance-checkin-cron.md
+++ b/thoughts/shared/proposals/monday-finance-checkin-cron.md
@@ -1,0 +1,55 @@
+# Proposal — Monday "finance check-in" nudge (Tier-2, propose before installing)
+
+**Status:** PROPOSED — not installed. Adding a cron is a Tier-2 shared-state change;
+this documents the wiring for Ben to approve. No PM2/crontab was touched.
+
+## What it does
+Every Monday, one Telegram push that IS the prompt to spend 30–45 min on the
+weekly finance check-in (`wiki/finance/weekly-finance-checkin.md`). It reports the
+three things the pass needs, so opening it is a decision not an investigation:
+1. **Card:** unreconciled Visa lines + $ (from `recon-status.mjs`).
+2. **Receipts:** live-quarter coverage % (from `bas-completeness.mjs`) + Gmail/Dext review backlog.
+3. **Deadline:** nearest `pending` obligation from `compliance-calendar.md`.
+
+It re-classifies nothing — reads the same live sources the cockpit does (single
+source of truth). Silent-if-nothing gate: if 0 unreconciled AND coverage ≥ target
+AND no obligation inside a lead-time window, it doesn't push.
+
+## Where it slots in
+The Monday-morning chain already runs (see `wiki/finance/cron-overview.md`):
+`weekly-project-pulse` 5:30 → `ghl-cleanup` 6:00 → `grant-seed` 6:30 →
+`weekly-reconciliation` 8:00 → `money-framework-sync` 9:10.
+
+Add **after `weekly-reconciliation` (Mon 8:00)** so the mirror is fresh:
+
+```
+# ecosystem.config.cjs — new PM2 entry (cron_restart)
+{
+  name: 'weekly-finance-checkin',
+  script: 'scripts/weekly-finance-checkin.mjs',   // NEW — thin aggregator, see below
+  cron_restart: '5 8 * * 1',                       // Mon 08:05 AEST
+  autorestart: false,
+}
+```
+
+## The script (thin aggregator — to build, ~40 lines)
+`scripts/weekly-finance-checkin.mjs` composes existing engines, emits nothing new:
+```
+recon   = require reconcile status  (scripts/recon-status.mjs engine)
+cover   = bas-completeness for the current quarter
+backlog = COUNT receipt_emails WHERE status IN ('review','captured') AND xero linked IS NULL
+next    = nearest pending row from compliance-calendar.md (build-compliance-calendar.mjs)
+push 5-line Telegram digest linking to wiki/finance/weekly-finance-checkin.md
+  (silent-if-nothing gate as above)
+```
+Reuses `weekly-card-reconcile.mjs --json` for the card block if preferred.
+
+## Guards
+- `--telegram` only (it's an alert, not a snapshot) per cron principles.
+- Silent-if-nothing gate (don't nag on a clean week).
+- Reads live sources; never writes.
+
+## Decision for Ben
+Approve → I build `weekly-finance-checkin.mjs` + wire the PM2 entry + `pm2 save`.
+Until then the cadence runs manually — the doc is the ritual; this just makes the
+Monday nudge automatic.

--- a/thoughts/shared/reports/weekly-checkin-2026-07-08.md
+++ b/thoughts/shared/reports/weekly-checkin-2026-07-08.md
@@ -1,0 +1,52 @@
+# Weekly Finance Check-in — Week of 2026-07-08
+
+First pass of the new cadence (`wiki/finance/weekly-finance-checkin.md`). Read-only
+status pulled live from Xero + the Supabase mirror. **The reconcile clicks below
+are Xero UI-only — this pass prepares the worklist; the clicks stay with Ben/SL.**
+
+## Context
+- **FY27** (1 Jul 2026 – 30 Jun 2027), 8 days in. **FY26 closed.**
+- **Standard Ledger just lodged the last two BAS** (per Ben) → books clean through
+  FY26. Q4 FY25-26 marked `filed` in `compliance-calendar.md` (⚠ confirm exact
+  lodge date + which two quarters with SL).
+- Xero still connected to the **sole-trader org** (Nicholas Marchesi) — Pty cutover
+  hasn't switched Xero yet.
+- **Cash $129,579 · receivables $598,036 · payables $312,888** (payables still
+  carry unreconciled/phantom AP — the accrual figure, not real debt).
+
+## Nearest deadline
+**BAS Q1 FY26-27 (Jul–Sep 2026) — due 28 Oct 2026**, first Pty Ltd BAS. T-112.
+No pressure yet; the job now is to keep the new quarter clean from day one.
+
+## Reconcile worklist — 29 open NAB Visa #8815 lines (all have receipts attached)
+
+**Only the reconcile click is missing.** ~15 min in Xero. Work newest-first.
+
+**4 lines need a project code first** (tag on `/finance/tagger-v2`, then reconcile):
+| Date | Vendor | Amount | Suggested code |
+|---|---|---:|---|
+| 2026-07-06 | Apple Pty Ltd | $14.99 | ACT-IN (or Drawings if personal — confirm) |
+| 2026-07-02 | Hugging Face | $13.06 | ACT-IN (AI/infra) |
+| 2026-07-01 | Qantas Group Accommodation | $440.00 | ACT-EL (NT field trip) |
+| 2026-06-23 | Qantas | $1,492.66 | ACT-EL (NT field trip) |
+
+**25 lines already coded** — reconcile as-is. Dominated by the **NT Empathy Ledger
+field trip (ACT-EL)**: Elliott Store, Arlparra, Diplomat Motel, Nyinkka Cafe,
+Sportspower/Woolworths/IGA/Kmart Alice Springs, Alice Springs Telegraph. Plus
+ACT-GD (Supercheap, Furniture Discounts, Pigglys, GM Taxipay), ACT-IN (HighLevel×3),
+ACT-CN (Australia Post, Officeworks), ACT-HV (IGA Witta ×2). Residual FY26: Qantas
+$1,492.66, Supercheap $310.94, Officeworks $116.30, HighLevel $139.26, IGA ×2, etc.
+
+## Receipts / Dext state
+- **Dext: 1,539 / 1,550 linked (99.3%)** — the rail is healthy.
+- **Orphan pile to clear (systemic):** Gmail `review` 275 · Gmail `captured` 97 ·
+  Gmail `failed` 17 · Dext `review` 39. → see `dext-xero-ai-alignment.md` (demote
+  the Gmail publisher to a gap-detector; forward real gaps into Dext).
+
+## Log entry (mirrors into weekly-finance-checkin.md §4)
+- **Nearest deadline + movement:** Q1 FY27 BAS T-112; FY26 closed & lodged → nothing at risk.
+- **Receipts:** Dext 99.3% linked; 428-item Gmail/Dext review backlog identified for pipeline fix.
+- **Card:** 29 open Visa lines, all receipted → clicks pending in Xero UI (~15 min); 4 need coding.
+- **Mirror caveat:** `is_reconciled` counts are mirror-side (single-GET is truth); expect small drift.
+- **Learned / filed:** built `dext-xero-ai-alignment.md` — three-rail → one-rail plan.
+- **Human minutes:** ~0 (agent status pass); ~20 min of clicks queued for Ben/SL.

--- a/wiki/concepts/finance-skill-suite.md
+++ b/wiki/concepts/finance-skill-suite.md
@@ -40,6 +40,17 @@ the **operators** that drive those surfaces with process, memory and guardrails.
 follow-up; `/finance/invoices` exists, no skill) and a month-end `close-cycle` (`/finance/close` exists,
 no skill). Runway/scenarios are already covered by Money Brain; EOFY cutover is a one-off, not skill-worthy.
 
+## The operating rhythm (how the operators run week to week)
+
+The operators aren't invoked ad-hoc — they run on a **fixed weekly cadence**. The
+canonical ritual is `wiki/finance/weekly-finance-checkin.md`: one ~30–45 min
+day-shift pass that runs `bas-cycle` (receipts/GST) then `reconcile-cycle` (card)
+back-to-back, glances the `compliance-calendar.md` deadline ladder, and logs the
+pass so the learning loops compound. It rolls up into the quarterly BAS phases
+(pre-close → close → prepare-for-accountant → retro) and the annual EOFY / R&D
+ladder. **Weekly is the floor; small batches forever is the whole point** — it's
+what stops the June-2026 heroic-backlog sprint from ever recurring.
+
 ## Suite-wide conventions (every finance skill follows these)
 
 Distilled from `bas-cycle` (the house exemplar), [garrytan/gstack](https://github.com/garrytan/gstack),

--- a/wiki/finance/compliance-calendar.md
+++ b/wiki/finance/compliance-calendar.md
@@ -40,12 +40,17 @@ obligations:
     type: BAS
     entity: sole-trader
     due_date: 2026-07-28
-    status: pending
+    status: filed
+    last_filed_at: 2026-07-07
     lead_times_days: [30, 7, 1]
     notes: |
-      LAST sole-trader BAS. Cutover to Pty happens 30 Jun 2026, so
-      this quarter is split: Apr-Jun sole-trader BAS, Pty Ltd starts
-      its own BAS lifecycle from Q1 FY26-27 (Jul-Sep 2026).
+      LAST sole-trader BAS. Lodged by Standard Ledger early Jul 2026
+      (per Ben, 2026-07-08 — "SL just did the last two BAS"). ⚠ CONFIRM
+      exact lodge date + that Q4 (not another quarter) is one of the two.
+      FY26 mirror is essentially reconciled (10 residual Visa lines/$2.3K).
+      Cutover to Pty: Xero still on the sole-trader org as of 2026-07-08 —
+      Pty Ltd BAS lifecycle starts Q1 FY26-27 (Jul-Sep 2026) once its org
+      is live.
 
   - id: bas-q1-fy26-27-pty
     title: BAS Q1 FY26-27 (Jul-Sep 2026) — FIRST Pty Ltd BAS

--- a/wiki/finance/dext-xero-ai-alignment.md
+++ b/wiki/finance/dext-xero-ai-alignment.md
@@ -1,0 +1,169 @@
+---
+title: Dext + Xero AI alignment — the receipt & reconciliation setup (canonical)
+status: Active
+canonical_slug: dext-xero-ai-alignment
+date: 2026-07-08
+owner: ben
+description: |
+  How receipts should flow through Dext, the vendor connectors, and Xero — and
+  where our custom AI layer (OCR, matching, tagging, reconcile cockpit) fits — so
+  every receipt lands once, coded, on the right Xero record, and the weekly
+  reconcile is a click not a hunt. Written to collapse the current THREE-rail
+  mess into one primary rail (Dext) with the rest feeding into it.
+---
+
+# Dext + Xero AI alignment
+
+> **The one-line thesis:** Dext is already doing 99% of the work — make it the
+> *single* receipt front door, demote the parallel Gmail scraper from "publisher"
+> to "gap-detector", let Xero bank rules mop up the receiptless recurring lines,
+> and keep our custom layer for the two things neither Dext nor Xero can do:
+> **project-tagging reconciliation** and the **per-line reconcile cockpit**.
+
+---
+
+## The evidence (live, 2026-07-08)
+
+| Rail | Volume | Linked to Xero | Verdict |
+|---|---:|---:|---|
+| **Dext** (`source='dext_import'`) | 1,550 | **1,539 (99.3%)** | Working. This is the rail. |
+| **Gmail scraper** (`source='gmail'`) | 817 | 411 (50%) | **275 stuck in `review`, 97 `captured`, 17 `failed` — all unlinked.** The orphan pile. |
+| **Xero Me** (`source='xero_me'`) | 110 | 110 | Fine, low volume. |
+| **Manual upload** | 15 | 4 | Negligible. |
+| Dext `review`/`junk`/`captured` | 90 | 0 | 39 real Dext items awaiting review + 49 junk (marketing noise). |
+
+**Reconcile state (SPEND, excl DELETED/VOIDED):** FY26 NAB Visa is essentially
+done — **10 residual unreconciled lines ($2.3K)**; Everyday clean. FY27 has **19
+fresh lines ($1.8K)** already. **Every one of the 29 open lines already has a
+receipt attached** — the gap is the *reconcile click* (Xero UI-only), not receipts.
+
+**Read this way:** receipts are NOT the problem. Dext + connectors capture them.
+The problems are (a) a parallel Gmail rail that publishes nothing useful and piles
+up orphans, and (b) the reconcile click, which no tool can automate.
+
+---
+
+## The four rails, and what each is FOR
+
+1. **Dext — the primary rail (keep + lean in).**
+   Receipt → Dext (email-in / mobile app / auto-fetch) → Dext AI extracts →
+   publishes to Xero as an ACCPAY bill with the image attached → mirrored to
+   `receipt_emails` as `dext_import`. 99% linked. No item-level Dext API — all
+   config is in the Dext UI (this is fine; config once, runs forever).
+
+2. **Vendor connectors — free and reliable (keep).**
+   Qantas / Uber / Webflow / Virgin / Booking.com auto-create ACCPAY bills with
+   PDFs. **The receipt is already in Xero, on the bill side** — it just needs
+   Find & Match to the bank line (the reconcile cockpit surfaces these). Never
+   download from the vendor portal for these; it's a duplicate.
+
+3. **Custom Gmail pipeline — DEMOTE from publisher to gap-detector.**
+   Today it OCRs Gmail receipts and tries to publish them itself — which created
+   the 275-review / 97-captured orphan pool (receipts half-processed, never
+   landed in Xero, cluttering the mirror). **Stop it publishing.** Repoint it to
+   answer one question: *"which receipts are in Gmail that Dext did NOT capture?"*
+   Those get **forwarded into Dext** (one email), so there's a single publisher.
+
+4. **Xero Me / manual — leave as-is.** Low volume, already linked.
+
+---
+
+## Target architecture — one front door
+
+```
+                         ┌─────────────────────────────┐
+  point-of-purchase ───▶ │  DEXT (single receipt inbox) │ ──▶ Xero ACCPAY bill
+  (Dext mobile app)      │  • email-in address          │      + image attached
+                         │  • supplier rules: account   │
+  finance mailbox   ───▶ │    + project tracking        │
+  (auto-forward to Dext) │  • auto-publish high-conf    │
+                         └─────────────────────────────┘
+  vendor connectors ───▶  Xero ACCPAY bills (Qantas/Uber/…) ──▶ Find & Match weekly
+
+  Gmail scraper (ours) ─▶  GAP REPORT: "in Gmail, not in Dext" ──▶ forward to Dext
+                           (no longer publishes directly)
+
+  ┌── our custom AI layer (owns what Dext/Xero can't) ──────────────────────────┐
+  │  • project-tag reconciliation: cross-check Dext's tracking vs project-resolver│
+  │  • reconcile cockpit /finance/reconcile: per-line verdict, dup + surcharge    │
+  │  • bas-completeness: the 6-path coverage model                                │
+  │  • R&D eligibility tagging (rd_eligible / rd_category)                         │
+  └──────────────────────────────────────────────────────────────────────────────┘
+
+  RECONCILE CLICK ──▶ always Xero UI (API cannot set IsReconciled, permanently)
+```
+
+---
+
+## Who does what (division of AI labour)
+
+| Job | Best tool | Why |
+|---|---|---|
+| Read a receipt image → structured fields | **Dext AI** (primary), our Gemini OCR (fallback for Gmail gap-detect) | Dext is purpose-built + already 99% here; Gemini 2.5 Flash-Lite is our cheap fallback (10× cheaper than Haiku, parity on AU receipts). |
+| Auto-code supplier → account + project | **Dext supplier rules** | Publishes pre-coded so the reconcile is a match, not a decision. |
+| Recurring receiptless lines (bank fees, subs) | **Xero bank rules** (UI; no API) | Set once, auto-codes forever. Shrinks the CREATE pile. |
+| Duplicate / surcharge detection | **Our reconcile cockpit** | Xero's suggested-match is amount-only → the Mar↔May date trap; ours gates amount + date + vendor token. |
+| Project-tag correctness across the ledger | **Our project-resolver + tagging cockpit** | Dext tracking is a starting guess; the resolver + `/finance/tagging` is the source of truth. |
+| "Is this receipt there to click on?" | **Our bas-completeness (6-path model)** | No single tool sees all six coverage paths. |
+| The reconcile click | **Human, in Xero UI** | Not automatable. Ever. Driven off the weekly sidecar sheet. |
+
+**Rule of thumb:** let Dext + Xero do the *capture and first-pass coding*; our
+layer does the *reconciliation of truth* (project tags, duplicates, coverage) and
+*surfaces* the click. Never let two rails publish the same receipt.
+
+---
+
+## Setup checklist (Dext + Xero config — Ben, in the UIs)
+
+**Dext:**
+- [ ] Confirm the Dext **email-in address**; make it the ONE receipt destination.
+- [ ] Add a Gmail **auto-forward rule**: `accounts@act.place` receipts → Dext email-in (so Gmail receipts enter the single rail instead of the scraper).
+- [ ] Install / confirm the **Dext mobile app** on the phones that do field spend — the NT Empathy Ledger trip (Elliott Store, Arlparra, Diplomat Motel…) should be snapped at the till, not chased later.
+- [ ] Set **supplier rules** for the top recurring vendors → auto-set account + project tracking category (start with the ACT-EL / ACT-GD / ACT-IN regulars).
+- [ ] Set **auto-publish** for high-confidence extractions; hold low-confidence in Dext's review, not ours.
+- [ ] Turn on **Dext duplicate detection** (belt with the cockpit's dedup).
+
+**Xero:**
+- [ ] Create **bank rules** for the truly recurring receiptless lines (bank fees, no-invoice subs) so they auto-code on import.
+- [ ] Turn **OFF** "Suggest previous entries" on the bank rec screen (the amount-only green matches are the Mar↔May trap — reconcile off our sidecar sheet instead).
+- [ ] Confirm the connectors (Qantas/Uber/Webflow/Virgin/Booking) are still authorised and publishing.
+
+**Our side (already built — just point it right):**
+- [ ] Repoint the Gmail scraper to **gap-report mode** (detect "in Gmail, not in Dext" → forward), stop it publishing.
+- [ ] Clear the existing backlog: triage the **275 gmail-`review` + 97 `captured` + 39 dext-`review`** — real & not-in-Xero → forward to Dext; junk → mark `junk`.
+
+---
+
+## Cutover implication (do this once, replicate on the Pty org)
+
+Xero is still connected to the **sole-trader org** ("Nicholas Marchesi", ABN
+21591780066) as of 2026-07-08 — the Pty cutover hasn't switched Xero yet. When
+A Curious Tractor Pty Ltd's Xero org goes live, this entire Dext/Xero setup must
+be **re-established against the new org**: Dext publishes to the new org, connectors
+re-authorise, bank rules and supplier rules re-created. **Documenting the config now
+(this file + the checklist) means it's a clean replication, not a rebuild.** Track
+it against the cutover line in `compliance-calendar.md` and the migration checklist
+`thoughts/shared/plans/act-entity-migration-checklist-2026-06-30.md`.
+
+---
+
+## Decisions that need Ben (blocking a "perfect" setup)
+
+1. **Dext plan tier** — does the current plan include supplier rules + auto-publish
+   + the volume we're pushing (~1,900/yr)? If not, the upgrade pays for itself in
+   reconcile time.
+2. **Auto-publish confidence threshold** — how aggressive? (Recommend: auto-publish
+   high-confidence, hold the rest — never blind-publish sub-threshold.)
+3. **Which mailbox forwards to Dext** — `accounts@`? `hi@`? all four?
+4. **Retire or keep** the custom Gmail *publisher*? (Recommend: retire the publish
+   path, keep the gap-detector.)
+
+Answer these and the setup is fully specified. Until then, the weekly cadence
+(`weekly-finance-checkin.md`) already keeps the pile from growing.
+
+## See also
+
+- `wiki/finance/weekly-finance-checkin.md` — the weekly ritual that runs this setup.
+- `.claude/skills/bas-cycle/` — receipts / 6-path coverage / GST.
+- `.claude/skills/reconcile-cycle/` — the card-line cockpit + matching engine.
+- `.claude/references/xero-tax-rd-expert.md` — Xero architecture + connector notes.

--- a/wiki/finance/weekly-finance-checkin.md
+++ b/wiki/finance/weekly-finance-checkin.md
@@ -1,0 +1,226 @@
+---
+title: Weekly Finance Check-in (canonical cadence)
+status: Active
+canonical_slug: weekly-finance-checkin
+date: 2026-07-08
+owner: ben
+description: |
+  The once-a-week, ~30–45 min finance ritual for ACT. One fixed running order
+  that keeps receipts, card reconciliation, and compliance deadlines from ever
+  piling up again — so we never repeat the June-2026 heroic-backlog sprint.
+
+  This is the FRONT DOOR for the weekly session. It ties together the two
+  operators (bas-cycle for receipts/GST, reconcile-cycle for the NAB Visa card)
+  and anchors both to the compliance-calendar deadline ladder. Read this first,
+  then dispatch into whichever skill the week needs.
+---
+
+# Weekly Finance Check-in
+
+> **The rule:** 30–45 minutes, once a week, day-shift. Same running order every
+> time. The point is *small batches, forever* — reconcile weekly, not monthly;
+> chase receipts while they're warm; never let a quarter build to a wall again.
+
+---
+
+## 0. Where we are now (review — dated 2026-07-08, will drift)
+
+**Financial year (live from Xero):** FY27 = **1 Jul 2026 → 30 Jun 2027**. We are
+8 days in. **FY26 (Jul 2025–Jun 2026) has CLOSED.**
+
+**The live deadline — Q4 FY26 BAS, due 28 Jul 2026 (~20 days out).**
+Per `compliance-calendar.md`: Q4 FY25-26 (Apr–Jun 2026) is `pending`. This is the
+**LAST sole-trader BAS** (cutover to A Curious Tractor Pty Ltd was scheduled
+30 Jun 2026). Q3 FY25-26 filed 2026-04-24. This quarter is the immediate focus of
+every weekly pass until it's lodged.
+
+**Backlog state:** The Q2+Q3 FY26 reconciliation backlog was cleared in a June
+sprint (see `thoughts/shared/handoffs/money-state-of-play/current.md`): NAB Visa
+duplicate cleanup done via API (~$86K phantom spend deleted, ~$107K phantom AP
+voided); the reconcile-cycle cockpit + BAS automation engine shipped. **The whole
+reason this cadence exists is to make that sprint a one-off** — weekly hygiene
+keeps the pile from ever rebuilding.
+
+**Open questions to confirm with Standard Ledger (don't assert — verify):**
+1. Is the Pty Ltd cutover actually complete, and is Q4 FY26 the true last
+   sole-trader BAS? (Calendar says cutover 30 Jun 2026, `pending`.)
+2. Q2 FY25-26 (Oct–Dec 2025) lodgement status — not in the calendar; confirm it
+   was lodged (due would have been 28 Feb 2026).
+3. R&D FY25-26 claim (~$200K, Path C) — filable from 1 Jul 2026, due 30 Apr 2027.
+   Evidence pack: `thoughts/shared/rd-pack-fy26/`.
+
+---
+
+## 1. The near-term deadline ladder (glance every week)
+
+Source of truth: **`wiki/finance/compliance-calendar.md`** (all fixed dates +
+T-30/T-7/T-1 Telegram alerts via `scripts/compliance-alerts.mjs`). The weekly
+check-in doesn't duplicate it — it *reads* it. The nearest obligations from today:
+
+| Due | Obligation | Entity | Status |
+|---|---|---|---|
+| **2026-07-28** | **BAS Q4 FY25-26 (Apr-Jun 2026)** — last sole-trader BAS | sole-trader | pending |
+| 2026-10-28 | BAS Q1 FY26-27 (Jul-Sep 2026) — first Pty Ltd BAS | pty-ltd | pending |
+| 2026-10-31 | ATO annual return FY25-26 (sole trader) | sole-trader | pending |
+| 2026-12-31 | ACNC Annual Information Statement — A Kind Tractor Ltd | charity | pending |
+| 2027-02-28 | BAS Q2 FY26-27 · ATO annual FY25-26 (Pty stub) | pty-ltd | pending |
+| 2027-04-24 | ASIC annual review — ACT Pty Ltd (first) | pty-ltd | pending |
+| 2027-04-30 | **R&D Tax Incentive claim FY25-26 (~$200K refund)** | pty-ltd | pending |
+
+**Each week, ask one question:** *what is the nearest `pending` obligation, and
+did this pass move it forward?* Right now that's Q4 FY26 BAS. When it's lodged,
+mark it `filed` in `compliance-calendar.md` and the ladder rolls to Q1 FY27.
+
+---
+
+## 2. The weekly ritual — fixed running order
+
+Work in this order every time. Value order, not comfort order: refresh first so
+you're on live data, then receipts (cheap, keeps R&D + GST credits intact), then
+the card (recovers double-counted money), then the deadline glance, then log.
+
+### Step 1 — Refresh the mirror (2 min)
+```bash
+node scripts/sync-xero-to-supabase.mjs        # mirror Xero → Supabase
+node scripts/sync-xero-tokens.mjs --dry-run    # confirm auth is live (3 token stores drift)
+```
+> The mirror lags the last Xero click until synced. `is_reconciled` in the mirror
+> is not authoritative — only a per-line single-GET is truth (June-2026 finding).
+
+### Step 2 — Receipts hygiene (10 min) → `bas-cycle`
+Runbook: **`.claude/skills/bas-cycle/workflows/weekly-hygiene.md`**.
+```bash
+node scripts/ocr-dext-processing.mjs --apply           # OCR new Dext rows
+node scripts/match-receipts-to-xero.mjs --apply        # auto-match new receipts
+node scripts/sync-bill-attachments-to-txns.mjs --apply # copy bill receipts → bank txns
+node scripts/bas-completeness.mjs Q4                    # coverage trend for the LIVE quarter
+```
+Target: coverage % should climb or hold every week. If it declines, stop and
+investigate — something regressed. Per-row receipt/project fixes happen on
+`/finance/workbench` (Receipt gaps card), which stamps `manual_workbench` so the
+nightly auto-taggers don't overwrite the call.
+
+### Step 3 — Card reconciliation triage (15 min) → `reconcile-cycle`
+Runbook: **`.claude/skills/reconcile-cycle/workflows/weekly-triage.md`**.
+```bash
+node scripts/recon-status.mjs                                  # always-current overview
+node scripts/reconcile-sidecar.mjs --scope fy26 --verify --limit 100  # per-line + single-GET truth
+```
+Then in the **`/finance/reconcile` cockpit** (https://command.act.place/finance/reconcile):
+work **Duplicates first** (they double-count spend) → **Matches** → **Creates**.
+Do the reconcile clicks **in Xero** off the sidecar sheet — the Xero API cannot
+set `IsReconciled` (UI-only, permanent). **Never bulk-accept green Match
+suggestions** (Xero matches on amount not date — the Mar↔May trap).
+
+### Step 4 — Compliance glance (2 min)
+Open `compliance-calendar.md` (or `/finance/command` AT RISK pane). Confirm the
+nearest `pending` obligation and whether this pass advanced it. Anything filed →
+set `status: filed` + `last_filed_at`.
+
+### Step 5 — Read the money (3 min)
+The strategic glance, not an operation: **Notion ACT Money Framework** (📡 Today's
+Pulse, refreshed daily 8:13am) or the Telegram 8am briefing. Are cash, runway, and
+pile-mix where you expect? This is where "strong understanding" accumulates —
+you're building the mental model, not just clearing a queue.
+
+### Step 6 — Close the loop: log + learn (5 min)
+- Append a dated entry to the **weekly log** (§4 below).
+- New confirmed card duplicate → `reconcile-cycle/references/confirmed-duplicates.md`.
+- New messy bank descriptor you decoded → `reconcile-cycle/references/vendor-aliases.md`.
+- New vendor receipt quirk → `bas-cycle/references/vendor-patterns.md`.
+- The learning loop is what makes next week's pass *shorter*. Skip it and the
+  cadence stops compounding.
+
+---
+
+## 3. Money guards (read before quoting any dollar figure)
+
+Both operators carry these; they apply to every weekly pass:
+
+1. **Two-account rule.** ACT business money lives only in **NAB Visa ACT #8815**
+   (card) + **NJ Marchesi T/as ACT Everyday** (bank). Exclude `NM Personal` and
+   `NJ Marchesi T/as ACT Maximiser` from every total.
+2. **Exclude DELETED/VOIDED** rows (NULL-safe `IS DISTINCT FROM 'DELETED'`) — a
+   voided row is neither a supply nor an acquisition.
+3. **Sum in SQL, not supabase-js.** A quarter is >1000 rows; supabase-js silently
+   truncates at the PostgREST 1000-row cap. Use `execute_sql` / `psql` `SUM()`.
+4. **Surcharge ≠ duplicate.** Bank ≥ bill by ≤$15 and ≤6% = one purchase with a
+   card fee, not a second purchase.
+5. **Verify before lodging.** Reconcile any GST / spend figure against the
+   canonical accrual P&L (`project_monthly_financials`). A silent wrong number is
+   the expensive finance failure.
+
+---
+
+## 4. The weekly log (where each pass is recorded)
+
+**Whole-pass summary** goes here (this file, append below). **Deep card detail**
+stays in `thoughts/shared/reviews/reconcile-weekly-log.md` (the reconcile-cycle
+learning loop). Keep the summary to 6 lines so the habit survives.
+
+### Entry template
+```
+## Week of YYYY-MM-DD
+- Nearest deadline + did this pass move it: (e.g. Q4 FY26 BAS, T-20 → coverage 80→84%)
+- Receipts: coverage % now / new gaps chased:
+- Card: clicks done / backlog remaining / $ duplicates recovered:
+- Mirror lies or false-matches caught this week:
+- One thing learned or filed (ref / issue #):
+- Human minutes spent:
+```
+
+<!-- Append new weekly entries below this line, most recent first -->
+
+---
+
+## 5. Escalation — when the weekly pass isn't enough
+
+The weekly cadence is the floor. It rolls up into larger rhythms:
+
+- **2 weeks before a quarter ends** → run the `bas-cycle` pre-close sweep
+  (`workflows/quarterly-checklist.md` Phase 2): full completeness report, gmail
+  deep-search, ambiguous-match resolution.
+- **Quarter end** → close + prepare-for-accountant (Phases 3–4): bank-transfer
+  pairing, `prepare-bas.mjs Q{N} --save`, accountant brief, hand to Standard
+  Ledger.
+- **After a BAS is lodged** → `bas-retrospective.mjs Q{N}-FY{YY}` (Phase 5). The
+  quarter's learnings feed back so the next one closes cleaner.
+
+**Stop and ask for help if:** coverage trend declines instead of improving · a
+vendor shows 10+ unreceipted txns with no matching bill anywhere · Xero sync
+fails repeatedly · a BAS figure won't reconcile against the accrual P&L ·
+Standard Ledger flags a discrepancy.
+
+---
+
+## 6. Ready for next stage — what this cadence is building toward
+
+The weekly ritual isn't housekeeping for its own sake. It's the contemporaneous
+record that unlocks the next stage:
+
+- **EOFY FY26 close** (now → ~Aug 2026): clean books = a clean final sole-trader
+  BAS and a clean handover to Standard Ledger for the cross-entity journals.
+- **R&D Tax Incentive FY25-26 claim** (~$200K, assembled Sept–Nov 2026, lodged by
+  30 Apr 2027): every receipt captured and every cost correctly project-tagged
+  *now* is refund preserved later — **every missing receipt on an R&D project
+  reduces the 43.5% offset.** The weekly receipts pass IS the R&D evidence pass.
+- **Pty Ltd bookkeeping lifecycle** (first BAS Q1 FY26-27, due 28 Oct 2026): the
+  same weekly cadence carries straight over to the new entity — same ritual, new
+  org in Xero.
+
+Strategy detail for the next stage: `wiki/finance/founder-pay-and-rd-thesis-fy26-fy27.md`,
+`wiki/finance/act-money-thesis-discussion.md`, `wiki/finance/rdti-claim-strategy.md`.
+
+---
+
+## Surfaces & operators (the map)
+
+**Four surfaces:** Notion reads · command-center operates · scripts automate ·
+Telegram pushes (`.claude/references/finance-surfaces.md`).
+
+**Operators driven by this cadence:**
+- `bas-cycle` — receipts, GST, quarterly BAS, learning loop.
+- `reconcile-cycle` — NAB Visa card-line matching + dedup.
+- `compliance-calendar.md` + `compliance-alerts.mjs` — the deadline ladder + alerts.
+
+Full team map: `wiki/concepts/finance-skill-suite.md`.

--- a/wiki/finance/weekly-finance-checkin.md
+++ b/wiki/finance/weekly-finance-checkin.md
@@ -28,26 +28,33 @@ description: |
 **Financial year (live from Xero):** FY27 = **1 Jul 2026 → 30 Jun 2027**. We are
 8 days in. **FY26 (Jul 2025–Jun 2026) has CLOSED.**
 
-**The live deadline — Q4 FY26 BAS, due 28 Jul 2026 (~20 days out).**
-Per `compliance-calendar.md`: Q4 FY25-26 (Apr–Jun 2026) is `pending`. This is the
-**LAST sole-trader BAS** (cutover to A Curious Tractor Pty Ltd was scheduled
-30 Jun 2026). Q3 FY25-26 filed 2026-04-24. This quarter is the immediate focus of
-every weekly pass until it's lodged.
+**BAS through FY26 is LODGED.** Standard Ledger just lodged the last two BAS (per
+Ben, 2026-07-08) — Q4 FY25-26 (Apr–Jun 2026) marked `filed` in
+`compliance-calendar.md`. Books are clean through FY26: the mirror shows only **10
+residual unreconciled NAB Visa lines ($2.3K)** and a clean Everyday account.
+**Next deadline is Q1 FY26-27 BAS — due 28 Oct 2026** (first Pty Ltd BAS). No time
+pressure; the job now is to keep the *new* quarter clean from day one.
+
+**The new quarter is already accumulating** — 19 fresh FY27 Visa lines ($1.8K), all
+receipted, mostly the NT Empathy Ledger field trip (ACT-EL). This is exactly what
+the weekly pass is for: clear it while it's small, don't let it become a sprint.
 
 **Backlog state:** The Q2+Q3 FY26 reconciliation backlog was cleared in a June
 sprint (see `thoughts/shared/handoffs/money-state-of-play/current.md`): NAB Visa
 duplicate cleanup done via API (~$86K phantom spend deleted, ~$107K phantom AP
 voided); the reconcile-cycle cockpit + BAS automation engine shipped. **The whole
-reason this cadence exists is to make that sprint a one-off** — weekly hygiene
-keeps the pile from ever rebuilding.
+reason this cadence exists is to make that sprint a one-off.**
+
+**Receipt rails:** Dext is the healthy primary rail (99.3% linked). The parallel
+Gmail scraper is orphaning ~415 half-processed items — the fix is
+`wiki/finance/dext-xero-ai-alignment.md` (collapse three rails to one).
 
 **Open questions to confirm with Standard Ledger (don't assert — verify):**
-1. Is the Pty Ltd cutover actually complete, and is Q4 FY26 the true last
-   sole-trader BAS? (Calendar says cutover 30 Jun 2026, `pending`.)
-2. Q2 FY25-26 (Oct–Dec 2025) lodgement status — not in the calendar; confirm it
-   was lodged (due would have been 28 Feb 2026).
+1. Exact lodge date of Q4 FY26 BAS, and which two quarters SL just lodged.
+2. Is the Pty Ltd cutover complete? Xero is **still on the sole-trader org** as of
+   2026-07-08 — the Pty BAS lifecycle can't start until its Xero org is live.
 3. R&D FY25-26 claim (~$200K, Path C) — filable from 1 Jul 2026, due 30 Apr 2027.
-   Evidence pack: `thoughts/shared/rd-pack-fy26/`.
+   Evidence pack: `thoughts/shared/rd-pack-fy26/`. Worth starting assembly now.
 
 ---
 
@@ -59,8 +66,8 @@ check-in doesn't duplicate it — it *reads* it. The nearest obligations from to
 
 | Due | Obligation | Entity | Status |
 |---|---|---|---|
-| **2026-07-28** | **BAS Q4 FY25-26 (Apr-Jun 2026)** — last sole-trader BAS | sole-trader | pending |
-| 2026-10-28 | BAS Q1 FY26-27 (Jul-Sep 2026) — first Pty Ltd BAS | pty-ltd | pending |
+| 2026-07-28 | BAS Q4 FY25-26 (Apr-Jun 2026) — last sole-trader BAS | sole-trader | **filed** (SL, ~7 Jul) |
+| **2026-10-28** | **BAS Q1 FY26-27 (Jul-Sep 2026)** — first Pty Ltd BAS | pty-ltd | pending |
 | 2026-10-31 | ATO annual return FY25-26 (sole trader) | sole-trader | pending |
 | 2026-12-31 | ACNC Annual Information Statement — A Kind Tractor Ltd | charity | pending |
 | 2027-02-28 | BAS Q2 FY26-27 · ATO annual FY25-26 (Pty stub) | pty-ltd | pending |
@@ -170,6 +177,14 @@ learning loop). Keep the summary to 6 lines so the habit survives.
 ```
 
 <!-- Append new weekly entries below this line, most recent first -->
+
+## Week of 2026-07-08
+- **Nearest deadline + movement:** Q1 FY27 BAS due 28 Oct (T-112). FY26 BAS lodged by SL → nothing at risk.
+- **Receipts:** Dext 99.3% linked (1,539/1,550); ~415 orphaned Gmail/Dext review items identified → pipeline fix in `dext-xero-ai-alignment.md`.
+- **Card:** 29 open NAB Visa lines (10 FY26 residual + 19 FY27), **all receipted** → reconcile clicks queued in Xero UI (~15 min); 4 need a project code first (Apple, Hugging Face, 2× Qantas). Full worklist: `thoughts/shared/reports/weekly-checkin-2026-07-08.md`.
+- **Mirror lies caught:** none this pass; `is_reconciled` counts are mirror-side (single-GET is truth) — small drift expected.
+- **One thing learned / filed:** built the Dext→Xero AI alignment strategy (three rails → one); Q4 FY26 BAS marked filed in the compliance calendar.
+- **Human minutes:** ~0 (agent status pass); ~20 min of Ben/SL clicks queued.
 
 ---
 


### PR DESCRIPTION
## What & why

Establishes a sustainable **weekly finance check-in cadence** so receipts, card reconciliation, and compliance deadlines never pile up into another heroic backlog sprint — and sets the receipt/reconciliation rails up cleanly for the next BAS cycle (first Pty Ltd BAS, due 28 Oct 2026).

Standard Ledger just lodged the last two BAS, so the books are clean through FY26. This work is about **staying** clean, weekly, and about aligning Dext + Xero + our custom AI layer so capture is effortless.

## Current state (live-verified this session)

- **FY27** started; **FY26 BAS lodged** by Standard Ledger. Books clean through FY26 (10 residual NAB Visa lines / $2.3K).
- Xero is **still connected to the sole-trader org** (Nicholas Marchesi) — the Pty cutover hasn't switched Xero yet.
- **29 open card lines** (10 FY26 residual + 19 fresh FY27), **all already receipted** → only the Xero reconcile click is missing (~15 min, UI-only); 4 need a project code.
- **Dext is the healthy primary rail: 99.3% linked.** The parallel Gmail scraper orphans ~415 half-processed items — the systemic fix.

## Changes

**New — the cadence (first PR of this branch):**
- `wiki/finance/weekly-finance-checkin.md` — the canonical once-a-week ritual (fixed running order: refresh → receipts → card → deadline glance → read → log), anchored to the compliance-calendar deadline ladder, money guards, weekly log, escalation to quarterly/annual, and the "ready for next stage" ladder (EOFY → R&D claim → Pty first BAS).
- `.claude/skills/bas-cycle/workflows/weekly-hygiene.md` — fills a broken `SKILL.md` pointer; the receipts half of the pass.
- Cross-links from both skill `SKILL.md` files + `finance-skill-suite.md`.

**New — this session (execution + strategy):**
- `wiki/finance/dext-xero-ai-alignment.md` — collapse the three receipt rails to one: Dext primary; the Gmail scraper demoted from publisher to gap-detector; Xero bank rules for recurring receiptless lines; our layer owns project-tagging + the reconcile cockpit. Includes a Dext/Xero setup checklist, a cutover-replication note (redo on the Pty org), and the open decisions that need Ben.
- `thoughts/shared/reports/weekly-checkin-2026-07-08.md` — the concrete worklist (the 29 lines + the 4 to code).
- `thoughts/shared/proposals/monday-finance-checkin-cron.md` — Monday nudge (Tier-2, **proposed not installed**).

**Updated:**
- `wiki/finance/compliance-calendar.md` — Q4 FY26 BAS marked `filed` (⚠ confirm exact lodge date with SL).
- `wiki/finance/weekly-finance-checkin.md` — current-state refreshed with live numbers + Week-of-2026-07-08 log entry.

## To confirm with Standard Ledger
1. Exact lodge date of Q4 FY26 BAS + which two quarters SL just lodged.
2. Whether the Pty cutover is complete (Xero still on sole-trader org).
3. R&D FY25-26 claim (~$200K) — filable now, due 30 Apr 2027; worth starting assembly.

## Not done here (needs Ben / a UI / explicit go)
- The 29 reconcile clicks (Xero UI-only) + coding the 4 untagged lines.
- Installing the Monday cron (Tier-2 — awaiting approval).
- Dext/Xero config changes + retiring the Gmail publisher path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSR9cwbNcub5a7Yk59mMyK)_