### PR TITLE
Align Harvest budget with live Xero and Notion data

### DIFF
--- a/apps/command-center/src/app/api/harvest/budget/route.ts
+++ b/apps/command-center/src/app/api/harvest/budget/route.ts
@@ -1,187 +1,246 @@
 import { NextResponse } from 'next/server'
+import { Client } from '@notionhq/client'
 import { supabase } from '@/lib/supabase'
-import { readFileSync } from 'fs'
-import { join } from 'path'
 
 const PROJECT_CODE = 'ACT-HV'
+const FUND_TOTAL = 250_000
+const FUND_START = '2026-01-01'
+const NOTION_BUDGET_DATA_SOURCE = process.env.NOTION_HARVEST_BUDGET_DATA_SOURCE_ID
+  || '3df521a0-b3f8-4f47-983d-6713657befe5'
 
-// Load budget config at module level
-const budgetPath = join(process.cwd(), '..', '..', 'config', 'harvest-budget.json')
-let harvestBudget: any
-try {
-  harvestBudget = JSON.parse(readFileSync(budgetPath, 'utf-8'))
-} catch {
-  // Fallback: try from repo root (Vercel build may have different cwd)
-  try {
-    const altPath = join(process.cwd(), 'config', 'harvest-budget.json')
-    harvestBudget = JSON.parse(readFileSync(altPath, 'utf-8'))
-  } catch {
-    harvestBudget = null
-  }
+type BudgetLine = {
+  id: string
+  name: string
+  budget: number
+  phase: string
+  category: string
+  zone: string
+  status: string
+  budgetType: string
+  notes: string
+  supplier: string
+}
+
+const terminalInvoiceStatuses = new Set(['DRAFT', 'VOIDED', 'DELETED'])
+
+function textValue(property: any) {
+  const values = property?.title || property?.rich_text || []
+  return values.map((value: any) => value.plain_text || '').join('')
+}
+
+function selectValue(property: any) {
+  return property?.select?.name || property?.status?.name || ''
+}
+
+async function fetchNotionBudget(): Promise<{ lines: BudgetLine[]; fetchedAt: string } | null> {
+  const token = process.env.NOTION_TOKEN || process.env.NOTION_API_KEY
+  if (!token) return null
+
+  const notion = new Client({ auth: token })
+  const pages: any[] = []
+  let startCursor: string | undefined
+
+  do {
+    const response = await notion.dataSources.query({
+      data_source_id: NOTION_BUDGET_DATA_SOURCE,
+      page_size: 100,
+      start_cursor: startCursor,
+    })
+    pages.push(...response.results)
+    startCursor = response.has_more ? response.next_cursor || undefined : undefined
+  } while (startCursor)
+
+  const lines = pages.map((page: any): BudgetLine => ({
+    id: page.id,
+    name: textValue(page.properties?.['Line item']) || 'Untitled budget line',
+    budget: Number(page.properties?.['Amount (AUD)']?.number) || 0,
+    phase: selectValue(page.properties?.Phase),
+    category: selectValue(page.properties?.Category),
+    zone: selectValue(page.properties?.Zone),
+    status: selectValue(page.properties?.Status),
+    budgetType: selectValue(page.properties?.['Budget type']),
+    notes: textValue(page.properties?.Notes),
+    supplier: textValue(page.properties?.['Supplier / source']),
+  }))
+
+  return { lines, fetchedAt: new Date().toISOString() }
+}
+
+function netOfGst(gross: number) {
+  return Math.round((gross / 1.1) * 100) / 100
 }
 
 export async function GET() {
   try {
-    if (!harvestBudget) {
-      return NextResponse.json({ error: 'Budget config not found' }, { status: 500 })
-    }
+    const [transactionsResult, invoicesResult, notionResult] = await Promise.all([
+      supabase
+        .from('xero_transactions')
+        .select('id, xero_transaction_id, date, line_items, contact_name, total, type, status, synced_at')
+        .eq('project_code', PROJECT_CODE)
+        .gte('date', FUND_START)
+        .order('date', { ascending: false }),
+      supabase
+        .from('xero_invoices')
+        .select('id, invoice_number, date, due_date, line_items, contact_name, subtotal, total, amount_paid, amount_due, type, status, project_code, synced_at')
+        .eq('type', 'ACCREC')
+        .ilike('contact_name', '%Sonas%')
+        .order('date', { ascending: true }),
+      fetchNotionBudget().catch((error) => {
+        console.error('Harvest Notion budget fetch failed:', error)
+        return null
+      }),
+    ])
 
-    // Fetch all Harvest transactions from Xero
-    const { data: transactions } = await supabase
-      .from('xero_transactions')
-      // description + account_code live in line_items[], not top-level columns
-      .select('id, date, line_items, contact_name, total, type')
-      .eq('project_code', PROJECT_CODE)
-      .order('date', { ascending: false })
+    if (transactionsResult.error) throw transactionsResult.error
+    if (invoicesResult.error) throw invoicesResult.error
 
-    const txData = transactions || []
+    const transactions = transactionsResult.data || []
+    const invoices = (invoicesResult.data || []).filter((invoice: any) =>
+      !terminalInvoiceStatuses.has(String(invoice.status || '').toUpperCase())
+    )
 
-    // Calculate total spent (actuals)
-    const totalSpent = txData
-      .filter((tx: any) => tx.type === 'SPEND')
-      .reduce((sum: number, tx: any) => sum + Math.abs(tx.total || 0), 0)
+    const spendTransactions = transactions.filter((transaction: any) => transaction.type === 'SPEND')
+    const receiptTransactions = transactions.filter((transaction: any) =>
+      transaction.type === 'RECEIVE' && /sonas|luff/i.test(transaction.contact_name || '')
+    )
 
-    const totalIncome = txData
-      .filter((tx: any) => tx.type === 'RECEIVE')
-      .reduce((sum: number, tx: any) => sum + Math.abs(tx.total || 0), 0)
+    const totalProjectSpend = spendTransactions.reduce(
+      (sum: number, transaction: any) => sum + Math.abs(Number(transaction.total) || 0),
+      0
+    )
+    const issuedNet = invoices.reduce(
+      (sum: number, invoice: any) => sum + Math.abs(Number(invoice.subtotal) || 0),
+      0
+    )
+    const issuedGross = invoices.reduce(
+      (sum: number, invoice: any) => sum + Math.abs(Number(invoice.total) || 0),
+      0
+    )
+    const invoicePaidGross = invoices.reduce(
+      (sum: number, invoice: any) => sum + Math.abs(Number(invoice.amount_paid) || 0),
+      0
+    )
 
-    // Group spend by contact (vendor)
-    const spendByVendor: Record<string, number> = {}
-    for (const tx of txData) {
-      if ((tx as any).type === 'SPEND' && (tx as any).contact_name) {
-        const name = (tx as any).contact_name
-        spendByVendor[name] = (spendByVendor[name] || 0) + Math.abs((tx as any).total || 0)
-      }
-    }
+    // INV-0316's $44k is present as two reconciled bank receipts but remains unmatched
+    // to the invoice in Xero. Include those receipts in cash received and expose the gap.
+    const unmatchedReceiptGross = receiptTransactions.reduce(
+      (sum: number, transaction: any) => sum + Math.abs(Number(transaction.total) || 0),
+      0
+    )
+    const receivedGross = invoicePaidGross + unmatchedReceiptGross
+    const receivedNet = netOfGst(receivedGross)
+    const outstandingGross = Math.max(issuedGross - receivedGross, 0)
+    const remainingToInvoice = Math.max(FUND_TOTAL - issuedNet, 0)
 
-    // Group spend by GL account code — attribute each line_item's amount to its own account_code
-    const spendByAccount: Record<string, { name: string; total: number }> = {}
-    for (const tx of txData) {
-      const t = tx as any
-      if (t.type !== 'SPEND') continue
-      for (const li of (t.line_items || [])) {
-        const code = li?.account_code
-        if (!code) continue
-        if (!spendByAccount[code]) spendByAccount[code] = { name: String(code), total: 0 }
-        spendByAccount[code].total += Math.abs(li.line_amount ?? li.unit_amount ?? 0)
-      }
-    }
-
-    // Build phase summaries from config
-    const fund = harvestBudget.capital_improvement_fund
-    const phases = Object.entries(fund.phases).map(([key, phase]: [string, any]) => {
-      const lineItems = phase.line_items.map((item: any) => ({
-        ...item,
-        spent: 0,
-        remaining: item.budget,
-        pctUsed: 0,
-      }))
-
+    const notionLines = notionResult?.lines || []
+    const phaseNames = ['Phase 1', 'Phase 2']
+    const phases = phaseNames.map((phaseName) => {
+      const lineItems = notionLines.filter((line) => line.phase === phaseName)
+      const budget = lineItems.reduce((sum, line) => sum + line.budget, 0)
       return {
-        id: key,
-        name: phase.name,
-        budget: phase.budget,
-        status: phase.status,
-        lineItems,
-        totalSpent: 0,
-        remaining: phase.budget,
-        pctUsed: 0,
+        id: phaseName.toLowerCase().replace(' ', '_'),
+        name: `${phaseName} — Notion working estimate`,
+        budget,
+        status: lineItems.some((line) => line.status === 'Approved') ? 'approved' : 'draft',
+        lineItems: lineItems.map((line) => ({
+          id: line.id,
+          name: line.name,
+          budget: line.budget,
+          spent: null,
+          remaining: null,
+          pctUsed: null,
+          zone: line.zone,
+          category: line.category,
+          status: line.status,
+          budgetType: line.budgetType,
+          notes: line.notes,
+          supplier: line.supplier,
+        })),
+        totalSpent: null,
+        remaining: null,
+        pctUsed: null,
       }
     })
+    const plannedTotal = phases.reduce((sum, phase) => sum + phase.budget, 0)
 
-    // Cost centre summary
-    const costCentres = Object.entries(harvestBudget.cost_centres.values).map(([code, description]: [string, any]) => {
-      const budgetLines = [
-        ...fund.phases.phase_1.line_items,
-        ...fund.phases.phase_2.line_items,
-      ].filter((item: any) => item.cost_centre === code)
+    const latestXeroSync = [...transactions, ...invoices]
+      .map((record: any) => record.synced_at)
+      .filter(Boolean)
+      .sort()
+      .at(-1) || null
 
-      const totalBudget = budgetLines.reduce((sum: number, item: any) => sum + item.budget, 0)
-
-      return {
-        code,
-        description,
-        budget: totalBudget,
-        spent: 0,
-        remaining: totalBudget,
-        pctUsed: 0,
-        lineItemCount: budgetLines.length,
-      }
-    }).filter(cc => cc.budget > 0)
-
-    // Fund drawdowns (money IN from landlord)
-    const drawdowns = (harvestBudget.fund_drawdowns?.drawdowns || []).map((d: any) => ({
-      ...d,
-      pctOfFund: ((d.subtotal / fund.total_budget) * 100).toFixed(1),
+    const drawdowns = invoices.map((invoice: any) => ({
+      number: invoice.invoice_number,
+      billed_to: invoice.contact_name,
+      date: invoice.date,
+      due_date: invoice.due_date,
+      subtotal: Number(invoice.subtotal) || 0,
+      total: Number(invoice.total) || 0,
+      amount_paid: Number(invoice.amount_paid) || 0,
+      amount_due: Number(invoice.amount_due) || 0,
+      status: invoice.status,
+      phase: (invoice.line_items?.[0]?.description || '').match(/Phase\s+[12]/i)?.[0] || '',
+      description: invoice.line_items?.map((item: any) => item.description).filter(Boolean).join(' · ') || '',
+      pctOfFund: (((Number(invoice.subtotal) || 0) / FUND_TOTAL) * 100).toFixed(1),
+      trackingGap: !invoice.project_code,
     }))
-    const totalDrawn = harvestBudget.fund_drawdowns?.total_drawn || 0
-    const remainingToDraw = fund.total_budget - totalDrawn
 
-    // Expenses (money OUT to contractors/suppliers)
-    const expenses = (harvestBudget.expenses?.payments || []).map((exp: any) => ({
-      ...exp,
-      pctOfFund: ((exp.total / fund.total_budget) * 100).toFixed(1),
+    const expenses = spendTransactions.slice(0, 50).map((transaction: any) => ({
+      number: transaction.xero_transaction_id,
+      vendor: transaction.contact_name || 'Unknown supplier',
+      date: transaction.date,
+      total: Number(transaction.total) || 0,
+      status: transaction.status,
+      description: transaction.line_items?.map((item: any) => item.description).filter(Boolean).join(' · ') || '',
+      account: transaction.line_items?.[0]?.account_code || '',
+      pctOfFund: (((Number(transaction.total) || 0) / FUND_TOTAL) * 100).toFixed(1),
     }))
-    const totalExpensed = harvestBudget.expenses?.total_spent || 0
-
-    // Cash position: drawn - spent = available cash for Harvest
-    const cashAvailable = totalDrawn - totalExpensed
-
-    // Lease summary
-    const lease = harvestBudget.lease
 
     return NextResponse.json({
       summary: {
-        totalBudget: fund.total_budget,
-        // Fund inflows
-        totalDrawn,
-        remainingToDraw,
-        pctDrawn: ((totalDrawn / fund.total_budget) * 100).toFixed(1),
-        // Fund outflows
-        totalExpensed,
-        pctSpent: ((totalExpensed / fund.total_budget) * 100).toFixed(1),
-        // Cash position
-        cashAvailable,
-        // Xero actuals
-        xeroIncome: Math.round(totalIncome),
-        xeroExpenses: Math.round(totalSpent),
-        // Phase budgets
-        phase1Budget: fund.phases.phase_1.budget,
-        phase2Budget: fund.phases.phase_2.budget,
+        totalBudget: FUND_TOTAL,
+        totalDrawn: Math.round(receivedNet),
+        totalDrawnGross: Math.round(receivedGross),
+        totalInvoiced: Math.round(issuedNet),
+        totalInvoicedGross: Math.round(issuedGross),
+        remainingToDraw: Math.round(FUND_TOTAL - receivedNet),
+        remainingToInvoice: Math.round(remainingToInvoice),
+        outstandingGross: Math.round(outstandingGross),
+        pctDrawn: ((receivedNet / FUND_TOTAL) * 100).toFixed(1),
+        totalExpensed: Math.round(totalProjectSpend),
+        pctSpent: ((totalProjectSpend / FUND_TOTAL) * 100).toFixed(1),
+        cashAvailable: Math.round(receivedNet - totalProjectSpend),
+        phase1Budget: phases[0]?.budget || 0,
+        phase2Budget: phases[1]?.budget || 0,
+        plannedTotal,
+        planVariance: plannedTotal - FUND_TOTAL,
+      },
+      sourceStatus: {
+        xero: { status: 'live', syncedAt: latestXeroSync },
+        notion: {
+          status: notionResult ? 'live' : 'unavailable',
+          syncedAt: notionResult?.fetchedAt || null,
+          lineCount: notionLines.length,
+        },
+        caveats: [
+          'Xero project spend includes all ACT-HV operating and capital transactions from 1 Jan 2026; capital-only spend cannot be proven until cost-centre tracking is applied.',
+          ...(unmatchedReceiptGross > 0
+            ? [`$${unmatchedReceiptGross.toLocaleString()} of Sonas bank receipts are not matched to their Xero invoice.`]
+            : []),
+          ...(!notionResult ? ['Notion is unavailable; phase estimates are not shown.'] : []),
+        ],
       },
       phases,
-      costCentres,
+      costCentres: [],
       drawdowns,
       expenses,
-      lease: {
-        landlord: lease.landlord,
-        premises: lease.premises,
-        commencementDate: lease.commencement_date,
-        earlyAccess: lease.early_access,
-        baseRentMonthly: lease.rent.base_rent_monthly,
-        baseRentAnnual: lease.rent.base_rent_pa,
-        targetRentAnnual: lease.rent.target_rent_pa,
-        revenueShare: lease.rent.revenue_share,
-        options: lease.options_to_extend,
-        outgoings: lease.outgoings,
-        reporting: lease.reporting,
-      },
-      spendByVendor: Object.entries(spendByVendor)
-        .sort(([, a], [, b]) => b - a)
-        .slice(0, 15)
-        .map(([name, total]) => ({ name, total: Math.round(total) })),
-      spendByAccount: Object.entries(spendByAccount)
-        .sort(([, a], [, b]) => b.total - a.total)
-        .map(([code, { name, total }]) => ({ code, name, total: Math.round(total) })),
-      recentTransactions: txData.slice(0, 20).map((tx: any) => ({
-        id: tx.id,
-        date: tx.date,
-        description: tx.line_items?.[0]?.description || '',
-        contact: tx.contact_name,
-        amount: tx.total,
-        type: tx.type,
-        account: tx.line_items?.[0]?.account_code || '',
-      })),
+      lease: null,
+      spendByVendor: Object.entries(spendTransactions.reduce((totals: Record<string, number>, transaction: any) => {
+        const vendor = transaction.contact_name || 'Unknown supplier'
+        totals[vendor] = (totals[vendor] || 0) + Math.abs(Number(transaction.total) || 0)
+        return totals
+      }, {})).sort(([, a], [, b]) => Number(b) - Number(a)).slice(0, 15).map(([name, total]) => ({ name, total })),
+      recentTransactions: expenses,
     })
   } catch (error) {
     console.error('Harvest budget API error:', error)

--- a/apps/command-center/src/app/harvest/page.tsx
+++ b/apps/command-center/src/app/harvest/page.tsx
@@ -461,15 +461,28 @@ function BudgetTab() {
   const drawdowns = data?.drawdowns || []
   const expenses = data?.expenses || []
   const lease = data?.lease || {}
+  const sourceStatus = data?.sourceStatus || {}
 
   return (
     <div className="space-y-6">
       {/* Budget overview cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-4">
         <MetricCard icon={Hammer} label="Total Fund" value={`$${(summary.totalBudget || 0).toLocaleString()}`} color="text-amber-400" />
-        <MetricCard icon={ArrowDownRight} label="Drawn from Fund" value={`$${(summary.totalDrawn || 0).toLocaleString()}`} color="text-emerald-400" />
-        <MetricCard icon={ArrowUpRight} label="Spent" value={`$${(summary.totalExpensed || 0).toLocaleString()}`} color="text-red-400" />
-        <MetricCard icon={DollarSign} label="Cash Available" value={`$${(summary.cashAvailable || 0).toLocaleString()}`} color="text-blue-400" />
+        <MetricCard icon={Receipt} label="Invoiced ex GST" value={`$${(summary.totalInvoiced || 0).toLocaleString()}`} color="text-blue-400" />
+        <MetricCard icon={ArrowDownRight} label="Received ex GST" value={`$${(summary.totalDrawn || 0).toLocaleString()}`} color="text-emerald-400" />
+        <MetricCard icon={DollarSign} label="Still to invoice" value={`$${(summary.remainingToInvoice || 0).toLocaleString()}`} color="text-purple-400" />
+        <MetricCard icon={ArrowUpRight} label="ACT-HV spend" value={`$${(summary.totalExpensed || 0).toLocaleString()}`} color="text-red-400" />
+        <MetricCard icon={Hammer} label="Notion plan" value={`$${(summary.plannedTotal || 0).toLocaleString()}`} color="text-amber-300" />
+      </div>
+
+      <div className="bg-zinc-900 border border-zinc-800 rounded-lg p-4 space-y-2">
+        <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-zinc-400">
+          <span>Xero: {sourceStatus.xero?.status || 'unknown'}{sourceStatus.xero?.syncedAt ? ` · synced ${new Date(sourceStatus.xero.syncedAt).toLocaleString('en-AU')}` : ''}</span>
+          <span>Notion: {sourceStatus.notion?.status || 'unknown'}{sourceStatus.notion?.lineCount ? ` · ${sourceStatus.notion.lineCount} lines` : ''}</span>
+        </div>
+        {(sourceStatus.caveats || []).map((caveat: string) => (
+          <div key={caveat} className="text-xs text-amber-300">{caveat}</div>
+        ))}
       </div>
 
       {/* Fund progress — drawn vs total */}
@@ -493,20 +506,20 @@ function BudgetTab() {
           </div>
           <div>
             <div className="flex justify-between text-xs text-zinc-500 mb-1">
-              <span>Spent (paid to contractors/suppliers)</span>
-              <span>${(summary.totalExpensed || 0).toLocaleString()} of ${(summary.totalBudget || 0).toLocaleString()}</span>
+              <span>Notion working plan</span>
+              <span>${(summary.plannedTotal || 0).toLocaleString()} against ${(summary.totalBudget || 0).toLocaleString()} fund</span>
             </div>
             <div className="w-full bg-zinc-800 rounded-full h-3 overflow-hidden">
               <div
-                className="h-full bg-gradient-to-r from-red-600 to-red-400 rounded-full transition-all"
-                style={{ width: `${Math.min(Number(summary.pctSpent) || 0, 100)}%` }}
+                className="h-full bg-gradient-to-r from-amber-600 to-amber-400 rounded-full transition-all"
+                style={{ width: `${Math.min(((summary.plannedTotal || 0) / (summary.totalBudget || 1)) * 100, 100)}%` }}
               />
             </div>
           </div>
         </div>
         <div className="flex justify-between mt-3 text-xs text-zinc-500">
           <span>Phase 1: ${(summary.phase1Budget || 0).toLocaleString()}</span>
-          <span>Still to draw: ${(summary.remainingToDraw || 0).toLocaleString()}</span>
+          <span className={(summary.planVariance || 0) > 0 ? 'text-amber-300' : ''}>Plan variance: ${(summary.planVariance || 0).toLocaleString()}</span>
           <span>Phase 2: ${(summary.phase2Budget || 0).toLocaleString()}</span>
         </div>
       </div>
@@ -532,7 +545,7 @@ function BudgetTab() {
                 <div className="text-xs text-zinc-500">{d.pctOfFund}% of fund</div>
                 <span className={cn(
                   'text-xs px-1.5 py-0.5 rounded mt-0.5 inline-block',
-                  d.status === 'paid' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-amber-500/20 text-amber-400'
+                  String(d.status).toUpperCase() === 'PAID' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-amber-500/20 text-amber-400'
                 )}>
                   {d.status}
                 </span>
@@ -550,7 +563,7 @@ function BudgetTab() {
         <div className="p-4 border-b border-zinc-800">
           <h3 className="text-sm font-medium text-zinc-300 flex items-center gap-2">
             <ArrowUpRight className="h-4 w-4 text-red-400" />
-            Expenses (Money Out to Contractors &amp; Suppliers)
+            Latest ACT-HV spend from Xero (capital and operating combined)
           </h3>
         </div>
         <div className="divide-y divide-zinc-800">
@@ -561,8 +574,7 @@ function BudgetTab() {
                 <div className="text-xs text-zinc-500 max-w-md truncate">{exp.description}</div>
                 <div className="flex items-center gap-2 mt-0.5">
                   <span className="text-xs text-zinc-600">{exp.date}</span>
-                  {exp.cost_centre && <span className="text-xs px-1.5 py-0.5 bg-zinc-800 text-zinc-400 rounded">{exp.cost_centre}</span>}
-                  {exp.total_hours && <span className="text-xs text-zinc-600">{exp.total_hours}hrs</span>}
+                  {exp.account && <span className="text-xs px-1.5 py-0.5 bg-zinc-800 text-zinc-400 rounded">Account {exp.account}</span>}
                 </div>
               </div>
               <div className="text-right flex-shrink-0">
@@ -570,7 +582,7 @@ function BudgetTab() {
                 <div className="text-xs text-zinc-500">{exp.pctOfFund}% of fund</div>
                 <span className={cn(
                   'text-xs px-1.5 py-0.5 rounded mt-0.5 inline-block',
-                  exp.status === 'paid' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-amber-500/20 text-amber-400'
+                  String(exp.status).toUpperCase() === 'PAID' ? 'bg-emerald-500/20 text-emerald-400' : 'bg-amber-500/20 text-amber-400'
                 )}>
                   {exp.status}
                 </span>
@@ -610,8 +622,9 @@ function BudgetTab() {
                   <div className="min-w-0 flex-1">
                     <div className="text-sm text-zinc-200 truncate">{item.name}</div>
                     <div className="flex items-center gap-2 mt-0.5">
-                      <span className="text-xs px-1.5 py-0.5 bg-zinc-800 text-zinc-400 rounded">{item.cost_centre}</span>
+                      <span className="text-xs px-1.5 py-0.5 bg-zinc-800 text-zinc-400 rounded">{item.category}</span>
                       <span className="text-xs text-zinc-600">{item.zone}</span>
+                      <span className="text-xs text-zinc-600">{item.status}</span>
                     </div>
                   </div>
                   <div className="text-right flex-shrink-0 ml-4">
@@ -625,7 +638,7 @@ function BudgetTab() {
       ))}
 
       {/* Cost centres summary */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-lg">
+      {costCentres.length > 0 && <div className="bg-zinc-900 border border-zinc-800 rounded-lg">
         <div className="p-4 border-b border-zinc-800">
           <h3 className="text-sm font-medium text-zinc-300 flex items-center gap-2">
             <Leaf className="h-4 w-4 text-green-400" />
@@ -643,10 +656,10 @@ function BudgetTab() {
             </div>
           ))}
         </div>
-      </div>
+      </div>}
 
       {/* Lease summary */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-lg">
+      {lease?.landlord && <div className="bg-zinc-900 border border-zinc-800 rounded-lg">
         <div className="p-4 border-b border-zinc-800">
           <h3 className="text-sm font-medium text-zinc-300 flex items-center gap-2">
             <Building2 className="h-4 w-4 text-purple-400" />
@@ -711,7 +724,7 @@ function BudgetTab() {
             </div>
           </div>
         </div>
-      </div>
+      </div>}
     </div>
   )
 }


### PR DESCRIPTION
## What changed
- replace the February budget snapshot with live Notion budget lines
- derive landlord drawdowns and outstanding amounts from current Xero invoices and receipts
- clearly separate total ACT-HV project spend from unverified capital-only spend
- show source freshness and reconciliation caveats in the dashboard

## Verified
- TypeScript check passes
- production build passes
- local authenticated /api/harvest/budget returns live Xero and Notion totals