### PR TITLE
Exclude deleted Xero rows from Harvest spend

### DIFF
--- a/apps/command-center/src/app/api/harvest/budget/route.ts
+++ b/apps/command-center/src/app/api/harvest/budget/route.ts
@@ -99,7 +99,10 @@ export async function GET() {
       !terminalInvoiceStatuses.has(String(invoice.status || '').toUpperCase())
     )
 
-    const spendTransactions = transactions.filter((transaction: any) => transaction.type === 'SPEND')
+    const spendTransactions = transactions.filter((transaction: any) =>
+      transaction.type === 'SPEND'
+      && !['DELETED', 'VOIDED'].includes(String(transaction.status || '').toUpperCase())
+    )
     const receiptTransactions = transactions.filter((transaction: any) =>
       transaction.type === 'RECEIVE' && /sonas|luff/i.test(transaction.contact_name || '')
     )


### PR DESCRIPTION
Verification follow-up: removes DELETED and VOIDED Xero transactions from the ACT-HV spend total and recent transaction list. TypeScript passes.