### PR TITLE
GHL target architecture ADR + quarantine sweep (D1)

### DIFF
--- a/scripts/ghl-quarantine-sweep.mjs
+++ b/scripts/ghl-quarantine-sweep.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * GHL Quarantine Sweep — D1 of the target architecture ADR
+ * (wiki/decisions/2026-07-12-ghl-target-architecture.md)
+ *
+ * Tags noise contacts with `status:quarantine` so every list, segment, and
+ * count describes real relationships. Reversible: nothing is deleted, and the
+ * tag can be bulk-removed.
+ *
+ * Cohort predicate (conservative — mirror-derived, all must hold):
+ *   - active in mirror (sync_status <> 'deleted')
+ *   - email IS NULL
+ *   - NO tag in the protected namespaces: project:* comms:* consent:* lane:*
+ *     member-level:* role:* cultural:* or 'storyteller'
+ *   - newsletter_consent is not true
+ *   - no active opportunity
+ *   - not already quarantined
+ *
+ * Usage:
+ *   node scripts/ghl-quarantine-sweep.mjs                # dry-run: count + sample
+ *   node scripts/ghl-quarantine-sweep.mjs --tracer       # apply to exactly 1 contact
+ *   node scripts/ghl-quarantine-sweep.mjs --apply        # full batch
+ *   node scripts/ghl-quarantine-sweep.mjs --apply --limit 100
+ *
+ * Tier 3: only run --tracer/--apply with explicit human go.
+ * Created: 2026-07-12
+ */
+
+import { createGHLService } from './lib/ghl-api-service.mjs';
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_SHARED_URL || process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SHARED_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const QUARANTINE_TAG = 'status:quarantine';
+const PROTECTED_PREFIXES = ['project:', 'comms:', 'consent:', 'lane:', 'member-level:', 'role:', 'cultural:'];
+const PROTECTED_EXACT = ['storyteller'];
+
+const APPLY = process.argv.includes('--apply');
+const TRACER = process.argv.includes('--tracer');
+const limIdx = process.argv.indexOf('--limit');
+const LIMIT = limIdx > -1 ? parseInt(process.argv[limIdx + 1], 10) : null;
+
+function isProtected(tags = []) {
+  return tags.some(t =>
+    PROTECTED_PREFIXES.some(p => t.startsWith(p)) || PROTECTED_EXACT.includes(t)
+  );
+}
+
+async function loadAllRows(supabase, table, columns, applyFilter) {
+  const rows = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    let q = supabase.from(table).select(columns).order('ghl_id').range(from, from + PAGE - 1);
+    if (applyFilter) q = applyFilter(q);
+    const { data, error } = await q;
+    if (error) throw error;
+    rows.push(...data);
+    if (data.length < PAGE) break;
+  }
+  return rows;
+}
+
+async function buildCohort(supabase) {
+  const contacts = await loadAllRows(
+    supabase, 'ghl_contacts',
+    'ghl_id, first_name, last_name, email, tags, newsletter_consent',
+    q => q.neq('sync_status', 'deleted').is('email', null)
+  );
+  const opps = await loadAllRows(
+    supabase, 'ghl_opportunities', 'ghl_contact_id',
+    q => q.neq('sync_status', 'deleted')
+  );
+  const oppContactIds = new Set(opps.map(o => o.ghl_contact_id).filter(Boolean));
+
+  return contacts.filter(c =>
+    !isProtected(c.tags || []) &&
+    !(c.tags || []).includes(QUARANTINE_TAG) &&
+    c.newsletter_consent !== true &&
+    !oppContactIds.has(c.ghl_id)
+  );
+}
+
+async function main() {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) throw new Error('Missing Supabase credentials');
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_KEY);
+  const ghl = createGHLService();
+
+  console.log('═══════════════════════════════════════');
+  console.log('   GHL Quarantine Sweep (D1)');
+  console.log('═══════════════════════════════════════\n');
+
+  let cohort = await buildCohort(supabase);
+  console.log(`Cohort: ${cohort.length} contacts match the quarantine predicate\n`);
+
+  if (TRACER) cohort = cohort.slice(0, 1);
+  else if (LIMIT) cohort = cohort.slice(0, LIMIT);
+
+  if (!APPLY && !TRACER) {
+    console.log('DRY RUN — no writes. Sample (first 20):\n');
+    for (const c of cohort.slice(0, 20)) {
+      console.log(`   ${c.ghl_id}  ${[c.first_name, c.last_name].filter(Boolean).join(' ') || '(no name)'}  tags=[${(c.tags || []).join(',')}]`);
+    }
+    console.log(`\nRun with --tracer (1 contact) then --apply (all ${cohort.length}).`);
+    return;
+  }
+
+  console.log(`${TRACER ? 'TRACER' : 'APPLY'} — tagging ${cohort.length} contact(s) with ${QUARANTINE_TAG}\n`);
+  let ok = 0, failed = 0;
+  const failures = [];
+
+  for (const c of cohort) {
+    try {
+      // GHL write first (source of truth), then mirror so lists are honest now
+      await ghl.addTagToContact(c.ghl_id, QUARANTINE_TAG);
+      const newTags = [...new Set([...(c.tags || []), QUARANTINE_TAG])];
+      const { data, error } = await supabase
+        .from('ghl_contacts')
+        .update({ tags: newTags, updated_at: new Date().toISOString() })
+        .eq('ghl_id', c.ghl_id)
+        .select('ghl_id');
+      if (error) throw error;
+      if (!data || data.length !== 1) throw new Error(`mirror update matched ${data?.length ?? 0} rows`);
+      ok++;
+      process.stdout.write('+');
+    } catch (err) {
+      failed++;
+      failures.push({ ghl_id: c.ghl_id, error: err.message });
+      process.stdout.write('!');
+    }
+  }
+
+  console.log(`\n\nAttempted: ${cohort.length}  Succeeded: ${ok}  Failed: ${failed}`);
+  if (failures.length) {
+    console.log('\nFailures:');
+    failures.slice(0, 10).forEach(f => console.log(`   ${f.ghl_id}: ${f.error}`));
+    process.exit(1);
+  }
+
+  if (TRACER && ok === 1) {
+    // Independent verification: re-fetch the contact from GHL
+    const live = await ghl.getContactById(cohort[0].ghl_id);
+    const hasTag = (live.tags || []).includes(QUARANTINE_TAG);
+    console.log(`\nTracer verification (live GHL re-fetch): tag present = ${hasTag}`);
+    if (!hasTag) process.exit(1);
+  }
+  console.log('\n✅ Done. Remember: smart lists/segments must exclude status:quarantine.');
+}
+
+main().catch(err => { console.error('❌ Sweep failed:', err.message); process.exit(1); });

