### PR TITLE
feat(harvest): add interactive commercial model

### DIFF
--- a/apps/command-center/src/app/harvest/page.tsx
+++ b/apps/command-center/src/app/harvest/page.tsx
@@ -23,12 +23,14 @@ import {
   Share2,
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { HarvestCommercialModel } from '@/components/harvest/HarvestCommercialModel'
 
-type TabId = 'overview' | 'budget' | 'financials' | 'pipeline' | 'grants' | 'team' | 'social'
+type TabId = 'overview' | 'budget' | 'model' | 'financials' | 'pipeline' | 'grants' | 'team' | 'social'
 
 const tabs: { id: TabId; label: string }[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'budget', label: 'Budget' },
+  { id: 'model', label: 'Commercial model' },
   { id: 'financials', label: 'Financials' },
   { id: 'pipeline', label: 'Pipeline' },
   { id: 'grants', label: 'Grants' },
@@ -99,6 +101,7 @@ export default function HarvestPage() {
       {/* Tab content */}
       {activeTab === 'overview' && <OverviewTab data={data} />}
       {activeTab === 'budget' && <BudgetTab />}
+      {activeTab === 'model' && <HarvestCommercialModel />}
       {activeTab === 'financials' && <FinancialsTab data={data} />}
       {activeTab === 'pipeline' && <PipelineTab data={data} />}
       {activeTab === 'grants' && <GrantsTab data={data} />}

--- a/apps/command-center/src/components/harvest/HarvestCommercialModel.tsx
+++ b/apps/command-center/src/components/harvest/HarvestCommercialModel.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Calculator, Coffee, ExternalLink, Palette, Users } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  calculateOffer,
+  DEFAULT_MONTHLY_OPERATING_BASE,
+  harvestOffers,
+  type HarvestOffer,
+} from '@/lib/harvest-commercial-model'
+
+const money = (value: number) => value.toLocaleString('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: 0 })
+
+export function HarvestCommercialModel() {
+  const [offers, setOffers] = useState(harvestOffers)
+  const [operatingBase, setOperatingBase] = useState(DEFAULT_MONTHLY_OPERATING_BASE)
+
+  const rows = useMemo(() => offers.map(offer => ({ offer, result: calculateOffer(offer) })), [offers])
+  const totals = rows.reduce((sum, row) => ({
+    revenue: sum.revenue + row.result.revenue,
+    contribution: sum.contribution + row.result.contribution,
+  }), { revenue: 0, contribution: 0 })
+  const monthlyNet = totals.contribution - operatingBase
+
+  const update = (id: string, field: keyof Pick<HarvestOffer, 'cadence' | 'units' | 'price'>, value: number) => {
+    setOffers(current => current.map(offer => offer.id === id ? { ...offer, [field]: Math.max(0, value || 0) } : offer))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-5">
+        <div className="flex items-start gap-3">
+          <Palette className="mt-0.5 h-5 w-5 text-amber-300" />
+          <div>
+            <h2 className="font-medium text-zinc-100">Harvest earns through the whole experience</h2>
+            <p className="mt-1 max-w-4xl text-sm text-zinc-400">
+              The working thesis is events + experiences + hire create margin; membership creates belonging and dependable cash;
+              food increases value and dwell time; residencies create the artistic program. Café-only trade must earn its place with actual covers.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Summary label="Monthly revenue" value={money(totals.revenue)} />
+        <Summary label="Contribution before base" value={money(totals.contribution)} />
+        <label className="rounded-lg border border-zinc-800 bg-zinc-900 p-4">
+          <span className="text-xs text-zinc-500">Monthly operating base</span>
+          <span className="mt-1 flex items-center text-xl font-semibold text-zinc-100">
+            $<input className="w-full bg-transparent outline-none" type="number" step="500" value={operatingBase} onChange={event => setOperatingBase(Math.max(0, Number(event.target.value)))} />
+          </span>
+          <span className="text-[11px] text-zinc-600">Legacy forecast; replace with live payroll + occupancy</span>
+        </label>
+        <Summary label="Modelled monthly net" value={money(monthlyNet)} tone={monthlyNet >= 0 ? 'good' : 'bad'} />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900">
+        <div className="border-b border-zinc-800 p-4">
+          <h3 className="flex items-center gap-2 text-sm font-medium text-zinc-200"><Calculator className="h-4 w-4 text-emerald-400" /> Play with the offer mix</h3>
+          <p className="mt-1 text-xs text-zinc-500">Change runs/month, people and price. Costs are visible assumptions—not forecasts.</p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[980px] text-sm">
+            <thead className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <tr><th className="p-3">Offer</th><th className="p-3">Runs/mo</th><th className="p-3">People / units</th><th className="p-3">Price</th><th className="p-3 text-right">Revenue</th><th className="p-3 text-right">Contribution</th><th className="p-3 text-right">Margin</th><th className="p-3 text-right">Break-even units/run</th></tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-800">
+              {rows.map(({ offer, result }) => (
+                <tr key={offer.id} className="align-top">
+                  <td className="p-3"><div className="font-medium text-zinc-200">{offer.name}</div><div className="mt-0.5 max-w-xs text-[11px] leading-4 text-zinc-600">{offer.note}</div><span className="mt-1 inline-block rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-500">{offer.lane} · {offer.evidence}</span></td>
+                  <Editable value={offer.cadence} step={offer.cadence < 1 ? 0.25 : 1} onChange={value => update(offer.id, 'cadence', value)} />
+                  <Editable value={offer.units} onChange={value => update(offer.id, 'units', value)} />
+                  <Editable value={offer.price} prefix="$" onChange={value => update(offer.id, 'price', value)} />
+                  <td className="p-3 text-right tabular-nums text-zinc-300">{money(result.revenue)}</td>
+                  <td className={cn('p-3 text-right font-medium tabular-nums', result.contribution >= 0 ? 'text-emerald-400' : 'text-red-400')}>{money(result.contribution)}</td>
+                  <td className="p-3 text-right tabular-nums text-zinc-400">{Math.round(result.contributionMargin * 100)}%</td>
+                  <td className="p-3 text-right tabular-nums text-zinc-400">{result.breakEvenUnits ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <Insight icon={Palette} title="Best strategic fit" text="Art dinners and destination experience days combine the site, food and artistic program instead of selling each piece separately." />
+        <Insight icon={Users} title="Best dependable layer" text="Membership can underwrite programming, but benefits should be priority, access and belonging—not unlimited free food or tickets." />
+        <Insight icon={Coffee} title="Biggest operating risk" text="At the default assumptions a standalone café day needs about 86 covers to break even. Start with event-led service and measure every trading day." />
+      </div>
+
+      <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4 text-xs text-zinc-500">
+        <div className="font-medium text-zinc-300">Benchmark anchors</div>
+        <div className="mt-2 flex flex-wrap gap-x-5 gap-y-2">
+          <Source href="https://www.ato.gov.au/api/public/content/0-ce584ea2-57ac-415c-9f42-ee6d351d9c59" label="ATO coffee-shop cost ranges" />
+          <Source href="https://www.sac.org.au/venue/the-artists-cottage/" label="Salamanca residency fees" />
+          <Source href="https://www.qagoma.qld.gov.au/membership/" label="QAGOMA membership design" />
+          <Source href="https://humanitix.com/au/pricing" label="Humanitix ticket fees" />
+          <Source href="https://www.tra.gov.au/content/dam/austrade-assets/global/wip/tra/documents/visiting-farm-2024-factsheet%20.pdf" label="Australian agritourism demand" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Editable({ value, onChange, prefix, step = 1 }: { value: number; onChange: (value: number) => void; prefix?: string; step?: number }) {
+  return <td className="p-3"><div className="flex w-24 items-center rounded border border-zinc-700 bg-zinc-950 px-2 text-zinc-300">{prefix}<input className="w-full bg-transparent p-1.5 outline-none" type="number" min="0" step={step} value={value} onChange={event => onChange(Number(event.target.value))} /></div></td>
+}
+
+function Summary({ label, value, tone }: { label: string; value: string; tone?: 'good' | 'bad' }) {
+  return <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4"><div className="text-xs text-zinc-500">{label}</div><div className={cn('mt-1 text-xl font-semibold', tone === 'good' ? 'text-emerald-400' : tone === 'bad' ? 'text-red-400' : 'text-zinc-100')}>{value}</div></div>
+}
+
+function Insight({ icon: Icon, title, text }: { icon: typeof Palette; title: string; text: string }) {
+  return <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4"><Icon className="h-4 w-4 text-amber-300" /><div className="mt-2 text-sm font-medium text-zinc-200">{title}</div><p className="mt-1 text-xs leading-5 text-zinc-500">{text}</p></div>
+}
+
+function Source({ href, label }: { href: string; label: string }) {
+  return <a className="flex items-center gap-1 text-blue-400 hover:text-blue-300" href={href} target="_blank" rel="noreferrer">{label}<ExternalLink className="h-3 w-3" /></a>
+}

--- a/apps/command-center/src/lib/harvest-commercial-model.ts
+++ b/apps/command-center/src/lib/harvest-commercial-model.ts
@@ -1,0 +1,77 @@
+export type HarvestOffer = {
+  id: string
+  name: string
+  lane: 'Events' | 'Food' | 'Membership' | 'Residency' | 'Experience' | 'Hire'
+  cadence: number
+  units: number
+  price: number
+  variableCostRate: number
+  fixedCost: number
+  labourHours: number
+  loadedLabourRate: number
+  note: string
+  evidence: 'benchmark' | 'assumption'
+}
+
+export const DEFAULT_MONTHLY_OPERATING_BASE = 18_170
+
+export const harvestOffers: HarvestOffer[] = [
+  {
+    id: 'art-dinner', name: 'Art + fire dinner', lane: 'Events', cadence: 4, units: 60, price: 65,
+    variableCostRate: 0.30, fixedCost: 950, labourHours: 28, loadedLabourRate: 40,
+    note: 'Ticket bundles the work, shared meal and place; strongest repeatable Harvest-shaped offer.', evidence: 'assumption',
+  },
+  {
+    id: 'workshop', name: 'Artist / maker workshop', lane: 'Events', cadence: 4, units: 20, price: 85,
+    variableCostRate: 0.18, fixedCost: 600, labourHours: 10, loadedLabourRate: 40,
+    note: 'Small capacity, high yield per visitor; facilitator fee sits in fixed cost.', evidence: 'assumption',
+  },
+  {
+    id: 'private-event', name: 'Private event + food', lane: 'Hire', cadence: 2, units: 60, price: 95,
+    variableCostRate: 0.30, fixedCost: 700, labourHours: 36, loadedLabourRate: 40,
+    note: 'Higher-margin calendar anchor; protect community access with a capped monthly cadence.', evidence: 'assumption',
+  },
+  {
+    id: 'experience-day', name: 'Harvest art experience', lane: 'Experience', cadence: 2, units: 30, price: 180,
+    variableCostRate: 0.25, fixedCost: 1_200, labourHours: 24, loadedLabourRate: 40,
+    note: 'A destination day: make, eat, walk, meet an artist. Designed for hinterland visitors.', evidence: 'assumption',
+  },
+  {
+    id: 'membership', name: 'Harvest membership', lane: 'Membership', cadence: 1, units: 250, price: 10,
+    variableCostRate: 0.12, fixedCost: 250, labourHours: 8, loadedLabourRate: 40,
+    note: '$120 annual membership recognised at $10/member/month; benefits must create belonging without unlimited free inventory.', evidence: 'benchmark',
+  },
+  {
+    id: 'commissioned-residency', name: 'Commissioned residency', lane: 'Residency', cadence: 0.5, units: 1, price: 7_500,
+    variableCostRate: 0.20, fixedCost: 1_000, labourHours: 20, loadedLabourRate: 45,
+    note: 'Partner-funded artist fee, public outcome and documentation; model assumes six per year.', evidence: 'assumption',
+  },
+  {
+    id: 'self-funded-residency', name: 'Self-funded residency week', lane: 'Residency', cadence: 2, units: 1, price: 835,
+    variableCostRate: 0.10, fixedCost: 140, labourHours: 6, loadedLabourRate: 45,
+    note: 'Price anchored to an Australian self-funded residency benchmark; valuable artist pipeline, modest cash margin.', evidence: 'benchmark',
+  },
+  {
+    id: 'venue-hire', name: 'Space-only venue hire', lane: 'Hire', cadence: 2, units: 1, price: 1_200,
+    variableCostRate: 0.05, fixedCost: 200, labourHours: 5, loadedLabourRate: 40,
+    note: 'Simple access to an otherwise idle room; add bonds, security and cleaning where risk requires.', evidence: 'benchmark',
+  },
+  {
+    id: 'cafe-day', name: 'Standalone café day', lane: 'Food', cadence: 8, units: 70, price: 24,
+    variableCostRate: 0.37, fixedCost: 80, labourHours: 32, loadedLabourRate: 38,
+    note: 'Deliberately conservative: café trading is a support layer until actual covers and labour prove otherwise.', evidence: 'benchmark',
+  },
+]
+
+export function calculateOffer(offer: HarvestOffer) {
+  const revenue = offer.cadence * offer.units * offer.price
+  const variableCosts = revenue * offer.variableCostRate
+  const occurrenceCosts = offer.cadence * (offer.fixedCost + offer.labourHours * offer.loadedLabourRate)
+  const contribution = revenue - variableCosts - occurrenceCosts
+  const contributionMargin = revenue ? contribution / revenue : 0
+  const unitContribution = offer.price * (1 - offer.variableCostRate)
+  const breakEvenUnits = unitContribution > 0
+    ? Math.ceil((offer.fixedCost + offer.labourHours * offer.loadedLabourRate) / unitContribution)
+    : null
+  return { revenue, variableCosts, occurrenceCosts, contribution, contributionMargin, breakEvenUnits }
+}

--- a/thoughts/shared/reports/harvest-commercial-model-research-2026-07-20.md
+++ b/thoughts/shared/reports/harvest-commercial-model-research-2026-07-20.md
@@ -1,0 +1,44 @@
+# Harvest commercial model research — 20 July 2026
+
+## Summary
+
+The Harvest should not be modelled as a café with arts activity attached. The stronger economic shape is a programmed place: paid art-and-food events, destination experiences, selective private hire, membership and partner-funded residencies, with café service activated around proven demand.
+
+The first dashboard model is deliberately assumption-led. It is a tool for testing price, attendance and cadence—not a forecast. Every offer must later be replaced with Harvest actuals from ticketing, Square/Stripe, payroll and Xero.
+
+## Findings
+
+- **Standalone café trading is the highest-volume, lowest-forgiveness offer.** The Australian Taxation Office coffee-shop benchmark shows cost of sales commonly around 33–42% of turnover and total expenses around 74–92%, depending on turnover band. Harvest should initially open food service around programmed demand and measure covers per labour hour.
+- **Bundling improves yield.** Art + meal + place can support a higher per-person price than admission, food or a workshop sold independently while sharing one marketing and staffing cycle.
+- **Membership is stabilising revenue, not the whole business.** Australian arts memberships commonly lead with priority access, discounts and exclusive programs. Harvest should sell belonging and access while avoiding benefits that create uncapped marginal costs.
+- **Residencies need two models.** Self-funded residencies can cover accommodation/hosting and seed the artistic pipeline; partner-funded or commissioned residencies carry artist fees, public outcomes and documentation and can create meaningful contribution.
+- **Hire is useful but should not colonise the calendar.** Regional/community venue benchmarks range from low-cost community access to material commercial-event fees. Harvest can use a two-rate model: accessible community/artist use and higher commercial/private pricing.
+- **The hinterland has a destination advantage.** Tourism sources position Maleny/Montville and the wider hinterland as established visitor destinations, while Tourism Research Australia reports about 3.3 million Australian trips included a farm visit. Harvest experiences should be bookable destination products, not only local events.
+
+## Recommended operating sequence
+
+1. Run an eight-week events-first test: art/fire dinners, workshops and one destination experience format.
+2. Open café service only around those programmed windows plus a small number of standalone test days.
+3. Launch one simple annual membership after two successful event cycles, using priority and discounts rather than free inventory.
+4. Sell commissioned residencies to institutions and funders; use self-funded weeks selectively to keep the artist pipeline alive.
+5. Track contribution per event, labour hours, attendance, secondary food/drink spend, repeat attendance and member conversion.
+
+## Sources
+
+- [ATO coffee-shop benchmark](https://www.ato.gov.au/api/public/content/0-ce584ea2-57ac-415c-9f42-ee6d351d9c59)
+- [Fair Work Restaurant Industry Award guidance](https://www.fairwork.gov.au/find-help-for/fast-food-restaurants-cafes/restaurant-cafes-industry)
+- [Humanitix Australian pricing](https://humanitix.com/au/pricing)
+- [QAGOMA membership model](https://www.qagoma.qld.gov.au/membership/)
+- [Flying Arts membership model](https://flyingarts.org.au/standard-membership/)
+- [Salamanca Arts Centre self-funded residency fees](https://www.sac.org.au/venue/the-artists-cottage/)
+- [BigCi artist residency fees](https://bigci.org/artist-residency/)
+- [Braidwood Regional Arts Group venue hire](https://www.bragart.com.au/venuehire)
+- [Central Highlands Regional Council 2026–27 venue fees](https://chrc.qld.gov.au/wp-content/uploads/2026/06/2026-27-Fees-Charges-Effective-1-July-2026.pdf)
+- [Tourism Research Australia agritourism factsheet](https://www.tra.gov.au/content/dam/austrade-assets/global/wip/tra/documents/visiting-farm-2024-factsheet%20.pdf)
+- [Destination NSW bookable agritourism guidance](https://www.destinationnsw.com.au/destination-nsw-business-support/nsw-first-program/nsw-first-develop/quick-tips-for-creating-bookable-agritourism-experiences)
+
+## Caveats
+
+- Harvest capacity, liquor/licensing conditions, food compliance, accommodation availability and current staffing were not yet verified.
+- The `$18,170` monthly operating base comes from the legacy Harvest budget configuration and may double-count or omit current staff. It is editable in the model and must be replaced with live payroll and occupancy costs.
+- Offer-level prices and costs are working assumptions except where the dashboard explicitly marks a benchmark anchor.

--- a/thoughts/shared/reports/harvest-commercial-model-research-2026-07-20.md.provenance.md
+++ b/thoughts/shared/reports/harvest-commercial-model-research-2026-07-20.md.provenance.md
@@ -1,0 +1,31 @@
+# Provenance — Harvest commercial model research
+
+## Sources queried
+
+- Current ACT steering: `wiki/concepts/soul.md`, `wiki/concepts/four-lanes.md`, `wiki/art/business/studio-business-model.md`.
+- Harvest working data: `config/harvest-budget.json`, the Harvest stage-budget plan, and the Harvest website research/codebase.
+- Current public sources listed in the report, accessed 20 July 2026.
+
+## Verified
+
+- Published membership, residency, venue and ticketing prices linked in the report.
+- ATO coffee-shop benchmark ranges.
+- The legacy Harvest operating forecast of `$18,170/month` in `config/harvest-budget.json`.
+
+## Inferred
+
+- The recommended events-first commercial architecture.
+- Relative attractiveness of offer types before Harvest has comparable actual trading data.
+
+## Unverified assumptions
+
+- Attendance, cadence, prices, direct costs and labour hours in the interactive model.
+- Current safe/legal capacities and availability of each Harvest space.
+- Current payroll and fixed operating base.
+
+## Reproduction
+
+1. Open `/harvest` in Command Center.
+2. Select `Commercial model`.
+3. Adjust runs per month, attendance/units, price and monthly operating base.
+4. Replace assumptions with actual results after each event/trading day.


### PR DESCRIPTION
## Outcome
Adds an interactive Commercial model tab to the Harvest Command Center for testing the economics of art + food events, workshops, destination experiences, memberships, residencies, venue hire and standalone cafe trading.

The model exposes runs/month, attendance or units, price, operating base, contribution margin and break-even units. Seed values are explicitly marked as assumptions or external benchmark anchors.

## Strategic finding
Harvest should be modelled as a programmed place where art, food and experience reinforce each other. Standalone cafe trading remains a measured demand test rather than the core engine.

## Verification
- pnpm --filter @act/command-center exec tsc --noEmit
- pnpm --filter @act/command-center build
- git diff --check

## Evidence
Includes a sourced research report and provenance sidecar covering ATO cafe benchmarks, arts memberships, residencies, venue hire, ticketing and agritourism.