### PR TITLE
GHL: fix PR #211 review blockers B1+B2 (opp pagination + resurrection)

### DIFF
--- a/scripts/lib/ghl-api-service.mjs
+++ b/scripts/lib/ghl-api-service.mjs
@@ -305,15 +305,39 @@ export class GHLService {
    * @returns {Promise<Array>} Opportunities in this pipeline
    */
   async getOpportunities(pipelineId, params = {}) {
-    const queryParams = new URLSearchParams({
-      location_id: this.locationId,
-      pipeline_id: pipelineId,  // v2 API uses snake_case
-      limit: params.limit || 100,
-      ...(params.cursor && { startAfter: params.cursor })
-    });
+    // Paginates through ALL opportunities in the pipeline. Before 2026-07-12
+    // this made a single request capped at 100 rows/pipeline and silently
+    // dropped the rest — which turned the mirror's deletion reconciliation
+    // into a wrong-delete path (PR #211 review B1). GHL v2 pagination:
+    // meta.startAfter (epoch ms) + meta.startAfterId.
+    const pageSize = params.limit || 100;
+    const all = [];
+    let startAfter = params.cursor || null;
+    let startAfterId = params.cursorId || null;
 
-    const data = await this.request(`/opportunities/search?${queryParams}`);
-    return data.opportunities || [];
+    for (;;) {
+      const queryParams = new URLSearchParams({
+        location_id: this.locationId,
+        pipeline_id: pipelineId,  // v2 API uses snake_case
+        limit: pageSize,
+        ...(startAfter && { startAfter }),
+        ...(startAfterId && { startAfterId })
+      });
+
+      const data = await this.request(`/opportunities/search?${queryParams}`);
+      const page = data.opportunities || [];
+      all.push(...page);
+
+      const meta = data.meta || {};
+      // Stop on short page, missing cursor, or non-advancing cursor (loop guard)
+      if (page.length < pageSize || !meta.startAfterId || meta.startAfterId === startAfterId) {
+        break;
+      }
+      startAfter = meta.startAfter;
+      startAfterId = meta.startAfterId;
+    }
+
+    return all;
   }
 
   /**

--- a/scripts/sync-ghl-to-supabase.mjs
+++ b/scripts/sync-ghl-to-supabase.mjs
@@ -57,7 +57,7 @@ const stats = {
 // implausibly small vs the mirror (indicates broken pagination / partial fetch,
 // not real deletions). See 2026-07-12 incident: 1,000-row default cap made the
 // script blind to 3,861 mirror rows.
-const RECONCILE_MIN_LIVE_RATIO = 0.5;
+const RECONCILE_MIN_LIVE_RATIO = 0.8;
 
 /**
  * Load ALL rows from a Supabase table, paginating past the 1,000-row default cap.
@@ -66,7 +66,9 @@ async function loadAllRows(supabase, table, columns, filter = null) {
   const rows = [];
   const PAGE = 1000;
   for (let from = 0; ; from += PAGE) {
-    let query = supabase.from(table).select(columns).range(from, from + PAGE - 1);
+    // Explicit order: PostgREST row order without .order() is unspecified, and
+    // concurrent webhook writes could destabilize pages (PR #211 review nit 1).
+    let query = supabase.from(table).select(columns).order('ghl_id').range(from, from + PAGE - 1);
     if (filter) query = filter(query);
     const { data, error } = await query;
     if (error) throw error;
@@ -375,7 +377,10 @@ async function syncOpportunities(supabase, ghl) {
           ghl_updated_at: opp.updatedAt || opp.dateUpdated || null,
           last_stage_change_at: opp.lastStageChangeAt || null,
           last_status_change_at: opp.lastStatusChangeAt || null,
-          last_synced_at: new Date().toISOString()
+          last_synced_at: new Date().toISOString(),
+          // Resurrection path (PR #211 review B2): an opp present in live GHL is
+          // never left soft-deleted — upsert always restores 'synced'.
+          sync_status: 'synced'
         };
 
         const { error } = await supabase

--- a/scripts/verify-ghl-mirror.mjs
+++ b/scripts/verify-ghl-mirror.mjs
@@ -25,7 +25,8 @@ const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL
 const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 const tolIdx = process.argv.indexOf('--tolerance');
-const TOLERANCE = tolIdx > -1 ? parseFloat(process.argv[tolIdx + 1]) : 0.02;
+const tolParsed = tolIdx > -1 ? parseFloat(process.argv[tolIdx + 1]) : 0.02;
+const TOLERANCE = Number.isFinite(tolParsed) && tolParsed >= 0 ? tolParsed : 0.02;
 
 async function countMirrorActive(supabase, table) {
   const { count, error } = await supabase


### PR DESCRIPTION
Follow-up to #211 — these fixes were reviewed but missed the merge. B1: getOpportunities paginates past the 100/pipeline cap (was feeding a wrong-delete path in reconciliation). B2: opp upsert sets sync_status:'synced' so wrongly soft-deleted rows self-repair. Plus .order() page stability, guard 0.5→0.8, gapcheck NaN fix.