--- a/wiki/decisions/2026-07-12-ghl-target-architecture.md
+++ b/wiki/decisions/2026-07-12-ghl-target-architecture.md
@@ -1,0 +1,38 @@
+# ADR: GHL Target Architecture — one system, not thirteen
+
+**Date:** 2026-07-12 · **Status:** accepted (D1–D3 locked by Ben) · **Supersedes:** nothing — sits under `act-ghl-master-operating-system.md` and narrows it
+**Context:** Live audit via HighLevel MCP (baseline: `wiki/outputs/2026-07-12-ghl-live-snapshot/`). The account felt bloated and disconnected; the numbers agreed: 13 pipelines (2 empty, 1 dead, front door at 6 opps), 543 opportunities of which ~90% sit permanently "open", and 3,267 contacts of which 66% carry no tags and 60% no email. The canonical tag system describes roughly a third of the account.
+
+## Decisions (locked 2026-07-12)
+
+### D1 — Quarantine the noise, don't delete it
+Contacts with no email AND no project tag AND no consent evidence AND no opportunities (overwhelmingly Gmail-discovery imports; ~1,900–2,100) get `status:quarantine`. Every smart list, segment, dashboard count, and sync-derived rollup excludes them. Reversible; nothing deleted; review in batches later. **Plus the source fix:** the Gmail discovery import must stop creating contacts from transactional senders (`welcome@supabase.com` class) — filter at import, not after.
+
+### D2 — One pipeline per living journey (13 → 4)
+A pipeline earns its existence by things *moving through it to a terminal stage*. Grants is the only one currently doing that. Target set:
+
+| Pipeline | Absorbs | Notes |
+|---|---|---|
+| **Grants** | (unchanged) | Already honest — 16/31 open, stages used. |
+| **Goods** | Buyer (18) + Demand Register (74) + Supporter Journey (67) | One pipeline; deal type via `role:buyer` / `role:supporter` tags + name prefix (RC6 pattern). Demand signals enter at a "Signal" stage instead of a separate register. |
+| **Harvest** | Inbox (54) + Shop (35) + Membership (139) | Inbox+Shop merge as intake→resolution lanes. **Build-time checkpoint:** Membership (139/139 open, untouched since 16 Jun) is a segment wearing a pipeline costume — `member-level:*` tags already encode the same state. Preferred: retire it INTO tags + a smart list; keep as stages only if Ben overrules at build. |
+| **CONTAINED** | Engagement (101) + Adelaide 2026 (4) | Engagement shape wins; stop distinguished by `place:*` (RC5). **Resolves the deal-pipeline drift:** amend RC6 — `GHL_PARTNER_PIPELINE_ID` / `GHL_FUNDER_PIPELINE_ID` point here; "CONTAINED: Partners & Funders" is not built. |
+
+**Archive** (export snapshot → then delete in UI): Empathy Ledger (0 opps — EL intake lives on the Empathy Ledger platform, not GHL), Supporters & Donors (0 opps — donor state belongs to tags + Xero), A Curious Tractor (14 opps, all closed, dead since 9 Jun), Universal Inquiry (see D3).
+
+**Standing rule:** every pipeline must move ≥1 opp to a terminal stage per month or it's flagged at the monthly review as a candidate to become a tag/smart list.
+
+### D3 — Per-project intake; retire the Universal front door
+Reality won: Harvest Inbox, Goods inquiry, and CONTAINED capture each own their intake. Universal Inquiry (6 opps) retires. Routing is tags, not a triage board. **Safety net:** the weekly gapcheck adds one query — contacts created >7 days ago with no `project:*` tag and not quarantined → surfaced in the report for human routing. A report, not a pipeline.
+
+## Execution order (updates the 2026-07-12 cleanup plan's Phases 3–6)
+
+1. **Quarantine batch** — define the exact predicate, tracer one contact, then MCP bulk-tag (Tier 3, batched, attempted-vs-actual). Fix the Gmail import filter in the same PR. After this, every count in the system describes real relationships.
+2. **R8 consent remediation** (plan Phase 5, unchanged) — still blocks all bulk sends.
+3. **Pipeline consolidation** — per merge: add any missing stages to the target pipeline (UI), bulk-move opps via MCP (batched, tracer first), verify counts source-vs-target, then archive the source. One pipeline at a time, Grants untouched.
+4. **Tag migration** (plan Phase 4, unchanged mechanics) — now runs over ~1,100 real contacts instead of 3,267, using `config/ghl-tag-canonical-map.json`. Post-quarantine, also retire the 138 tags with <5 uses (fold or drop via the map's decide-list).
+5. **Workflow re-key + draft cleanup** (plan Phase 3) — re-point triggers at the 4 target pipelines and canonical tags; delete superseded drafts.
+6. **Docs close the loop** — update `act-ghl-master-operating-system.md` to this shape; `git mv` the superseded forms/tag-alignment plans into `_archive/`; keep this ADR as the durable record.
+
+## What "connected" means when this is done
+One intake per project → canonical tags describe every real contact → four honest pipelines where movement means something → mirror (already zero-drift, self-correcting) feeds dashboards that exclude quarantine → consent provable before any send. The measure: **any count you read in GHL, the mirror, or a dashboard agrees, and describes only real relationships.**


### PR DESCRIPTION
Locked decisions: 13 pipelines→4, quarantine ~1,806 noise contacts (reversible), per-project intake. ADR in wiki/decisions/. Sweep script is dry-run by default; tracer verifies against live GHL before batch.