### PR TITLE
skills: give seven skills a description, so they can actually be found

### DIFF
--- a/.claude/skills/agent-kanban/skill.md
+++ b/.claude/skills/agent-kanban/skill.md
@@ -1,3 +1,8 @@
+---
+name: agent-kanban
+description: Orchestrates parallel Claude Code agents through Vibe Kanban, giving each task its own git worktree, a diff viewer before merge, and live monitoring of agent reasoning. Use when the user wants several coding agents running at once, work fanned out across isolated worktrees, or a review step before agent work is merged. Do not use for a single sequential task or for ordinary git branching.
+---
+
 # Vibe Kanban - ACT Ecosystem Task Orchestration
 
 ## Overview

--- a/.claude/skills/enrich-project/skill.md
+++ b/.claude/skills/enrich-project/skill.md
@@ -1,3 +1,8 @@
+---
+name: enrich-project
+description: Enriches ACT projects with intelligence drawn from every connected knowledge source, and builds the project and frontends dashboards. Use when the user wants a project enriched by its code, project intelligence refreshed across the ecosystem, or a combined project or frontends dashboard. Also use on /enrich-project. Do not use for contact or relationship enrichment, which is a separate pipeline.
+---
+
 # /enrich-project - Deep Project Intelligence
 
 Enrich ACT projects with intelligence from ALL knowledge sources.

--- a/.claude/skills/enrich/SKILL.md
+++ b/.claude/skills/enrich/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: enrich
+description: Runs the contact enrichment cycle over ACT relationship data: links communications to contacts, consolidates duplicate identity records, refreshes last-contact dates, raises relationship alerts, and reports data quality. Use when the user wants contact data refreshed, stale relationships surfaced, duplicate contacts merged, or CRM data quality checked. Also use on /enrich. Do not use for project enrichment, which is a separate pipeline.
+---
+
 # /enrich - Contact Enrichment Cycle
 
 Run the full contact enrichment pipeline to keep relationship data fresh.

--- a/.claude/skills/find-receipt/SKILL.md
+++ b/.claude/skills/find-receipt/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: find-receipt
+description: Hunts missing receipts across ACT finance data through the Finance Workbench and the unified receipt search, applying the rules for which rows genuinely need one. Use when the user asks to find a receipt, chase receipt gaps, or reconcile spend with no documentation. Carries the guards that matter: internal transfers, credit-card payoffs, bank fees and sub-$75 no-GST items never need a receipt; DELETED rows are not real spend; only NAB Visa ACT #8815 and NJ Marchesi T/as ACT Everyday count as ACT accounts. Also use on /find-receipt.
+---
+
 # /find-receipt
 
 Intelligent receipt hunting across all data sources.

--- a/.claude/skills/query/SKILL.md
+++ b/.claude/skills/query/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: query
+description: Answers data questions against the ACT Supabase database, turning a plain-language question into the right query so the user does not write SQL. Use when the user asks how many, show me, or what is the status of something whose answer lives in the ACT database. Also use on /query. Read and analysis only; do not use for migrations, writes, or schema changes.
+---
+
 # /query — Supabase Analytics Skill
 
 Run analytics queries against the ACT Supabase database without writing SQL manually.

--- a/.claude/skills/scan-subscriptions/SKILL.md
+++ b/.claude/skills/scan-subscriptions/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: scan-subscriptions
+description: Discovers and reconciles recurring software subscriptions by pulling Xero repeating invoices and detecting recurring bank-transaction patterns, then surfacing untracked subscriptions, price rises beyond a small variance, and cancellation candidates. Use when the user asks what are we paying for, wants a subscription audit or reconciliation, or suspects a price increase. Also use on /scan-subscriptions.
+---
+
 # /scan-subscriptions
 
 Discover and reconcile software subscriptions from multiple sources.

--- a/.claude/skills/sync-storytellers/SKILL.md
+++ b/.claude/skills/sync-storytellers/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: sync-storytellers
+description: Syncs storyteller records from Empathy Ledger v2 into GoHighLevel as tagged contacts, then links them back with story counts and storyteller and elder flags. Use when the user wants storytellers pushed into GHL, GHL contacts refreshed from Empathy Ledger, or the two systems brought back into step. Also use on /sync-storytellers. This writes to GHL, so treat it as a change to an external system of record.
+---
+
 # /sync-storytellers - Empathy Ledger v2 → GHL Sync
 
 Sync storyteller data from Empathy Ledger v2 to GHL contacts.


### PR DESCRIPTION
Seven skills here had **no YAML frontmatter at all**. Each opened with a markdown heading, so it carried no name and no description — and a skill with no description cannot be matched against a request. They were reachable only by typing their name, which made them invisible to anyone who did not already know they existed.

`agent-kanban`, `enrich`, `enrich-project`, `find-receipt`, `query`, `scan-subscriptions`, `sync-storytellers`.

Every one already documented its own triggering conditions in prose, under an *Activation*, *Usage* or *When to Use* heading. That prose is now in the frontmatter, where it does something. Each description also says when **not** to use the skill: `enrich` and `enrich-project` are easily confused with each other, and `/query` is read-only.

## Two judgement calls worth reviewing

**`find-receipt` carries its money guards in the description**, not only in the body: internal transfers, credit-card payoffs, bank fees and sub-$75 no-GST items never need a receipt; `DELETED` rows are not real spend; only NAB Visa ACT #8815 and NJ Marchesi T/as ACT Everyday count as ACT accounts. Those are the rules that separate a useful receipt hunt from a wrong one, and they belong where they are read first.

**`sync-storytellers` states plainly that it writes to GHL**, so it reads as a change to an external system of record rather than a lookup.

## Scope

Seven files, 35 insertions, nothing else. Found during an inventory of all 56 installed skills across four scopes; the equivalent fixes for `act-regenerative-studio` are in [that repo's PR #72](https://github.com/Acurioustractor/act-regenerative-studio/pull/72).

## Note on how this was pushed

Local `main` here is 9 commits behind origin and carries two unpushed brand-map commits from 22 and 28 July that are not mine. Rather than push those along as a side effect, this commit was cherry-picked alone onto current `origin/main`. Local `main` and its 75 uncommitted files are untouched.

`agent-kanban` and `enrich-project` use a lowercase `skill.md`; the other five use `SKILL.md`. Left as found rather than doing a case-only rename in a tree with other work in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
